### PR TITLE
[controller] Fix resize for thinPools

### DIFF
--- a/images/agent/pkg/controller/lvm_logical_volume_watcher.go
+++ b/images/agent/pkg/controller/lvm_logical_volume_watcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sds-node-configurator/api/v1alpha1"
 	"sds-node-configurator/config"
 	"sds-node-configurator/internal"
@@ -434,7 +433,7 @@ func shouldReconcileByUpdateFunc(llv *v1alpha1.LvmLogicalVolume) (bool, error) {
 		return false, fmt.Errorf("requested size %d is less than actual %d", llv.Spec.Size.Value(), llv.Status.ActualSize.Value())
 	}
 
-	if AreSizesEqualWithinDelta(llv.Spec.Size, llv.Status.ActualSize, delta) {
+	if utils.AreSizesEqualWithinDelta(llv.Spec.Size, llv.Status.ActualSize, delta) {
 		return false, nil
 	}
 
@@ -716,11 +715,4 @@ func updateLVMLogicalVolume(ctx context.Context, metrics monitoring.Metrics, cl 
 	}
 
 	return err
-}
-
-func AreSizesEqualWithinDelta(leftSize, rightSize, allowedDelta resource.Quantity) bool {
-	leftSizeFloat := float64(leftSize.Value())
-	rightSizeFloat := float64(rightSize.Value())
-
-	return math.Abs(leftSizeFloat-rightSizeFloat) < float64(allowedDelta.Value())
 }

--- a/images/agent/pkg/controller/lvm_logical_volume_watcher.go
+++ b/images/agent/pkg/controller/lvm_logical_volume_watcher.go
@@ -272,8 +272,8 @@ func deleteLVIfExists(log logger.Logger, llv *v1alpha1.LvmLogicalVolume) error {
 	}
 
 	if lv == nil {
-		log.Debug(fmt.Sprintf("[deleteLVIfExists] did not find LV %s", lv.LVName))
-		return errors.New("lv does not exist")
+		log.Warning(fmt.Sprintf("[deleteLVIfExists] did not find LV %s", llv.Name))
+		return nil
 	}
 
 	cmd, err = utils.RemoveLV(lv.VGName, lv.LVName)
@@ -592,6 +592,10 @@ func addLLVFinalizerIfNotExist(ctx context.Context, cl client.Client, metrics mo
 }
 
 func shouldReconcileByCreateFunc(log logger.Logger, llv *v1alpha1.LvmLogicalVolume) (bool, error) {
+	if llv.DeletionTimestamp != nil {
+		return false, nil
+	}
+
 	if llv.Status == nil {
 		return true, nil
 	}

--- a/images/agent/pkg/utils/units.go
+++ b/images/agent/pkg/utils/units.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package utils
 
-import "k8s.io/apimachinery/pkg/api/resource"
+import (
+	"math"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 func BytesToQuantity(size int64) string {
 	tmp := resource.NewQuantity(size, resource.BinarySI)
@@ -29,4 +33,11 @@ func QuantityToBytes(quantity string) (int64, error) {
 		return 0, err
 	}
 	return b.Value(), nil
+}
+
+func AreSizesEqualWithinDelta(leftSize, rightSize, allowedDelta resource.Quantity) bool {
+	leftSizeFloat := float64(leftSize.Value())
+	rightSizeFloat := float64(rightSize.Value())
+
+	return math.Abs(leftSizeFloat-rightSizeFloat) < float64(allowedDelta.Value())
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR addresses an issue where the controller would erroneously enter the resize code path for thin pools even when resizing was not required. This unintended behavior led to errors in the resize logic, preventing the controller from proceeding to handle subsequent thin pools. As a result, the creation of new thin pools was inadvertently blocked. The fix ensures that the controller correctly bypasses the resize logic when no resizing is necessary, allowing for the seamless processing of thin pools and the unimpeded creation of new ones.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fix is crucial to address a flaw where the controller unnecessarily attempts to resize thin pools, leading to errors and halting further thin pool processing. This issue directly impedes the creation of new thin pools, disrupting normal storage operations. Correcting this ensures the controller only enters resize logic when needed, maintaining smooth and efficient thin pool management.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

The expected outcome of this PR is the elimination of the erroneous resize behavior in the controller's handling of thin pools. Specifically, it will:

Prevent unnecessary entry into the resize logic for thin pools, thereby avoiding errors associated with unwarranted resize attempts.
Ensure that the processing of thin pools can proceed without interruption, allowing for the continuous creation of new thin pools as required.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
