### PR TITLE
[controller] LVMLogicalVolumeWatcher considers any other LVMLogicalVolume finalizers before the resource deletion

### DIFF
--- a/images/agent/pkg/controller/lvm_logical_volume_watcher.go
+++ b/images/agent/pkg/controller/lvm_logical_volume_watcher.go
@@ -150,7 +150,42 @@ func RunLVMLogicalVolumeWatcherController(
 
 			log.Info(fmt.Sprintf("[RunLVMLogicalVolumeWatcherController] UpdateFunc ends reconciliation of LLV: %s", newLLV.Name))
 		},
+		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+			log.Info(fmt.Sprintf("[RunLVMLogicalVolumeWatcherController] DeleteFunc starts reconciliation of LLV: %s", e.Object.GetName()))
+
+			llv, ok := e.Object.(*v1alpha1.LVMLogicalVolume)
+			if !ok {
+				err = errors.New("unable to cast event object to a given type")
+				log.Error(err, "[DeleteFunc] an error occurs while handling update event")
+				return
+			}
+			log.Trace("[RunLVMLogicalVolumeWatcherController] DeleteFunc got LVMLogicalVolume: ", llv.Name, llv)
+
+			lvg, err := getLVMVolumeGroup(ctx, cl, metrics, "", llv.Spec.LvmVolumeGroupName)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[DeleteFunc] unable to get the LVMVolumeGroup, name: %s", llv.Spec.LvmVolumeGroupName))
+				err = updateLVMLogicalVolumePhase(ctx, cl, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Unable to get selected LVMVolumeGroup, err: %s", err.Error()))
+				if err != nil {
+					log.Error(err, "[DeleteFunc] unable to update LVMLogicalVolume Phase")
+				}
+				return
+			}
+
+			if !belongsToNode(lvg, cfg.NodeName) {
+				log.Debug(fmt.Sprintf("[DeleteFunc] the LVMVolumeGroup %s does not belongs to the current node: %s. Reconciliation stopped", lvg.Name, cfg.NodeName))
+				return
+			}
+			log.Debug(fmt.Sprintf("[DeleteFunc] the LVMVolumeGroup %s belongs to the current node: %s", lvg.Name, cfg.NodeName))
+
+			err = deleteLVIfExists(log, lvg.Spec.ActualVGNameOnTheNode, llv.Spec.ActualLVNameOnTheNode)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[DeleteFunc] an error occured while trying to delete LV for LVMLogicalVolume %s", llv.Name))
+			}
+
+			log.Info(fmt.Sprintf("[RunLVMLogicalVolumeWatcherController] DeleteFunc ends reconciliation of LLV: %s", llv.Name))
+		},
 	})
+
 	if err != nil {
 		log.Error(err, "[RunLVMLogicalVolumeWatcherController] the controller is unable to watch")
 		return nil, err
@@ -228,11 +263,17 @@ func reconcileLLVDeleteFunc(
 ) {
 	log.Info("[reconcileLLVDeleteFunc] starts reconciliation")
 
+	// The controller won't remove the LLV resource and LV volume till the resource has any other finalizer.
+	if len(llv.Finalizers) != 1 ||
+		llv.Finalizers[0] != internal.SdsNodeConfiguratorFinalizer {
+		log.Debug(fmt.Sprintf("[reconcileLLVDeleteFunc] unable to delete LVMLogicalVolume %s for now due to it has any other finalizer", llv.Name))
+		return
+	}
+
 	vgName := lvg.Spec.ActualVGNameOnTheNode
 	lvName := llv.Spec.ActualLVNameOnTheNode
 
 	err := deleteLVIfExists(log, vgName, lvName)
-
 	if err != nil {
 		log.Error(err, fmt.Sprintf("[reconcileLLVDeleteFunc] unable to delete the LV %s in VG %s", lvName, vgName))
 		err = updateLVMLogicalVolumePhase(ctx, cl, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Unable to delete the the LV %s in VG %s, err: %s", lvName, vgName, err.Error()))


### PR DESCRIPTION
## Description
LVMLogicalVolumeWatcher considers any other LVMLogicalVolume finalizers before the resource deletion.

## Why do we need it, and what problem does it solve?
It prevents LV deletion before PVC deletion or any other unfinished operations.

## What is the expected result?
LVMLogicalVolume resources cannot be deleted till the resource has any other finalizer but Sds-node-configurator's one.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
