### PR TITLE
[controller] Change LVMVolumeGroupDiscover controller logic to work with the controller's cache

### DIFF
--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -129,7 +129,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if _, err = controller.RunLVMVolumeGroupDiscoverController(ctx, mgr, *cfgParams, *log, metrics); err != nil {
+	if _, err = controller.RunLVMVolumeGroupDiscoverController(ctx, mgr, *cfgParams, *log, metrics, sdsCache); err != nil {
 		log.Error(err, "[main] unable to controller.RunLVMVolumeGroupDiscoverController")
 		os.Exit(1)
 	}

--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -113,7 +113,7 @@ func main() {
 	sdsCache := cache.New()
 
 	go func() {
-		if err = controller.RunScanner(*log, sdsCache); err != nil {
+		if err = controller.RunScanner(*log, *cfgParams, sdsCache); err != nil {
 			log.Error(err, "[main] unable to run scanner")
 			os.Exit(1)
 		}

--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -113,13 +113,13 @@ func main() {
 	sdsCache := cache.New()
 
 	go func() {
-		if err = controller.RunScanner(*log, *cfgParams, sdsCache); err != nil {
+		if err = controller.RunScanner(*log, sdsCache); err != nil {
 			log.Error(err, "[main] unable to run scanner")
 			os.Exit(1)
 		}
 	}()
 
-	if _, err = controller.RunBlockDeviceController(ctx, mgr, *cfgParams, *log, metrics, sdsCache); err != nil {
+	if _, err = controller.RunBlockDeviceController(ctx, mgr, *cfgParams, *log, metrics); err != nil {
 		log.Error(err, "[main] unable to controller.RunBlockDeviceController")
 		os.Exit(1)
 	}

--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -119,7 +119,7 @@ func main() {
 		}
 	}()
 
-	if _, err = controller.RunBlockDeviceController(ctx, mgr, *cfgParams, *log, metrics); err != nil {
+	if _, err = controller.RunBlockDeviceController(ctx, mgr, *cfgParams, *log, metrics, sdsCache); err != nil {
 		log.Error(err, "[main] unable to controller.RunBlockDeviceController")
 		os.Exit(1)
 	}

--- a/images/agent/pkg/cache/cache.go
+++ b/images/agent/pkg/cache/cache.go
@@ -13,8 +13,8 @@ type Cache struct {
 	lvs     []internal.LVData
 }
 
-func New() *Cache {
-	return &Cache{}
+func New() Cache {
+	return Cache{}
 }
 
 func (c *Cache) StoreDevices(devices []internal.Device) {

--- a/images/agent/pkg/cache/cache.go
+++ b/images/agent/pkg/cache/cache.go
@@ -1,64 +1,73 @@
 package cache
 
 import (
+	"bytes"
 	"fmt"
 	"sds-node-configurator/internal"
 	"sds-node-configurator/pkg/logger"
 )
 
 type Cache struct {
-	devices []internal.Device
-	pvs     []internal.PVData
-	vgs     []internal.VGData
-	lvs     []internal.LVData
+	devices    []internal.Device
+	deviceErrs bytes.Buffer
+	pvs        []internal.PVData
+	pvsErrs    bytes.Buffer
+	vgs        []internal.VGData
+	vgsErrs    bytes.Buffer
+	lvs        []internal.LVData
+	lvsErrs    bytes.Buffer
 }
 
 func New() Cache {
 	return Cache{}
 }
 
-func (c *Cache) StoreDevices(devices []internal.Device) {
+func (c *Cache) StoreDevices(devices []internal.Device, stdErr bytes.Buffer) {
 	c.devices = devices
+	c.deviceErrs = stdErr
 }
 
-func (c *Cache) GetDevices() []internal.Device {
+func (c *Cache) GetDevices() ([]internal.Device, bytes.Buffer) {
 	dst := make([]internal.Device, len(c.devices))
 	copy(dst, c.devices)
 
-	return dst
+	return dst, c.deviceErrs
 }
 
-func (c *Cache) StorePVs(pvs []internal.PVData) {
+func (c *Cache) StorePVs(pvs []internal.PVData, stdErr bytes.Buffer) {
 	c.pvs = pvs
+	c.pvsErrs = stdErr
 }
 
-func (c *Cache) GetPVs() []internal.PVData {
+func (c *Cache) GetPVs() ([]internal.PVData, bytes.Buffer) {
 	dst := make([]internal.PVData, len(c.pvs))
 	copy(dst, c.pvs)
 
-	return dst
+	return dst, c.pvsErrs
 }
 
-func (c *Cache) StoreVGs(vgs []internal.VGData) {
+func (c *Cache) StoreVGs(vgs []internal.VGData, stdErr bytes.Buffer) {
 	c.vgs = vgs
+	c.vgsErrs = stdErr
 }
 
-func (c *Cache) GetVGs() []internal.VGData {
+func (c *Cache) GetVGs() ([]internal.VGData, bytes.Buffer) {
 	dst := make([]internal.VGData, len(c.vgs))
 	copy(dst, c.vgs)
 
-	return dst
+	return dst, c.vgsErrs
 }
 
-func (c *Cache) StoreLVs(lvs []internal.LVData) {
+func (c *Cache) StoreLVs(lvs []internal.LVData, stdErr bytes.Buffer) {
 	c.lvs = lvs
+	c.lvsErrs = stdErr
 }
 
-func (c *Cache) GetLVs() []internal.LVData {
+func (c *Cache) GetLVs() ([]internal.LVData, bytes.Buffer) {
 	dst := make([]internal.LVData, len(c.lvs))
 	copy(dst, c.lvs)
 
-	return dst
+	return dst, c.lvsErrs
 }
 
 func (c *Cache) PrintTheCache(log logger.Logger) {
@@ -67,21 +76,29 @@ func (c *Cache) PrintTheCache(log logger.Logger) {
 	for _, d := range c.devices {
 		log.Cache(fmt.Sprintf("     Device Name: %s, size: %s, fsType: %s, serial: %s, wwn: %s", d.Name, d.Size.String(), d.FSType, d.Serial, d.Wwn))
 	}
+	log.Cache("[ERRS]")
+	log.Cache(c.deviceErrs.String())
 	log.Cache("[Devices ENDS]")
 	log.Cache("[PVs BEGIN]")
 	for _, pv := range c.pvs {
 		log.Cache(fmt.Sprintf("     PV Name: %s, VG Name: %s, size: %s, vgTags: %s", pv.PVName, pv.VGName, pv.PVSize.String(), pv.VGTags))
 	}
+	log.Cache("[ERRS]")
+	log.Cache(c.pvsErrs.String())
 	log.Cache("[PVs ENDS]")
 	log.Cache("[VGs BEGIN]")
 	for _, vg := range c.vgs {
 		log.Cache(fmt.Sprintf("     VG Name: %s, size: %s, free: %s, vgTags: %s", vg.VGName, vg.VGSize.String(), vg.VGFree.String(), vg.VGTags))
 	}
+	log.Cache("[ERRS]")
+	log.Cache(c.vgsErrs.String())
 	log.Cache("[VGs ENDS]")
 	log.Cache("[LVs BEGIN]")
 	for _, lv := range c.lvs {
 		log.Cache(fmt.Sprintf("     LV Name: %s, VG name: %s, size: %s, tags: %s, attr: %s, pool: %s", lv.LVName, lv.VGName, lv.LVSize.String(), lv.LvTags, lv.LVAttr, lv.PoolLv))
 	}
+	log.Cache("[ERRS]")
+	log.Cache(c.lvsErrs.String())
 	log.Cache("[LVs ENDS]")
 	log.Cache("*****************CACHE ENDS*****************")
 }

--- a/images/agent/pkg/cache/cache.go
+++ b/images/agent/pkg/cache/cache.go
@@ -18,8 +18,8 @@ type Cache struct {
 	lvsErrs    bytes.Buffer
 }
 
-func New() Cache {
-	return Cache{}
+func New() *Cache {
+	return &Cache{}
 }
 
 func (c *Cache) StoreDevices(devices []internal.Device, stdErr bytes.Buffer) {

--- a/images/agent/pkg/cache/cache_test.go
+++ b/images/agent/pkg/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/assert"
 	"sds-node-configurator/internal"
 	"testing"
@@ -56,13 +57,82 @@ func TestCache(t *testing.T) {
 		},
 	}
 
-	sdsCache.StoreDevices(devices)
-	sdsCache.StorePVs(pvs)
-	sdsCache.StoreVGs(vgs)
-	sdsCache.StoreLVs(lvs)
+	sdsCache.StoreDevices(devices, bytes.Buffer{})
+	sdsCache.StorePVs(pvs, bytes.Buffer{})
+	sdsCache.StoreVGs(vgs, bytes.Buffer{})
+	sdsCache.StoreLVs(lvs, bytes.Buffer{})
 
-	assert.ElementsMatch(t, devices, sdsCache.GetDevices())
-	assert.ElementsMatch(t, pvs, sdsCache.GetPVs())
-	assert.ElementsMatch(t, vgs, sdsCache.GetVGs())
-	assert.ElementsMatch(t, lvs, sdsCache.GetLVs())
+	actualDev, _ := sdsCache.GetDevices()
+	actualPVs, _ := sdsCache.GetPVs()
+	actualVGs, _ := sdsCache.GetVGs()
+	actualLVs, _ := sdsCache.GetLVs()
+	assert.ElementsMatch(t, devices, actualDev)
+	assert.ElementsMatch(t, pvs, actualPVs)
+	assert.ElementsMatch(t, vgs, actualVGs)
+	assert.ElementsMatch(t, lvs, actualLVs)
+}
+
+func BenchmarkCache(b *testing.B) {
+	sdsCache := New()
+	devices := []internal.Device{
+		{
+			Name: "test-1",
+		},
+		{
+			Name: "test-2",
+		},
+		{
+			Name: "test-3",
+		},
+	}
+
+	pvs := []internal.PVData{
+		{
+			PVName: "pv-1",
+		},
+		{
+			PVName: "pv-2",
+		},
+		{
+			PVName: "pv-3",
+		},
+	}
+
+	vgs := []internal.VGData{
+		{
+			VGName: "vg-1",
+		},
+		{
+			VGName: "vg-2",
+		},
+		{
+			VGName: "vg-3",
+		},
+	}
+
+	lvs := []internal.LVData{
+		{
+			LVName: "lv-1",
+		},
+		{
+			LVName: "lv-2",
+		},
+		{
+			LVName: "lv-3",
+		},
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sdsCache.StoreDevices(devices, bytes.Buffer{})
+			sdsCache.StorePVs(pvs, bytes.Buffer{})
+			sdsCache.StoreVGs(vgs, bytes.Buffer{})
+			sdsCache.StoreLVs(lvs, bytes.Buffer{})
+
+			sdsCache.GetDevices()
+			sdsCache.GetPVs()
+			sdsCache.GetVGs()
+			sdsCache.GetLVs()
+		}
+	})
 }

--- a/images/agent/pkg/controller/block_device.go
+++ b/images/agent/pkg/controller/block_device.go
@@ -274,7 +274,7 @@ func GetBlockDeviceCandidates(log logger.Logger, cfg config.Options, sdsCache *c
 		}
 
 		log.Trace(fmt.Sprintf("[GetBlockDeviceCandidates] Get following candidate: %+v", candidate))
-		candidateName := CreateCandidateName(log, candidate)
+		candidateName := CreateCandidateName(log, candidate, devices)
 
 		if candidateName == "" {
 			log.Trace("[GetBlockDeviceCandidates] candidateName is empty. Skipping device")
@@ -430,10 +430,10 @@ func CheckTag(tags string) (bool, string) {
 	return true, ""
 }
 
-func CreateCandidateName(log logger.Logger, candidate internal.BlockDeviceCandidate) string {
+func CreateCandidateName(log logger.Logger, candidate internal.BlockDeviceCandidate, devices []internal.Device) string {
 	if len(candidate.Serial) == 0 {
 		log.Trace(fmt.Sprintf("[CreateCandidateName] Serial number is empty for device: %s", candidate.Path))
-		if candidate.Type == internal.TypePart {
+		if candidate.Type == internal.PartType {
 			if len(candidate.PartUUID) == 0 {
 				log.Warning(fmt.Sprintf("[CreateCandidateName] Type = part and cannot get PartUUID; skipping this device, path: %s", candidate.Path))
 				return ""
@@ -442,25 +442,38 @@ func CreateCandidateName(log logger.Logger, candidate internal.BlockDeviceCandid
 		} else {
 			log.Debug(fmt.Sprintf("[CreateCandidateName] Serial number is empty and device type is not part; trying to obtain serial number or its equivalent for device: %s, with type: %s", candidate.Path, candidate.Type))
 
-			isMdRaid := false
-			matched, err := regexp.MatchString(`raid.*`, candidate.Type)
-			if err != nil {
-				log.Error(err, "[CreateCandidateName] failed to match regex - unable to determine if the device is an mdraid. Attempting to retrieve serial number directly from the device")
-			} else if matched {
-				log.Debug(fmt.Sprintf("[CreateCandidateName] device %s is mdraid", candidate.Path))
-				isMdRaid = true
+			switch candidate.Type {
+			case internal.MultiPathType:
+				log.Debug(fmt.Sprintf("[CreateCandidateName] device %s type = %s; get serial number from parent device.", candidate.Path, candidate.Type))
+				log.Trace(fmt.Sprintf("[CreateCandidateName] device: %+v. Device list: %+v", candidate, devices))
+				serial, err := getSerialForMultipathDevice(candidate, devices)
+				if err != nil {
+					log.Warning(fmt.Sprintf("[CreateCandidateName] Unable to obtain serial number or its equivalent; skipping device: %s. Error: %s", candidate.Path, err))
+					return ""
+				}
+				candidate.Serial = serial
+				log.Info(fmt.Sprintf("[CreateCandidateName] Successfully obtained serial number or its equivalent: %s for device: %s", candidate.Serial, candidate.Path))
+			default:
+				isMdRaid := false
+				matched, err := regexp.MatchString(`raid.*`, candidate.Type)
+				if err != nil {
+					log.Error(err, "[CreateCandidateName] failed to match regex - unable to determine if the device is an mdraid. Attempting to retrieve serial number directly from the device")
+				} else if matched {
+					log.Trace("[CreateCandidateName] device is mdraid")
+					isMdRaid = true
+				}
+				serial, err := readSerialBlockDevice(candidate.Path, isMdRaid)
+				if err != nil {
+					log.Warning(fmt.Sprintf("[CreateCandidateName] Unable to obtain serial number or its equivalent; skipping device: %s. Error: %s", candidate.Path, err))
+					return ""
+				}
+				log.Info(fmt.Sprintf("[CreateCandidateName] Successfully obtained serial number or its equivalent: %s for device: %s", serial, candidate.Path))
+				candidate.Serial = serial
 			}
-			serial, err := readSerialBlockDevice(candidate.Path, isMdRaid)
-			if err != nil {
-				log.Warning(fmt.Sprintf("[CreateCandidateName] Unable to obtain serial number or its equivalent; skipping device: %s. Error: %s", candidate.Path, err))
-				return ""
-			}
-			log.Info(fmt.Sprintf("[CreateCandidateName] Successfully obtained serial number or its equivalent: %s for device: %s", serial, candidate.Path))
-			candidate.Serial = serial
-			log.Trace(fmt.Sprintf("[CreateCandidateName] Serial number is now: %s. Creating candidate name", candidate.Serial))
 		}
 	}
 
+	log.Trace(fmt.Sprintf("[CreateCandidateName] Serial number is now: %s. Creating candidate name", candidate.Serial))
 	return CreateUniqDeviceName(candidate)
 }
 
@@ -624,6 +637,7 @@ func ReTag(log logger.Logger, metrics monitoring.Metrics) error {
 				cmdStr, err = utils.LVChangeDelTag(lv, tag)
 				metrics.UtilsCommandsDuration(blockDeviceCtrlName, "lvchange").Observe(metrics.GetEstimatedTimeInSeconds(start))
 				metrics.UtilsCommandsExecutionCount(blockDeviceCtrlName, "lvchange").Inc()
+				log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", cmdStr))
 				if err != nil {
 					metrics.UtilsCommandsErrorsCount(blockDeviceCtrlName, "lvchange").Inc()
 					log.Error(err, "[ReTag] unable to LVChangeDelTag")
@@ -692,4 +706,33 @@ func ReTag(log logger.Logger, metrics monitoring.Metrics) error {
 	log.Debug("[ReTag] stop re-tagging LVM")
 
 	return nil
+}
+
+func getSerialForMultipathDevice(candidate internal.BlockDeviceCandidate, devices []internal.Device) (string, error) {
+	parentDevice := getParentDevice(candidate.PkName, devices)
+	if parentDevice.Name == "" {
+		err := fmt.Errorf("parent device %s not found for multipath device: %s in device list", candidate.PkName, candidate.Path)
+		return "", err
+	}
+
+	if parentDevice.FSType != internal.MultiPathMemberFSType {
+		err := fmt.Errorf("parent device %s for multipath device %s is not a multipath member (fstype != %s)", parentDevice.Name, candidate.Path, internal.MultiPathMemberFSType)
+		return "", err
+	}
+
+	if parentDevice.Serial == "" {
+		err := fmt.Errorf("serial number is empty for parent device %s", parentDevice.Name)
+		return "", err
+	}
+
+	return parentDevice.Serial, nil
+}
+
+func getParentDevice(pkName string, devices []internal.Device) internal.Device {
+	for _, device := range devices {
+		if device.Name == pkName {
+			return device
+		}
+	}
+	return internal.Device{}
 }

--- a/images/agent/pkg/controller/lvm_volume_group_discover.go
+++ b/images/agent/pkg/controller/lvm_volume_group_discover.go
@@ -51,6 +51,7 @@ func RunLVMVolumeGroupDiscoverController(
 	cfg config.Options,
 	log logger.Logger,
 	metrics monitoring.Metrics,
+	sdsCache *cache.Cache,
 ) (controller.Controller, error) {
 	cl := mgr.GetClient()
 	cache := mgr.GetCache()
@@ -108,7 +109,7 @@ func RunLVMVolumeGroupDiscoverController(
 
 			filteredResources := filterResourcesByNode(ctx, cl, log, currentLVMVGs, blockDevices, cfg.NodeName)
 
-			candidates, err := GetLVMVolumeGroupCandidates(log, metrics, blockDevices, cfg.NodeName)
+			candidates, err := GetLVMVolumeGroupCandidates(log, sdsCache, blockDevices, cfg.NodeName)
 			if err != nil {
 				log.Error(err, "[RunLVMVolumeGroupDiscoverController] unable to run GetLVMVolumeGroupCandidates")
 				for _, lvg := range filteredResources {
@@ -126,7 +127,6 @@ func RunLVMVolumeGroupDiscoverController(
 						log.Debug(fmt.Sprintf(`[RunLVMVolumeGroupDiscoverController] no data to update for LvmVolumeGroup, name: "%s"`, lvmVolumeGroup.Name))
 						continue
 					}
-					//TODO: take lock
 
 					log.Debug(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] run UpdateLVMVolumeGroupByCandidate, lvmVolumeGroup name: %s", lvmVolumeGroup.Name))
 					if err = UpdateLVMVolumeGroupByCandidate(ctx, cl, metrics, *lvmVolumeGroup, candidate); err != nil {
@@ -136,7 +136,6 @@ func RunLVMVolumeGroupDiscoverController(
 					}
 
 					log.Info(fmt.Sprintf(`[RunLVMVolumeGroupDiscoverController] updated LvmVolumeGroup, name: "%s"`, lvmVolumeGroup.Name))
-					//TODO: release lock
 				} else {
 					lvm, err := CreateLVMVolumeGroup(ctx, log, metrics, cl, candidate)
 					if err != nil {
@@ -239,8 +238,6 @@ func hasLVMVolumeGroupDiff(log logger.Logger, res v1alpha1.LvmVolumeGroup, candi
 	log.Trace(fmt.Sprintf(`VGUuid, candidate: %s, res: %s`, candidate.VGUuid, res.Status.VGUuid))
 	log.Trace(fmt.Sprintf(`Nodes, candidate: %v, res: %v`, convertLVMVGNodes(candidate.Nodes), res.Status.Nodes))
 
-	//TODO: Uncomment this
-	//return strings.Join(candidate.Finalizers, "") == strings.Join(res.Finalizers, "") ||
 	return candidate.AllocatedSize.Value() != res.Status.AllocatedSize.Value() ||
 		candidate.Health != res.Status.Health ||
 		candidate.Message != res.Status.Message ||
@@ -325,10 +322,10 @@ func DeleteLVMVolumeGroup(ctx context.Context, kc kclient.Client, metrics monito
 	return nil
 }
 
-func GetLVMVolumeGroupCandidates(log logger.Logger, sdsCache *cache.Cache, metrics monitoring.Metrics, bds map[string]v1alpha1.BlockDevice, currentNode string) ([]internal.LVMVolumeGroupCandidate, error) {
+func GetLVMVolumeGroupCandidates(log logger.Logger, sdsCache *cache.Cache, bds map[string]v1alpha1.BlockDevice, currentNode string) ([]internal.LVMVolumeGroupCandidate, error) {
 	var candidates []internal.LVMVolumeGroupCandidate
 
-	vgs := sdsCache.GetVGs()
+	vgs, vgErrs := sdsCache.GetVGs()
 	vgWithTag := filterVGByTag(vgs, internal.LVMTags)
 
 	// If there is no VG with our tag, then there is no any candidate.
@@ -339,10 +336,11 @@ func GetLVMVolumeGroupCandidates(log logger.Logger, sdsCache *cache.Cache, metri
 	// If vgErrs is not empty, that means we have some problems on vgs, so we need to identify unhealthy vgs.
 	var vgIssues map[string]string
 	if vgErrs.Len() != 0 {
+		log.Warning("[GetLVMVolumeGroupCandidates] some errors have been occurred while executing vgs command")
 		vgIssues = sortVGIssuesByVG(log, vgWithTag)
 	}
 
-	pvs := sdsCache.GetPVs()
+	pvs, pvErrs := sdsCache.GetPVs()
 	if len(pvs) == 0 {
 		err := errors.New("no PV found")
 		log.Error(err, "[GetLVMVolumeGroupCandidates] no PV was found, but VG with tags are not empty")
@@ -352,20 +350,11 @@ func GetLVMVolumeGroupCandidates(log logger.Logger, sdsCache *cache.Cache, metri
 	// If pvErrs is not empty, that means we have some problems on vgs, so we need to identify unhealthy vgs.
 	var pvIssues map[string][]string
 	if pvErrs.Len() != 0 {
+		log.Warning("[GetLVMVolumeGroupCandidates] some errors have been occurred while executing pvs command")
 		pvIssues = sortPVIssuesByVG(log, pvs)
 	}
 
-	lvs, cmdStr, lvErrs, err := utils.GetAllLVs()
-	metrics.UtilsCommandsDuration(LVMVolumeGroupDiscoverCtrlName, "lvs").Observe(metrics.GetEstimatedTimeInSeconds(start))
-	metrics.UtilsCommandsExecutionCount(LVMVolumeGroupDiscoverCtrlName, "lvs").Inc()
-	log.Debug(fmt.Sprintf("[GetLVMVolumeGroupCandidates] exec cmd: %s", cmdStr))
-
-	// As long as LVS data is used to fill ThinPool fields, that is optional, we won't break but log the error.
-	if err != nil {
-		metrics.UtilsCommandsErrorsCount(LVMVolumeGroupDiscoverCtrlName, "lvs").Inc()
-		log.Error(err, "[GetLVMVolumeGroupCandidates] unable to GetAllLVs")
-	}
-
+	lvs, lvErrs := sdsCache.GetLVs()
 	var thinPools []internal.LVData
 	if lvs != nil && len(lvs) > 0 {
 		// Filter LV to get only thin pools as we do not support thick for now.
@@ -375,6 +364,7 @@ func GetLVMVolumeGroupCandidates(log logger.Logger, sdsCache *cache.Cache, metri
 	// If lvErrs is not empty, that means we have some problems on vgs, so we need to identify unhealthy vgs.
 	var lvIssues map[string][]string
 	if lvErrs.Len() != 0 {
+		log.Warning("[GetLVMVolumeGroupCandidates] some errors have been occurred while executing lvs command")
 		lvIssues = sortLVIssuesByVG(log, thinPools)
 	}
 
@@ -384,14 +374,10 @@ func GetLVMVolumeGroupCandidates(log logger.Logger, sdsCache *cache.Cache, metri
 	sortedThinPools := sortLVsByVG(thinPools, vgWithTag)
 
 	for _, vg := range vgWithTag {
-		if err != nil {
-			log.Error(err, "[GetLVMVolumeGroupCandidates] unable to count ParseInt vgSize, err: %w", err)
-		}
-
 		allocateSize := vg.VGSize
 		allocateSize.Sub(vg.VGFree)
 
-		health, message := checkVGHealth(err, sortedBDs, vgIssues, pvIssues, lvIssues, vg)
+		health, message := checkVGHealth(sortedBDs, vgIssues, pvIssues, lvIssues, vg)
 
 		candidate := internal.LVMVolumeGroupCandidate{
 			LVMVGName:             generateLVMVGName(),
@@ -415,12 +401,8 @@ func GetLVMVolumeGroupCandidates(log logger.Logger, sdsCache *cache.Cache, metri
 	return candidates, nil
 }
 
-func checkVGHealth(err error, blockDevices map[string][]v1alpha1.BlockDevice, vgIssues map[string]string, pvIssues map[string][]string, lvIssues map[string][]string, vg internal.VGData) (health, message string) {
+func checkVGHealth(blockDevices map[string][]v1alpha1.BlockDevice, vgIssues map[string]string, pvIssues map[string][]string, lvIssues map[string][]string, vg internal.VGData) (health, message string) {
 	issues := make([]string, 0, len(vgIssues)+len(pvIssues)+len(lvIssues)+1)
-
-	if err != nil {
-		issues = append(issues, err.Error())
-	}
 
 	if bds, exist := blockDevices[vg.VGName+vg.VGUuid]; !exist || len(bds) == 0 {
 		issues = append(issues, fmt.Sprintf("[ERROR] Unable to get block devices for VG, name: %s ; uuid: %s", vg.VGName, vg.VGUuid))

--- a/images/agent/pkg/controller/scanner.go
+++ b/images/agent/pkg/controller/scanner.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/pilebones/go-udev/netlink"
-	"sds-node-configurator/config"
 	"sds-node-configurator/internal"
 	"sds-node-configurator/pkg/cache"
 	"sds-node-configurator/pkg/logger"
@@ -13,10 +12,10 @@ import (
 	"time"
 )
 
-func RunScanner(log logger.Logger, cfg config.Options, sdsCache *cache.Cache) error {
+func RunScanner(log logger.Logger, sdsCache cache.Cache) error {
 	log.Info("[RunScanner] starts the work")
 
-	t := throttler.New(cfg.ThrottleInterval * time.Second)
+	t := throttler.New(2 * time.Second)
 
 	conn := new(netlink.UEventConn)
 	if err := conn.Connect(netlink.UdevEvent); err != nil {
@@ -85,7 +84,7 @@ func RunScanner(log logger.Logger, cfg config.Options, sdsCache *cache.Cache) er
 	}
 }
 
-func fillTheCache(log logger.Logger, cache *cache.Cache) error {
+func fillTheCache(log logger.Logger, cache cache.Cache) error {
 	devices, err := scanDevices(log)
 	if err != nil {
 		return err

--- a/images/agent/pkg/controller/scanner.go
+++ b/images/agent/pkg/controller/scanner.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/pilebones/go-udev/netlink"
+	"sds-node-configurator/config"
 	"sds-node-configurator/internal"
 	"sds-node-configurator/pkg/cache"
 	"sds-node-configurator/pkg/logger"
@@ -12,10 +13,10 @@ import (
 	"time"
 )
 
-func RunScanner(log logger.Logger, sdsCache cache.Cache) error {
+func RunScanner(log logger.Logger, cfg config.Options, sdsCache cache.Cache) error {
 	log.Info("[RunScanner] starts the work")
 
-	t := throttler.New(2 * time.Second)
+	t := throttler.New(cfg.ThrottleInterval * time.Second)
 
 	conn := new(netlink.UEventConn)
 	if err := conn.Connect(netlink.UdevEvent); err != nil {

--- a/images/agent/pkg/utils/commands.go
+++ b/images/agent/pkg/utils/commands.go
@@ -29,7 +29,7 @@ import (
 	golog "log"
 )
 
-func GetBlockDevices() ([]internal.Device, string, error) {
+func GetBlockDevices() ([]internal.Device, string, bytes.Buffer, error) {
 	var outs bytes.Buffer
 	args := []string{"-J", "-lpfb", "-no", "name,MOUNTPOINT,PARTUUID,HOTPLUG,MODEL,SERIAL,SIZE,FSTYPE,TYPE,WWN,KNAME,PKNAME,ROTA"}
 	cmd := exec.Command(internal.LSBLKCmd, args...)
@@ -40,15 +40,15 @@ func GetBlockDevices() ([]internal.Device, string, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		return nil, cmd.String(), fmt.Errorf("unable to run cmd: %s, err: %w, stderr: %s", cmd.String(), err, stderr.String())
+		return nil, cmd.String(), stderr, fmt.Errorf("unable to run cmd: %s, err: %w, stderr: %s", cmd.String(), err, stderr.String())
 	}
 
 	devices, err := UnmarshalDevices(outs.Bytes())
 	if err != nil {
-		return nil, cmd.String(), fmt.Errorf("unable to unmarshal devices, err: %w", err)
+		return nil, cmd.String(), stderr, fmt.Errorf("unable to unmarshal devices, err: %w", err)
 	}
 
-	return devices, cmd.String(), nil
+	return devices, cmd.String(), stderr, nil
 }
 
 func GetAllVGs() (data []internal.VGData, command string, stdErr bytes.Buffer, err error) {


### PR DESCRIPTION
## Description
LVMVolumeGroupDiscover controller uses cache to get all needed information to create LVMVolumeGroup resources successfully.


## Why do we need it, and what problem does it solve?
As the cache was invented to prevent regular and useless utils command executions, the controller should use it.

## What is the expected result?
New LVMVolumeGroup resources are creating successfully, old one are not deleted or updated for no reason.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
