### PR TITLE
[controller] Fix MD RAID block device discovery by reading UUID instead of serial

### DIFF
--- a/images/agent/pkg/controller/block_device.go
+++ b/images/agent/pkg/controller/block_device.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"os"
+	"regexp"
 	"sds-node-configurator/api/v1alpha1"
 	"sds-node-configurator/config"
 	"sds-node-configurator/internal"
@@ -167,7 +168,7 @@ func GetAPIBlockDevices(ctx context.Context, kc kclient.Client, metrics monitori
 	metrics.ApiMethodsExecutionCount(blockDeviceCtrlName, "list").Inc()
 	if err != nil {
 		metrics.ApiMethodsErrors(blockDeviceCtrlName, "list").Inc()
-		return nil, fmt.Errorf("Unable to kc.List, error: %w", err)
+		return nil, fmt.Errorf("unable to kc.List, error: %w", err)
 	}
 
 	devices := make(map[string]v1alpha1.BlockDevice, len(listDevice.Items))
@@ -273,25 +274,23 @@ func GetBlockDeviceCandidates(log logger.Logger, cfg config.Options, metrics mon
 
 		log.Trace(fmt.Sprintf("[GetBlockDeviceCandidates] Get following candidate: %+v", candidate))
 		if len(candidate.Serial) == 0 {
-			log.Info(fmt.Sprintf("[GetBlockDeviceCandidates] Serial is empty, trying to get it from device: %s", candidate.Path))
+			log.Info(fmt.Sprintf("[GetBlockDeviceCandidates] Serial number is empty; attempting to retrieve it from an alternate source: %s", candidate.Path))
+
 			if candidate.Type == internal.TypePart {
 				if len(candidate.PartUUID) == 0 {
 					log.Warning(fmt.Sprintf("[GetBlockDeviceCandidates] Type = part and cannot get PartUUID; skipping this device, path: %s", candidate.Path))
 					continue
 				}
 			} else {
-				err, serial := readSerialBlockDevice(candidate.Path)
+				serial, err := GetSerial(log, candidate)
 				if err != nil {
-					log.Warning(fmt.Sprintf("[GetBlockDeviceCandidates] readSerialBlockDevice, err: %s", err.Error()))
-
-					if len(candidate.Wwn) == 0 {
-						log.Warning(fmt.Sprintf("[GetBlockDeviceCandidates] Cannot get WWN and serial number; skipping this device, path: %s", candidate.Path))
-						continue
-					}
+					log.Warning(fmt.Sprintf("[GetBlockDeviceCandidates] Unable to obtain serial number or its equivalent; skipping device: %s. Error: %s", candidate.Path, err))
+					continue
 				}
 				candidate.Serial = serial
 			}
 		}
+
 		candidate.Name = CreateUniqDeviceName(candidate)
 		log.Trace(fmt.Sprintf("[GetBlockDeviceCandidates] Generated a unique candidate name: %s", candidate.Name))
 
@@ -444,13 +443,44 @@ func CreateUniqDeviceName(can internal.BlockDeviceCandidate) string {
 	return s
 }
 
-func readSerialBlockDevice(deviceName string) (error, string) {
+func GetSerial(log logger.Logger, candidate internal.BlockDeviceCandidate) (string, error) {
+	var serial string
+	matched, err := regexp.MatchString(`raid.*`, candidate.Type)
+	if err != nil {
+		log.Error(err, "[GetSerial] unable to regexp.MatchString. Trying to get serial from device")
+		serial, err = readSerialBlockDevice(candidate.Path)
+	} else if matched {
+		serial, err = readUUIDmdRaidBlockDevice(candidate.Path)
+	} else {
+		serial, err = readSerialBlockDevice(candidate.Path)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return serial, nil
+}
+
+func readSerialBlockDevice(deviceName string) (string, error) {
 	strPath := fmt.Sprintf("/sys/block/%s/serial", deviceName[5:])
 	serial, err := os.ReadFile(strPath)
 	if err != nil {
-		return err, ""
+		return "", fmt.Errorf("unable to read serial from block device: %s, error: %s", deviceName, err)
 	}
-	return nil, string(serial)
+	if len(serial) == 0 {
+		return "", fmt.Errorf("serial is empty")
+	}
+	return string(serial), nil
+}
+
+func readUUIDmdRaidBlockDevice(deviceName string) (string, error) {
+	strPath := fmt.Sprintf("/sys/block/%s/md/uuid", deviceName[5:])
+	uuid, err := os.ReadFile(strPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to read uuid from mdraid block device: %s, error: %s", deviceName, err)
+	}
+	return string(uuid), nil
 }
 
 func UpdateAPIBlockDevice(ctx context.Context, kc kclient.Client, metrics monitoring.Metrics, res v1alpha1.BlockDevice, candidate internal.BlockDeviceCandidate) error {

--- a/images/agent/pkg/controller/block_device.go
+++ b/images/agent/pkg/controller/block_device.go
@@ -463,6 +463,10 @@ func GetSerial(log logger.Logger, candidate internal.BlockDeviceCandidate) (stri
 }
 
 func readSerialBlockDevice(deviceName string) (string, error) {
+	if len(deviceName) < 6 {
+		return "", fmt.Errorf("device name is too short")
+	}
+
 	strPath := fmt.Sprintf("/sys/block/%s/serial", deviceName[5:])
 	serial, err := os.ReadFile(strPath)
 	if err != nil {
@@ -475,6 +479,10 @@ func readSerialBlockDevice(deviceName string) (string, error) {
 }
 
 func readUUIDmdRaidBlockDevice(deviceName string) (string, error) {
+	if len(deviceName) < 6 {
+		return "", fmt.Errorf("device name is too short")
+	}
+
 	strPath := fmt.Sprintf("/sys/block/%s/md/uuid", deviceName[5:])
 	uuid, err := os.ReadFile(strPath)
 	if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This update introduces a fix in the discovery process of MD RAID block devices. Previously, MD RAID block devices were not detected correctly by our controller. The fix changes the identification method from using serial numbers to using UUIDs, which ensures accurate detection and identification of these devices.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fix addresses the issue where MD RAID block devices were not being identified by our controller. This was a significant problem as it prevented the correct recognition and management of these devices. By switching to UUIDs for identification, we now have a reliable method for detecting MD RAID block devices, resolving the previous oversight.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

After applying this update, MD RAID block devices should now be correctly identified and listed within the system.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
