### PR TITLE
[controller] Add conditions crd to LVMVolumeGroup

### DIFF
--- a/crds/lvmvolumegroup.yaml
+++ b/crds/lvmvolumegroup.yaml
@@ -105,7 +105,7 @@ spec:
                           - Ready
                           - ""
                       status:
-                        type: boolean
+                        type: string
                       reason:
                         type: string
                       message:
@@ -206,7 +206,8 @@ spec:
                               type: string
                               description: |
                                 The name of the corresponding block device resource.
-
+      subresources:
+        status: {}
       additionalPrinterColumns:
         - jsonPath: .status.health
           name: health

--- a/crds/lvmvolumegroup.yaml
+++ b/crds/lvmvolumegroup.yaml
@@ -82,6 +82,38 @@ spec:
             status:
               type: object
               properties:
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Ready
+                    - NotReady
+                    - Terminating
+                    - ""
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - VGConfigurationApplied
+                          - VGReady
+                          - NodeReady
+                          - AgentReady
+                          - Ready
+                          - ""
+                      status:
+                        type: boolean
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      observedGeneration:
+                        type: integer
                 health:
                   type: string
                   description: |
@@ -132,6 +164,10 @@ spec:
                         type: string
                         description: |
                           The Thin-pool used size.
+                      ready:
+                        type: boolean
+                      message:
+                        type: string
                 nodes:
                   type: array
                   description: |

--- a/images/agent/api/v1alpha1/lvm_volume_group.go
+++ b/images/agent/api/v1alpha1/lvm_volume_group.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 type LvmVolumeGroupList struct {
@@ -65,6 +66,8 @@ type StatusThinPool struct {
 	Name       string            `json:"name"`
 	ActualSize resource.Quantity `json:"actualSize"`
 	UsedSize   resource.Quantity `json:"usedSize"`
+	Ready      bool              `json:"ready"`
+	Message    string            `json:"message"`
 }
 
 type LvmVolumeGroupStatus struct {
@@ -75,4 +78,14 @@ type LvmVolumeGroupStatus struct {
 	ThinPools     []StatusThinPool     `json:"thinPools"`
 	VGSize        resource.Quantity    `json:"vgSize"`
 	VGUuid        string               `json:"vgUUID"`
+	Phase         string               `json:"phase"`
+}
+
+type Condition struct {
+	Type               string    `json:"type"`
+	Status             bool      `json:"status"`
+	Reason             string    `json:"reason"`
+	Message            string    `json:"message"`
+	lastTransitionTime time.Time `json:"lastTransitionTime"`
+	observedGeneration int       `json:"observedGeneration"`
 }

--- a/images/agent/api/v1alpha1/lvm_volume_group.go
+++ b/images/agent/api/v1alpha1/lvm_volume_group.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 type LvmVolumeGroupList struct {
@@ -79,13 +78,5 @@ type LvmVolumeGroupStatus struct {
 	VGSize        resource.Quantity    `json:"vgSize"`
 	VGUuid        string               `json:"vgUUID"`
 	Phase         string               `json:"phase"`
-}
-
-type Condition struct {
-	Type               string    `json:"type"`
-	Status             bool      `json:"status"`
-	Reason             string    `json:"reason"`
-	Message            string    `json:"message"`
-	lastTransitionTime time.Time `json:"lastTransitionTime"`
-	observedGeneration int       `json:"observedGeneration"`
+	Conditions    []metav1.Condition   `json:"conditions"`
 }

--- a/images/agent/internal/type.go
+++ b/images/agent/internal/type.go
@@ -61,6 +61,8 @@ type LVMVGStatusThinPool struct {
 	Name       string
 	ActualSize resource.Quantity
 	UsedSize   resource.Quantity
+	Ready      bool
+	Message    string
 }
 
 type LVMVGDevice struct {

--- a/images/agent/pkg/controller/lvm_volume_group_discover_test.go
+++ b/images/agent/pkg/controller/lvm_volume_group_discover_test.go
@@ -843,7 +843,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			},
 		}
 
-		actual := filterResourcesByNode(ctx, cl, testLogger, lvs, blockDevices, currentNode)
+		actual := filterLVGsByNode(ctx, cl, testLogger, lvs, blockDevices, currentNode)
 
 		assert.Equal(t, expected, actual)
 	})
@@ -896,7 +896,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			}
 		)
 
-		actual := filterResourcesByNode(ctx, cl, testLogger, lvs, blockDevices, currentNode)
+		actual := filterLVGsByNode(ctx, cl, testLogger, lvs, blockDevices, currentNode)
 
 		assert.Equal(t, 0, len(actual))
 	})

--- a/images/agent/pkg/controller/lvm_volume_group_watcher_func.go
+++ b/images/agent/pkg/controller/lvm_volume_group_watcher_func.go
@@ -58,7 +58,7 @@ func updateLVMVolumeGroupHealthStatus(ctx context.Context, cl client.Client, met
 	lvg.Status.Message = message
 
 	start := time.Now()
-	err := cl.Update(ctx, lvg)
+	err := cl.Status().Update(ctx, lvg)
 	metrics.ApiMethodsDuration(LVMVolumeGroupWatcherCtrlName, "update").Observe(metrics.GetEstimatedTimeInSeconds(start))
 	metrics.ApiMethodsExecutionCount(LVMVolumeGroupWatcherCtrlName, "update").Inc()
 	if err != nil {

--- a/images/agent/pkg/utils/units.go
+++ b/images/agent/pkg/utils/units.go
@@ -22,19 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func BytesToQuantity(size int64) string {
-	tmp := resource.NewQuantity(size, resource.BinarySI)
-	return tmp.String()
-}
-
-func QuantityToBytes(quantity string) (int64, error) {
-	b, err := resource.ParseQuantity(quantity)
-	if err != nil {
-		return 0, err
-	}
-	return b.Value(), nil
-}
-
 func AreSizesEqualWithinDelta(leftSize, rightSize, allowedDelta resource.Quantity) bool {
 	leftSizeFloat := float64(leftSize.Value())
 	rightSizeFloat := float64(rightSize.Value())

--- a/templates/agent/rbac.yaml
+++ b/templates/agent/rbac.yaml
@@ -29,6 +29,7 @@ rules:
     resources:
       - blockdevices
       - lvmvolumegroups
+      - lvmvolumegroups/status
       - lvmlogicalvolumes
     verbs:
       - get


### PR DESCRIPTION
## Description
CRD and api-models refactoring to include the Kubernetes conditions. 
Controllers adds its own finalizer to LVMVolumeGroup resources.

## Why do we need it, and what problem does it solve?
We need the conditions for UI integration.

## What is the expected result?
Existing LVMVolumeGroup CRD is updated, everything works fine.
Finalizers are added automatically to the existing and new resources. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
