### PR TITLE
[controller] Change BlockDevices logic to work with the controller's cache

### DIFF
--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -113,7 +113,7 @@ func main() {
 	sdsCache := cache.New()
 
 	go func() {
-		if err = controller.RunScanner(*log, *cfgParams, sdsCache); err != nil {
+		if err = controller.RunScanner(*log, sdsCache); err != nil {
 			log.Error(err, "[main] unable to run scanner")
 			os.Exit(1)
 		}

--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -113,7 +113,7 @@ func main() {
 	sdsCache := cache.New()
 
 	go func() {
-		if err = controller.RunScanner(*log, sdsCache); err != nil {
+		if err = controller.RunScanner(*log, *cfgParams, sdsCache); err != nil {
 			log.Error(err, "[main] unable to run scanner")
 			os.Exit(1)
 		}

--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -119,7 +119,7 @@ func main() {
 		}
 	}()
 
-	if _, err = controller.RunBlockDeviceController(ctx, mgr, *cfgParams, *log, metrics); err != nil {
+	if _, err = controller.RunBlockDeviceController(ctx, mgr, *cfgParams, *log, metrics, sdsCache); err != nil {
 		log.Error(err, "[main] unable to controller.RunBlockDeviceController")
 		os.Exit(1)
 	}

--- a/images/agent/pkg/cache/cache.go
+++ b/images/agent/pkg/cache/cache.go
@@ -13,8 +13,8 @@ type Cache struct {
 	lvs     []internal.LVData
 }
 
-func New() Cache {
-	return Cache{}
+func New() *Cache {
+	return &Cache{}
 }
 
 func (c *Cache) StoreDevices(devices []internal.Device) {

--- a/images/agent/pkg/controller/scanner.go
+++ b/images/agent/pkg/controller/scanner.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/pilebones/go-udev/netlink"
-	"sds-node-configurator/config"
 	"sds-node-configurator/internal"
 	"sds-node-configurator/pkg/cache"
 	"sds-node-configurator/pkg/logger"
@@ -13,10 +12,10 @@ import (
 	"time"
 )
 
-func RunScanner(log logger.Logger, cfg config.Options, sdsCache cache.Cache) error {
+func RunScanner(log logger.Logger, sdsCache cache.Cache) error {
 	log.Info("[RunScanner] starts the work")
 
-	t := throttler.New(cfg.ThrottleInterval * time.Second)
+	t := throttler.New(2 * time.Second)
 
 	conn := new(netlink.UEventConn)
 	if err := conn.Connect(netlink.UdevEvent); err != nil {

--- a/images/agent/pkg/controller/scanner.go
+++ b/images/agent/pkg/controller/scanner.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/pilebones/go-udev/netlink"
+	"sds-node-configurator/config"
 	"sds-node-configurator/internal"
 	"sds-node-configurator/pkg/cache"
 	"sds-node-configurator/pkg/logger"
@@ -12,10 +13,10 @@ import (
 	"time"
 )
 
-func RunScanner(log logger.Logger, sdsCache cache.Cache) error {
+func RunScanner(log logger.Logger, cfg config.Options, sdsCache cache.Cache) error {
 	log.Info("[RunScanner] starts the work")
 
-	t := throttler.New(2 * time.Second)
+	t := throttler.New(cfg.ThrottleInterval * time.Second)
 
 	conn := new(netlink.UEventConn)
 	if err := conn.Connect(netlink.UdevEvent); err != nil {

--- a/images/agent/pkg/controller/scanner.go
+++ b/images/agent/pkg/controller/scanner.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func RunScanner(log logger.Logger, cfg config.Options, sdsCache cache.Cache) error {
+func RunScanner(log logger.Logger, cfg config.Options, sdsCache *cache.Cache) error {
 	log.Info("[RunScanner] starts the work")
 
 	t := throttler.New(cfg.ThrottleInterval * time.Second)
@@ -85,7 +85,7 @@ func RunScanner(log logger.Logger, cfg config.Options, sdsCache cache.Cache) err
 	}
 }
 
-func fillTheCache(log logger.Logger, cache cache.Cache) error {
+func fillTheCache(log logger.Logger, cache *cache.Cache) error {
 	devices, err := scanDevices(log)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
BlockDevice controller uses cache to get all needed information to create BlockDevice resources successfully.

## Why do we need it, and what problem does it solve?
As the cache was invented to prevent regular and useless utils command executions, the controller should use it.

## What is the expected result?
New BlockDevice resources are creating successfully, old ones are not deleted or updated for no reason.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
