### PR TITLE
[monitoring] Change metric ports

### DIFF
--- a/images/agent/README.md
+++ b/images/agent/README.md
@@ -22,7 +22,7 @@
 
 `NODE_NAME`
 
-`METRICS_PORT` - default : 8080
+`METRICS_PORT` - default : 9695
 
 
 #### Metrics

--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	"sds-node-configurator/pkg/kubutils"
 	"sds-node-configurator/pkg/logger"
 	"sds-node-configurator/pkg/monitoring"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	v1 "k8s.io/api/core/v1"
 	sv1 "k8s.io/api/storage/v1"
@@ -89,9 +90,9 @@ func main() {
 	log.Info("[main] successfully read scheme CR")
 
 	managerOpts := manager.Options{
-		Scheme: scheme,
-		//MetricsBindAddress: cfgParams.MetricsPort,
-		Logger: log.GetLogger(),
+		Scheme:  scheme,
+		Logger:  log.GetLogger(),
+		Metrics: server.Options{BindAddress: cfgParams.MetricsPort},
 	}
 
 	mgr, err := manager.New(kConfig, managerOpts)

--- a/images/agent/config/config.go
+++ b/images/agent/config/config.go
@@ -72,7 +72,7 @@ func NewConfig() (*Options, error) {
 
 	opts.MetricsPort = os.Getenv(MetricsPort)
 	if opts.MetricsPort == "" {
-		opts.MetricsPort = ":8080"
+		opts.MetricsPort = ":9695"
 	}
 
 	scanInt := os.Getenv(ScanInterval)

--- a/images/agent/config/config_test.go
+++ b/images/agent/config/config_test.go
@@ -107,7 +107,7 @@ func TestNewConfig(t *testing.T) {
 
 	t.Run("MetricsPortNotSet_ReturnsDefaultPort", func(t *testing.T) {
 		expNodeName := "test-node"
-		expMetricsPort := ":8080"
+		expMetricsPort := ":9695"
 		expMachineId := "test-id"
 
 		err := os.Setenv(NodeName, expNodeName)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change metric ports

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Now metric ports conflicts with Deckhouse pod

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

No port conflict in cluster

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
