### PR TITLE
[controller] Move lsblk and its libraries inside the agent image

### DIFF
--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -1,7 +1,6 @@
 ARG GOLANG_20_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.20.5-alpine3.18@sha256:51a47fb0851397db2f506c15c426735bc23de31177cbdd962880c0879d1906a4
 ARG UBUNTU_UTILS_BUILDER=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
-# ARG BASE_IMAGE=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
-ARG BASE_IMAGE=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
+ARG BASE_IMAGE=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
 
 #################################
 FROM $UBUNTU_UTILS_BUILDER as util-linux-builder
@@ -64,6 +63,7 @@ COPY --from=util-linux-builder /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/dec
 COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/
 COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libc.so.6 /opt/deckhouse/sds/lib/
 COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/lib/
+COPY --from=util-linux-builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 COPY --from=util-linux-builder /opt/deckhouse/sds/bin/lsblk /opt/deckhouse/sds/bin/lsblk.dynamic
 
 COPY --from=agent-builder /go/src/cmd/sds-node-configurator-agent /go/src/cmd/sds-node-configurator-agent

--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -30,7 +30,7 @@ RUN git clone ${SOURCE_REPO}/util-linux/util-linux.git . && \
 RUN ./configure LDFLAGS="-static" --enable-static-programs -disable-all-programs --enable-nsenter && \
     make install-strip
 
-RUN ./configure --prefix /opt/deckhouse/sds && \
+RUN ./configure --prefix /opt/deckhouse/sds --with-udev && \
     make install-strip
 
 

--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -1,7 +1,7 @@
 ARG GOLANG_20_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.20.5-alpine3.18@sha256:51a47fb0851397db2f506c15c426735bc23de31177cbdd962880c0879d1906a4
 ARG UBUNTU_UTILS_BUILDER=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
-# ARG BASE_IMAGE=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
-ARG BASE_IMAGE=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
+ARG BASE_IMAGE=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
+# ARG BASE_IMAGE=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
 
 #################################
 FROM $UBUNTU_UTILS_BUILDER as util-linux-builder
@@ -16,6 +16,10 @@ RUN apt-get update && apt-get install -y \
     autoconf \
     bison \
     libtool \
+    libudev-dev \
+    libblkid-dev \
+    libsmartcols-dev \
+    libmount-dev \
     automake \
     gettext \
     flex \

--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -1,6 +1,7 @@
 ARG GOLANG_20_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.20.5-alpine3.18@sha256:51a47fb0851397db2f506c15c426735bc23de31177cbdd962880c0879d1906a4
 ARG UBUNTU_UTILS_BUILDER=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
-ARG BASE_IMAGE=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
+# ARG BASE_IMAGE=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
+ARG BASE_IMAGE=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
 
 #################################
 FROM $UBUNTU_UTILS_BUILDER as util-linux-builder

--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -1,7 +1,7 @@
 ARG GOLANG_20_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.20.5-alpine3.18@sha256:51a47fb0851397db2f506c15c426735bc23de31177cbdd962880c0879d1906a4
 ARG UBUNTU_UTILS_BUILDER=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
-ARG BASE_IMAGE=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
-# ARG BASE_IMAGE=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
+# ARG BASE_IMAGE=registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
+ARG BASE_IMAGE=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
 
 #################################
 FROM $UBUNTU_UTILS_BUILDER as util-linux-builder

--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -24,10 +24,14 @@ WORKDIR /util-linux
 
 RUN git clone ${SOURCE_REPO}/util-linux/util-linux.git . && \
   git checkout v${UTIL_LINUX_VERSION} && \
-  ./autogen.sh && \
-  ./configure LDFLAGS="-static" --enable-static-programs -disable-all-programs --enable-nsenter
+  ./autogen.sh
 
-RUN make install-strip
+RUN ./configure LDFLAGS="-static" --enable-static-programs -disable-all-programs --enable-nsenter && \
+    make install-strip
+
+RUN ./configure --prefix /opt/deckhouse/sds && \
+    make install-strip
+
 
 #################################
 FROM $GOLANG_20_ALPINE_BUILDER as agent-builder
@@ -47,6 +51,16 @@ RUN GOOS=linux GOARCH=amd64 go build -o sds-node-configurator-agent
 FROM --platform=linux/amd64 $BASE_IMAGE
 
 COPY --from=util-linux-builder /util-linux/nsenter.static /opt/deckhouse/sds/bin/nsenter.static
+
+# Got from ldd lsblk.dynamic
+COPY --from=util-linux-builder /opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/
+COPY --from=util-linux-builder /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/
+COPY --from=util-linux-builder /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/lib/
+COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/
+COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libc.so.6 /opt/deckhouse/sds/lib/
+COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/lib/
+COPY --from=util-linux-builder /opt/deckhouse/sds/bin/lsblk /opt/deckhouse/sds/bin/lsblk.dynamic
+
 COPY --from=agent-builder /go/src/cmd/sds-node-configurator-agent /go/src/cmd/sds-node-configurator-agent
 
 CMD ["/go/src/cmd/sds-node-configurator-agent"]

--- a/images/agent/pkg/utils/commands.go
+++ b/images/agent/pkg/utils/commands.go
@@ -27,9 +27,8 @@ import (
 
 func GetBlockDevices() ([]internal.Device, string, error) {
 	var outs bytes.Buffer
-	args := []string{internal.LSBLKCmd, "-J", "-lpfb", "-no", "name,MOUNTPOINT,PARTUUID,HOTPLUG,MODEL,SERIAL,SIZE,FSTYPE,TYPE,WWN,KNAME,PKNAME,ROTA"}
-	extendedArgs := extendArgs(args)
-	cmd := exec.Command(internal.NSENTERCmd, extendedArgs...)
+	args := []string{"-J", "-lpfb", "-no", "name,MOUNTPOINT,PARTUUID,HOTPLUG,MODEL,SERIAL,SIZE,FSTYPE,TYPE,WWN,KNAME,PKNAME,ROTA"}
+	cmd := exec.Command(internal.LSBLKCmd, args...)
 	cmd.Stdout = &outs
 
 	var stderr bytes.Buffer

--- a/images/sds-utils-installer/Dockerfile
+++ b/images/sds-utils-installer/Dockerfile
@@ -80,7 +80,6 @@ FROM --platform=linux/amd64 $BASE_IMAGE
 RUN apk add --no-cache rsync
 
 WORKDIR /
-
 COPY --from=lvm-builder /lvm2/tools/lvm.static /sds-utils/bin/lvm.static
 
 # Got from ldd lsblk.dynamic

--- a/images/sds-utils-installer/Dockerfile
+++ b/images/sds-utils-installer/Dockerfile
@@ -31,37 +31,6 @@ RUN git clone ${SOURCE_REPO}/lvmteam/lvm2.git . && \
   make
 
 #################################
-FROM $UBUNTU_UTILS_BUILDER as util-linux-builder
-ARG SOURCE_REPO
-ARG UTIL_LINUX_VERSION=2.39.3
-
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
-    pkg-config \
-    autopoint \
-    autoconf \
-    bison \
-    libtool \
-    libudev-dev \
-    libblkid-dev \
-    libsmartcols-dev \
-    libmount-dev \
-    automake \
-    gettext \
-    flex \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /util-linux
-
-RUN git clone ${SOURCE_REPO}/util-linux/util-linux.git . && \
-  git checkout v${UTIL_LINUX_VERSION} && \
-  ./autogen.sh && \
-  ./configure --prefix /opt/deckhouse/sds
-
-RUN make install-strip
-
-#################################
 FROM $BASE_GOLANG_22_ALPINE as bin-copier-builder
 WORKDIR /go/src
 
@@ -77,19 +46,8 @@ RUN GOOS=linux GOARCH=amd64 go build -o /bin-copier
 ################################
 FROM --platform=linux/amd64 $BASE_IMAGE
 
-RUN apk add --no-cache rsync
-
 WORKDIR /
 COPY --from=lvm-builder /lvm2/tools/lvm.static /sds-utils/bin/lvm.static
-
-# Got from ldd lsblk.dynamic
-COPY --from=util-linux-builder /opt/deckhouse/sds/lib/libblkid.so.1 /sds-utils/lib/
-COPY --from=util-linux-builder /opt/deckhouse/sds/lib/libmount.so.1 /sds-utils/lib/
-COPY --from=util-linux-builder /opt/deckhouse/sds/lib/libsmartcols.so.1 /sds-utils/lib/
-COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libudev.so.1 /sds-utils/lib/
-COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libc.so.6 /sds-utils/lib/
-COPY --from=util-linux-builder /lib/x86_64-linux-gnu/libcap.so.2 /sds-utils/lib/
-COPY --from=util-linux-builder /opt/deckhouse/sds/bin/lsblk /sds-utils/bin/lsblk.dynamic
 COPY --from=bin-copier-builder /bin-copier /bin-copier
 
 

--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -93,6 +93,8 @@ spec:
         volumeMounts:
         - mountPath: /sys/
           name: host-sys-dir
+        - mountPath: /run/udev/
+          name: host-run-udev-dir
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
@@ -108,4 +110,8 @@ spec:
           path: /sys/
           type: Directory
         name: host-sys-dir
+      - hostPath:
+          path: /run/udev/
+          type: Directory
+        name: host-run-udev-dir
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

In this update, we've changed our approach by moving the `lsblk` binary and its dependent libraries from the host into the container agent image itself. Previously, we deployed our own version of `lsblk` along with necessary libraries onto the host to ensure compatibility. However, executing `lsblk` via `nsenter` directly from the host led to unstable behavior in certain operating systems, such as Ubuntu 20.04, where we encountered `segmentation fault` errors likely due to library incompatibilities. By integrating `lsblk` and its libraries directly into the agent's container image, we eliminate these compatibility issues, aiming for uniform execution across all environments.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The relocation of `lsblk` into the agent's container directly addresses the issue of unstable performance and operational errors in different OS versions. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- A stable and consistent execution of `lsblk` across all platforms, without encountering `segmentation fault` errors or other compatibility issues.
- Simplified deployment and operation processes, with reduced dependency on the host's library configurations.




## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
