### PR TITLE
[ci] Rewrite the bin-copier script in Golang.

### DIFF
--- a/.werf/bundle.yaml
+++ b/.werf/bundle.yaml
@@ -2,7 +2,7 @@
 ---
 image: bundle
 from: registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
-fromCacheVersion: "2024-02-12.1"
+fromCacheVersion: "2024-03-27.1"
 import:
 # Rendering .werf/images-digests.yaml is required!
 - image: images-digests

--- a/images/sds-utils-installer/Dockerfile
+++ b/images/sds-utils-installer/Dockerfile
@@ -1,4 +1,5 @@
 ARG UBUNTU_UTILS_BUILDER=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
+ARG BASE_GOLANG_22_ALPINE=registry.deckhouse.io/base_images/golang:1.22.1-alpine@sha256:0de6cf7cceab6ecbf0718bdfb675b08b78113c3709c5e4b99456cdb2ae8c2495
 ARG BASE_IMAGE=registry.deckhouse.io/base_images/alpine:3.16.3@sha256:5548e9172c24a1b0ca9afdd2bf534e265c94b12b36b3e0c0302f5853eaf00abb
 ARG SOURCE_REPO
 
@@ -61,6 +62,19 @@ RUN git clone ${SOURCE_REPO}/util-linux/util-linux.git . && \
 RUN make install-strip
 
 #################################
+FROM $BASE_GOLANG_22_ALPINE as bin-copier-builder
+WORKDIR /go/src
+
+ADD go.mod .
+ADD go.sum .
+
+RUN go mod download
+
+COPY bin-copier.go .
+
+RUN GOOS=linux GOARCH=amd64 go build -o /bin-copier
+
+################################
 FROM --platform=linux/amd64 $BASE_IMAGE
 
 RUN apk add --no-cache rsync
@@ -77,8 +91,8 @@ COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libudev.so.1 /sds-utils/lib
 COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libc.so.6 /sds-utils/lib/
 COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libcap.so.2 /sds-utils/lib/
 COPY --from=util-linux-builder /opt/deckhouse/sds/bin/lsblk /sds-utils/bin/lsblk.dynamic
+COPY --from=bin-copier-builder /bin-copier /bin-copier
 
-ADD bin-copier.sh  .
 
-ENTRYPOINT ["/bin-copier.sh"]
+ENTRYPOINT ["/bin-copier"]
 CMD ["/sds-utils", "/opt/deckhouse/sds"]

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -205,7 +205,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 		if err != nil {
 			return err
 		}
-		log.Printf("Set file permissions on a new file %s according to %s successfully\n", dstPath, srcPath)
+		log.Printf("Set permissions on a new file %s according to %s successfully\n", dstPath, srcPath)
 
 		return nil
 	})

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -81,7 +81,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Println(dstPath, "- File already exists, checking sha256 checksum..")
+			fmt.Println(dstPath, "- File already exists, checking sha256..")
 			dstChecksum, err := getChecksum(dstPath)
 			if err != nil {
 				return err

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -19,7 +19,6 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -72,7 +71,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 		dstPath := filepath.Join(dstDir, relPath)
 
 		if info.IsDir() {
-			fmt.Println("Checking subfolder", dstPath)
+			log.Println("Checking subfolder", dstPath)
 			return os.MkdirAll(dstPath, info.Mode())
 		}
 
@@ -81,17 +80,17 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Println(dstPath, "- File already exists, checking sha256 sum..")
+			log.Println(dstPath, "- File already exists, checking sha256 sum..")
 			dstChecksum, err := getChecksum(dstPath)
 			if err != nil {
 				return err
 			}
 
 			if srcChecksum == dstChecksum {
-				fmt.Printf("Skipping %s: Checksum is the same\n", path)
+				log.Printf("Skipping %s: Checksum is the same\n", path)
 				return nil
 			} else {
-				fmt.Println("Copying\n", path)
+				log.Println("Copying\n", path)
 			}
 		}
 
@@ -100,7 +99,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 			return err
 		}
 
-		fmt.Printf("Copied %s successfully\n", path)
+		log.Printf("Copied %s successfully\n", path)
 
 		return nil
 	})
@@ -128,9 +127,9 @@ func main() {
 
 	err = copyFilesRecursive(srcDir, dstDir)
 	if err != nil {
-		fmt.Println("Error:", err)
+		log.Println("Error:", err)
 		return
 	}
 
-	fmt.Println("Done.")
+	log.Println("Done.")
 }

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -136,7 +136,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 				log.Printf("Skipping %s: Checksum is the same\n", path)
 				return nil
 			} else {
-				log.Println("Copying\n", path)
+				log.Printf("Copying %s: Checksum is different\n", path)
 			}
 		}
 

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -81,7 +81,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Println(dstPath, "- File already exists, checking sha256..")
+			fmt.Println(dstPath, "- File already exists, checking sha256 sum..")
 			dstChecksum, err := getChecksum(dstPath)
 			if err != nil {
 				return err

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -24,9 +24,11 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 func main() {
+	time.Sleep(time.Minute * 2)
 	srcDir := os.Args[1]
 	dstDir := os.Args[2]
 

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package main
+
+import (
+    "fmt"
+    "os"
+    "io"
+    "io/ioutil"
+    "path/filepath"
+    "sort"
+    "strings"
+    "log"
+    "crypto/sha256"
+    "encoding/hex"
+)
+
+
+
+func DirHash(path string) (string, error) {
+    var hashes []string
+
+    err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+        if err != nil {
+            return err
+        }
+        if info.IsDir() {
+            return nil
+        }
+
+        data, err := ioutil.ReadFile(path)
+        if err != nil {
+            return err
+        }
+
+        hasher := sha256.New()
+        hasher.Write(data)
+
+        hashes = append(hashes, hex.EncodeToString(hasher.Sum(nil)))
+
+        return nil
+    })
+    if err != nil {
+        return "", err
+    }
+
+    sort.Strings(hashes)
+    return hex.EncodeToString(sha256.New().Sum([]byte(strings.Join(hashes, "")))), nil
+}
+
+
+func CopyDir(src, dst string) error {
+    return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+        if err != nil {
+            return err
+        }
+
+        dstPath := filepath.Join(dst, strings.TrimPrefix(path, src))
+        if info.IsDir() {
+            return os.MkdirAll(dstPath, info.Mode())
+        }
+
+        srcFile, err := os.Open(path)
+        if err != nil {
+            return err
+        }
+        defer srcFile.Close()
+
+        dstFile, err := os.Create(dstPath)
+        if err != nil {
+            return err
+        }
+        
+        _, err = io.Copy(dstFile, srcFile)
+        dstFile.Close()
+
+        return err
+    })
+}
+
+
+
+
+func main() {
+	source := os.Args[1]
+	dest := os.Args[2]
+
+
+	info_src, err := os.Stat(source)
+	if os.IsNotExist(err) {
+		log.Fatal("ERR: source path doesn't exist!")
+	} else if !info_src.IsDir() {
+		log.Fatal("ERR: source path is a file (expecting dir)!")
+	}
+
+        info_dst, err := os.Stat(dest)
+        if os.IsNotExist(err) {
+                log.Fatal("ERR: destination path doesn't exist!")
+        } else if !info_dst.IsDir() {
+                log.Fatal("ERR: destination path is a file (expecting dir)!")
+        }
+
+
+        srcHash, err := DirHash(source)
+    	if err != nil {
+        	log.Fatal("ERR failed calculating src dir hash")
+	}
+
+	dstHash, err := DirHash(dest)
+	if err != nil {
+        	log.Fatal("ERR failed calculating destination dir hash")
+	}
+
+	if srcHash != dstHash {
+        	err = CopyDir(source, dest)
+        	if err != nil {
+            		log.Fatal("ERR failed copying files")
+	        }
+        		fmt.Println("Directories were different. Copied files from source to destination.")
+		} else {
+        		fmt.Println("Directories are identical. No files were copied.")
+	 }
+
+
+
+}

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -24,11 +24,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 func main() {
-	time.Sleep(time.Minute * 2)
 	srcDir := os.Args[1]
 	dstDir := os.Args[2]
 
@@ -83,6 +81,8 @@ func copyFile(src, dst string) (err error) {
 	return err
 }
 
+//func getRights()
+
 func getChecksum(filePath string) (checksum string, err error) {
 	var file *os.File
 	file, err = os.Open(filePath)
@@ -106,12 +106,12 @@ func getChecksum(filePath string) (checksum string, err error) {
 }
 
 func copyFilesRecursive(srcDir, dstDir string) error {
-	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(srcDir, func(srcPath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		relPath, err := filepath.Rel(srcDir, path)
+		relPath, err := filepath.Rel(srcDir, srcPath)
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 		}
 
 		if _, err := os.Stat(dstPath); err == nil {
-			srcChecksum, err := getChecksum(path)
+			srcChecksum, err := getChecksum(srcPath)
 			if err != nil {
 				return err
 			}
@@ -135,19 +135,23 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 			}
 
 			if srcChecksum == dstChecksum {
-				log.Printf("Skipping %s: Checksum is the same\n", path)
+
+				//TODO - проверить права на файл функцией
+
+				log.Printf("Skipping %s: Checksum is the same\n", srcPath)
 				return nil
 			} else {
-				log.Printf("Copying %s: Checksum is different\n", path)
+				log.Printf("Copying %s: Checksum is different\n", srcPath)
 			}
+
 		}
 
-		err = copyFile(path, dstPath)
+		err = copyFile(srcPath, dstPath)
 		if err != nil {
 			return err
 		}
-
-		log.Printf("Copied %s successfully\n", path)
+		// TODO - копирование прав здесь
+		log.Printf("Copied file from %s to %s successfully\n", srcPath, dstPath)
 
 		return nil
 	})

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -81,7 +81,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Println(dstPath, "- File already exists, checking sha256..")
+			fmt.Println(dstPath, "- File already exists, checking sha256 checksum..")
 			dstChecksum, err := getChecksum(dstPath)
 			if err != nil {
 				return err

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -1,148 +1,125 @@
 package main
 
 import (
-    "io"
-    "os"
-    "path/filepath"
-    "crypto/sha256"
-    "encoding/hex"
-    "io/ioutil"
-    "log"
-    "fmt"
-    "sort"
-    "strings"
-
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 )
 
+func contentsHash(path string) (string, error) {
+	var hashes []string
 
-func DirHash(path string) (string, error) {
-    var hashes []string
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
 
-    err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-        if err != nil {
-            return err
-        }
-        if info.IsDir() {
-            return nil
-        }
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
 
-        data, err := ioutil.ReadFile(path)
-        if err != nil {
-            return err
-        }
+		hasher := sha256.New()
+		hasher.Write(data)
 
-        hasher := sha256.New()
-        hasher.Write(data)
+		hashes = append(hashes, hex.EncodeToString(hasher.Sum(nil)))
 
-        hashes = append(hashes, hex.EncodeToString(hasher.Sum(nil)))
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
 
-        return nil
-    })
-    if err != nil {
-        return "", err
-    }
-
-    sort.Strings(hashes)
-    return hex.EncodeToString(sha256.New().Sum([]byte(strings.Join(hashes, "")))), nil
- }
-
-
-
-func FileHash(path string) (string, error) {
-    data, err := ioutil.ReadFile(path)
-    if err != nil {
-        return "", err
-    }
-
-    hasher := sha256.New()
-    hasher.Write(data)
-
-    return hex.EncodeToString(hasher.Sum(nil)), nil
+	sort.Strings(hashes)
+	return hex.EncodeToString(sha256.New().Sum([]byte(strings.Join(hashes, "")))), nil
 }
 
+func copyIfDifferent(src, dst string) error {
+	return filepath.Walk(src, func(srcPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 
-func CopyIfDifferent(src, dst string) error {
-    return filepath.Walk(src, func(srcPath string, info os.FileInfo, err error) error {
-        if err != nil {
-            return err
-        }
+		dstPath := filepath.Join(dst, strings.TrimPrefix(srcPath, src))
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
 
-        dstPath := filepath.Join(dst, strings.TrimPrefix(srcPath, src))
-        if info.IsDir() {
-            return os.MkdirAll(dstPath, info.Mode())
-        }
+		srcHash, err := contentsHash(srcPath)
+		if err != nil {
+			return err
+		}
 
-        srcHash, err := FileHash(srcPath)
-        if err != nil {
-            return err
-        }
+		dstHash, _ := contentsHash(dstPath)
 
-        dstHash, _ := FileHash(dstPath) 
+		if srcHash != dstHash {
+			srcFile, err := os.Open(srcPath)
+			if err != nil {
+				fmt.Println("Error getting file from source")
+			}
+			defer srcFile.Close()
 
-        if srcHash != dstHash {
-            srcFile, err := os.Open(srcPath)
-            if err != nil {
-                return err
-            }
-            defer srcFile.Close()
+			dstFile, err := os.Create(dstPath)
+			if err != nil {
+				fmt.Println("Error copying file to destination folder")
+			}
+			fmt.Println(dstPath)
+			defer dstFile.Close()
 
-            dstFile, err := os.Create(dstPath)
-            if err != nil {
-                return err
-            }
-	    fmt.Println(dstPath)
-            defer dstFile.Close()
+			_, err = io.Copy(dstFile, srcFile)
+			return err
+		}
 
-            _, err = io.Copy(dstFile, srcFile)
-            return err
-        }
-
-        return nil
-    })
+		return nil
+	})
 }
-
 
 func main() {
-    src := os.Args[1]
-    dst := os.Args[2]
+	src := os.Args[1]
+	dst := os.Args[2]
 
+	srcCheck, err := os.Stat(src)
+	if os.IsNotExist(err) {
+		log.Fatal("ERR: source path doesn't exist!")
+	} else if !srcCheck.IsDir() {
+		log.Fatal("ERR: source path is a file (expecting dir)!")
+	}
 
-        info_src, err := os.Stat(src)
-        if os.IsNotExist(err) {
-                log.Fatal("ERR: source path doesn't exist!")
-        } else if !info_src.IsDir() {
-                log.Fatal("ERR: source path is a file (expecting dir)!")
-        }
+	dstCheck, err := os.Stat(dst)
+	if os.IsNotExist(err) {
+		log.Fatal("ERR: destination path doesn't exist!")
+	} else if !dstCheck.IsDir() {
+		log.Fatal("ERR: destination path is a file (expecting dir)!")
+	}
 
-        info_dst, err := os.Stat(dst)
-        if os.IsNotExist(err) {
-                log.Fatal("ERR: destination path doesn't exist!")
-        } else if !info_dst.IsDir() {
-                log.Fatal("ERR: destination path is a file (expecting dir)!")
-        }
+	srcHash, err := contentsHash(src)
+	if err != nil {
+		log.Fatal("ERR failed calculating src dir hash")
+	}
 
+	dstHash, err := contentsHash(dst)
+	if err != nil {
+		log.Fatal("ERR failed calculating destination dir hash")
+	}
 
-        srcHash, err := DirHash(src)
-        if err != nil {
-                log.Fatal("ERR failed calculating src dir hash")
-        }
-
-        dstHash, err := DirHash(dst)
-        if err != nil {
-        log.Fatal("ERR failed calculating destination dir hash")
-        }
-
-        if srcHash != dstHash {
-                err := CopyIfDifferent(src, dst)
-                if err != nil {
-                        log.Fatal("ERR failed copying files")
-                }
-                        fmt.Println("Directories' sha256 sum is different, see what's been copied above")
-                } else {
-                        fmt.Println("Directories are identical. No files were copied.")
-         }
-
+	if srcHash != dstHash {
+		fmt.Println("Found new files, copying:")
+		err := copyIfDifferent(src, dst)
+		if err != nil {
+			log.Fatal("ERR failed copying files")
+		}
+		fmt.Println("Utils have been updated successfully.")
+	} else {
+		fmt.Println("Everything is up-to-date. No files were copied.")
+	}
 
 }
-
-	

--- a/images/sds-utils-installer/bin-copier.go
+++ b/images/sds-utils-installer/bin-copier.go
@@ -126,7 +126,7 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 		dstPath := filepath.Join(dstDir, relPath)
 
 		if info.IsDir() {
-			log.Println("Checking subfolder", dstPath)
+			log.Println("Checking subfolder: ", dstPath)
 			return os.MkdirAll(dstPath, info.Mode())
 		}
 
@@ -135,14 +135,14 @@ func copyFilesRecursive(srcDir, dstDir string) error {
 			if err != nil {
 				return err
 			}
-			log.Printf("%s - File already exists, checking sha256 and permissions..", dstPath)
+			log.Printf("%s - File already exists, checking sha256 and permissions\n", dstPath)
 			dstChecksum, err := getChecksum(dstPath)
 			if err != nil {
 				return err
 			}
 
 			if srcChecksum == dstChecksum {
-				log.Printf("%s: Checksum is the same\n", srcPath)
+				log.Printf("Checksum of %s in unchanged, checking permissions\n", srcPath)
 			} else {
 				log.Printf("Copying %s: Checksum is different\n", srcPath)
 			}

--- a/images/sds-utils-installer/go.mod
+++ b/images/sds-utils-installer/go.mod
@@ -1,0 +1,13 @@
+module std
+
+go 1.22
+
+require (
+	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
+	golang.org/x/net v0.19.0
+)
+
+require (
+	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/images/sds-utils-installer/go.mod
+++ b/images/sds-utils-installer/go.mod
@@ -1,13 +1,3 @@
 module bin-copier
 
 go 1.22
-
-require (
-	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
-	golang.org/x/net v0.19.0
-)
-
-require (
-	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
-)

--- a/images/sds-utils-installer/go.mod
+++ b/images/sds-utils-installer/go.mod
@@ -1,4 +1,4 @@
-module std
+module bin-copier
 
 go 1.22
 

--- a/images/sds-utils-installer/go.sum
+++ b/images/sds-utils-installer/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=
+golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/images/sds-utils-installer/go.sum
+++ b/images/sds-utils-installer/go.sum
@@ -1,8 +1,0 @@
-golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=
-golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=


### PR DESCRIPTION
## Description

Rewrite the bin-copier script in Golang.
Abandon the former shell script.

## Why do we need it, and what problem does it solve?

Independent of the system shell and utilities - eliminates the need for having rsync or explicitly using bash.

## What is the expected result?

An environment-independent binary.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
