### PR TITLE
[monitoring] Add metrics collectors

### DIFF
--- a/images/agent/README.md
+++ b/images/agent/README.md
@@ -22,7 +22,7 @@
 
 `NODE_NAME`
 
-`METRICS_PORT` - default : 9695
+`METRICS_PORT` - default : 4202
 
 
 #### Metrics

--- a/images/agent/config/config.go
+++ b/images/agent/config/config.go
@@ -38,7 +38,7 @@ const (
 	ThrottleInterval                     = "THROTTLER_INTERVAL"
 	CmdDeadlineDuration                  = "CMD_DEADLINE_DURATION"
 	DefaultHealthProbeBindAddressEnvName = "HEALTH_PROBE_BIND_ADDRESS"
-	DefaultHealthProbeBindAddress        = ":8081"
+	DefaultHealthProbeBindAddress        = ":4228"
 )
 
 type Options struct {
@@ -77,7 +77,7 @@ func NewConfig() (*Options, error) {
 
 	opts.MetricsPort = os.Getenv(MetricsPort)
 	if opts.MetricsPort == "" {
-		opts.MetricsPort = ":9695"
+		opts.MetricsPort = ":4202"
 	}
 
 	opts.HealthProbeBindAddress = os.Getenv(DefaultHealthProbeBindAddressEnvName)

--- a/images/agent/config/config_test.go
+++ b/images/agent/config/config_test.go
@@ -107,7 +107,7 @@ func TestNewConfig(t *testing.T) {
 
 	t.Run("MetricsPortNotSet_ReturnsDefaultPort", func(t *testing.T) {
 		expNodeName := "test-node"
-		expMetricsPort := ":9695"
+		expMetricsPort := ":4202"
 		expMachineId := "test-id"
 
 		err := os.Setenv(NodeName, expNodeName)

--- a/images/sds-health-watcher-controller/config/config.go
+++ b/images/sds-health-watcher-controller/config/config.go
@@ -54,7 +54,7 @@ func NewConfig() (*Options, error) {
 
 	opts.MetricsPort = os.Getenv(MetricsPort)
 	if opts.MetricsPort == "" {
-		opts.MetricsPort = ":9695"
+		opts.MetricsPort = ":8080"
 	}
 
 	opts.HealthProbeBindAddress = os.Getenv(DefaultHealthProbeBindAddressEnvName)

--- a/images/sds-health-watcher-controller/config/config_test.go
+++ b/images/sds-health-watcher-controller/config/config_test.go
@@ -107,7 +107,7 @@ func TestNewConfig(t *testing.T) {
 
 	t.Run("MetricsPortNotSet_ReturnsDefaultPort", func(t *testing.T) {
 		expNodeName := "test-node"
-		expMetricsPort := ":9695"
+		expMetricsPort := ":8080"
 		expMachineId := "test-id"
 
 		err := os.Setenv(NodeName, expNodeName)

--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -72,7 +72,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: 4228
             scheme: HTTP
           initialDelaySeconds: 5
           failureThreshold: 2
@@ -80,10 +80,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: 4228
             scheme: HTTP
           periodSeconds: 1
           failureThreshold: 3
+        ports:
+          - name: metrics
+            containerPort: 4202
+            protocol: TCP
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/templates/agent/podmonitor.yaml
+++ b/templates/agent/podmonitor.yaml
@@ -1,0 +1,32 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: sds-node-configurator
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list $ (dict "prometheus" "main")) | nindent 2 }}
+spec:
+  podMetricsEndpoints:
+  - targetPort: metrics
+    scheme: http
+    path: /metrics
+    relabelings:
+    - regex: endpoint|namespace|pod|container
+      action: labeldrop
+    - targetLabel: job
+      replacement: sds-node-configurator
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      targetLabel: node
+    - targetLabel: tier
+      replacement: cluster
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      regex: "true"
+      action: keep
+  selector:
+    matchLabels:
+      app: sds-node-configurator
+  namespaceSelector:
+    matchNames:
+    - d8-{{ .Chart.Name }}
+{{- end }}

--- a/templates/sds-health-watcher-controller/deployment.yaml
+++ b/templates/sds-health-watcher-controller/deployment.yaml
@@ -83,6 +83,10 @@ spec:
               scheme: HTTP
             periodSeconds: 1
             failureThreshold: 3
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}

--- a/templates/sds-health-watcher-controller/servicemonitor.yaml
+++ b/templates/sds-health-watcher-controller/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sds-health-watcher-controller
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list $ (dict "prometheus" "main")) | nindent 2 }}
+spec:
+  endpoints:
+  - port: metrics
+    scheme: http
+    path: /metrics
+    bearerTokenSecret:
+      name: "prometheus-token"
+      key: "token"
+    tlsConfig:
+      insecureSkipVerify: true
+    relabelings:
+    - regex: endpoint|namespace|pod|container
+      action: labeldrop
+    - targetLabel: job
+      replacement: sds-health-watcher-controller
+    - targetLabel: tier
+      replacement: cluster
+    - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
+      regex: "true"
+      action: keep
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: sds-health-watcher-controller
+      app.kubernetes.io/managed-by: Helm
+  namespaceSelector:
+    matchNames:
+    - d8-{{ .Chart.Name }}
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add metric collector for sds-node-configurator agent

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need metrics for node-configurator monitoring

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Node configurator metrics collector

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
