### PR TITLE
[controller] Implement stderr filtering for LVM commands

### DIFF
--- a/images/agent/pkg/utils/commands.go
+++ b/images/agent/pkg/utils/commands.go
@@ -507,6 +507,7 @@ func lvmStaticExtendedArgs(args []string) []string {
 // system security. Therefore, they can be safely ignored to simplify the analysis of command output.
 //
 // Parameters:
+//   - command (string): The command that generated the stderr output.
 //   - stdErr (bytes.Buffer): The buffer containing the stderr output from a command execution.
 //
 // Returns:

--- a/images/agent/pkg/utils/commands.go
+++ b/images/agent/pkg/utils/commands.go
@@ -496,6 +496,20 @@ func lvmStaticExtendedArgs(args []string) []string {
 	return append(result, args...)
 }
 
+// filterStdErr processes a bytes.Buffer containing stderr output and filters out specific
+// messages that match a predefined regular expression pattern. In this context, it's used to
+// exclude "Regex version mismatch" messages generated due to SELinux checks on a statically
+// compiled LVM binary. These messages report a discrepancy between the versions of the regex
+// library used inside the LVM binary, but since LVM is statically compiled and doesn't rely on
+// system libraries at runtime, these warnings do not impact LVM's functionality or overall
+// system security. Therefore, they can be safely ignored to simplify the analysis of command output.
+//
+// Parameters:
+//   - stdErr (bytes.Buffer): The buffer containing the stderr output from a command execution.
+//
+// Returns:
+//   - bytes.Buffer: A new buffer containing the filtered stderr output, excluding lines that
+//     match the "Regex version mismatch" pattern.
 func filterStdErr(stdErr bytes.Buffer) bytes.Buffer {
 	var filteredStdErr bytes.Buffer
 	stdErrScanner := bufio.NewScanner(&stdErr)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR introduces a new function, `filterStdErr`, designed to process stderr output from LVM command executions and filter out specific messages that can be safely ignored. The primary focus is on excluding "Regex version mismatch" messages that arise due to SELinux checks on a statically compiled LVM binary. These messages, while reporting a discrepancy between the regex library versions, do not affect LVM's functionality or compromise system security, as our LVM binary operates independently of system libraries at runtime.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In systems with SELinux, executing LVM commands from our binary generates "Regex version mismatch" warnings in stderr, even when the commands complete successfully. Our controller's logic, which checks for any stderr output to determine operational status, may mistakenly interpret these warnings as errors, incorrectly setting LVMVolumeGroup resources to a `NonOperational` status. The `filterStdErr` function addresses this issue by removing such misleading messages from stderr, ensuring that only genuine errors affect the operational status, thereby preventing false positives in system monitoring.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Reduced false positives in operational status checks for LVMVolumeGroup resources in SELinux environments, by ignoring "Regex version mismatch" warnings in stderr.
- Improved reliability and accuracy of system monitoring and error reporting for LVM operations, focusing attention on actual errors that require intervention.
- Enhanced compatibility and seamless operation of statically compiled LVM binaries in systems with SELinux.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
