### PR TITLE
[controller] Add condition reconcile to LVMVolumeGroups 

### DIFF
--- a/crds/lvmvolumegroup.yaml
+++ b/crds/lvmvolumegroup.yaml
@@ -105,7 +105,7 @@ spec:
                           - Ready
                           - ""
                       status:
-                        type: boolean
+                        type: string
                       reason:
                         type: string
                       message:
@@ -206,7 +206,8 @@ spec:
                               type: string
                               description: |
                                 The name of the corresponding block device resource.
-
+      subresources:
+        status: {}
       additionalPrinterColumns:
         - jsonPath: .status.health
           name: health

--- a/crds/lvmvolumegroup.yaml
+++ b/crds/lvmvolumegroup.yaml
@@ -82,6 +82,38 @@ spec:
             status:
               type: object
               properties:
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Ready
+                    - NotReady
+                    - Terminating
+                    - ""
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - VGConfigurationApplied
+                          - VGReady
+                          - NodeReady
+                          - AgentReady
+                          - Ready
+                          - ""
+                      status:
+                        type: boolean
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      observedGeneration:
+                        type: integer
                 health:
                   type: string
                   description: |
@@ -132,6 +164,10 @@ spec:
                         type: string
                         description: |
                           The Thin-pool used size.
+                      ready:
+                        type: boolean
+                      message:
+                        type: string
                 nodes:
                   type: array
                   description: |

--- a/images/agent/api/v1alpha1/lvm_volume_group.go
+++ b/images/agent/api/v1alpha1/lvm_volume_group.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 type LvmVolumeGroupList struct {
@@ -65,6 +66,8 @@ type StatusThinPool struct {
 	Name       string            `json:"name"`
 	ActualSize resource.Quantity `json:"actualSize"`
 	UsedSize   resource.Quantity `json:"usedSize"`
+	Ready      bool              `json:"ready"`
+	Message    string            `json:"message"`
 }
 
 type LvmVolumeGroupStatus struct {
@@ -75,4 +78,14 @@ type LvmVolumeGroupStatus struct {
 	ThinPools     []StatusThinPool     `json:"thinPools"`
 	VGSize        resource.Quantity    `json:"vgSize"`
 	VGUuid        string               `json:"vgUUID"`
+	Phase         string               `json:"phase"`
+}
+
+type Condition struct {
+	Type               string    `json:"type"`
+	Status             bool      `json:"status"`
+	Reason             string    `json:"reason"`
+	Message            string    `json:"message"`
+	lastTransitionTime time.Time `json:"lastTransitionTime"`
+	observedGeneration int       `json:"observedGeneration"`
 }

--- a/images/agent/api/v1alpha1/lvm_volume_group.go
+++ b/images/agent/api/v1alpha1/lvm_volume_group.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 type LvmVolumeGroupList struct {
@@ -79,13 +78,5 @@ type LvmVolumeGroupStatus struct {
 	VGSize        resource.Quantity    `json:"vgSize"`
 	VGUuid        string               `json:"vgUUID"`
 	Phase         string               `json:"phase"`
-}
-
-type Condition struct {
-	Type               string    `json:"type"`
-	Status             bool      `json:"status"`
-	Reason             string    `json:"reason"`
-	Message            string    `json:"message"`
-	lastTransitionTime time.Time `json:"lastTransitionTime"`
-	observedGeneration int       `json:"observedGeneration"`
+	Conditions    []metav1.Condition   `json:"conditions"`
 }

--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -72,9 +72,9 @@ func main() {
 	log.Info(fmt.Sprintf("[main] %s = %s", config.LogLevel, cfgParams.Loglevel))
 	log.Info(fmt.Sprintf("[main] %s = %s", config.NodeName, cfgParams.NodeName))
 	log.Info(fmt.Sprintf("[main] %s = %s", config.MachineID, cfgParams.MachineId))
-	log.Info(fmt.Sprintf("[main] %s = %d", config.ScanInterval, cfgParams.BlockDeviceScanIntervalSec))
-	log.Info(fmt.Sprintf("[main] %s = %d", config.ThrottleInterval, cfgParams.ThrottleIntervalSec))
-	log.Info(fmt.Sprintf("[main] %s = %d", config.CmdDeadlineDuration, cfgParams.CmdDeadlineDurationSec))
+	log.Info(fmt.Sprintf("[main] %s = %s", config.ScanInterval, cfgParams.BlockDeviceScanIntervalSec.String()))
+	log.Info(fmt.Sprintf("[main] %s = %s", config.ThrottleInterval, cfgParams.ThrottleIntervalSec.String()))
+	log.Info(fmt.Sprintf("[main] %s = %s", config.CmdDeadlineDuration, cfgParams.CmdDeadlineDurationSec.String()))
 
 	kConfig, err := kubutils.KubernetesDefaultConfigCreate()
 	if err != nil {

--- a/images/agent/internal/const.go
+++ b/images/agent/internal/const.go
@@ -35,6 +35,9 @@ const (
 	NSENTERCmd                   = "/opt/deckhouse/sds/bin/nsenter.static"
 	LSBLKCmd                     = "/opt/deckhouse/sds/bin/lsblk.dynamic"
 	LVMCmd                       = "/opt/deckhouse/sds/bin/lvm.static"
+
+	VGConfigurationAppliedType = "VGConfigurationApplied"
+	VGReadyType                = "VGReady"
 )
 
 var (

--- a/images/agent/internal/type.go
+++ b/images/agent/internal/type.go
@@ -61,6 +61,8 @@ type LVMVGStatusThinPool struct {
 	Name       string
 	ActualSize resource.Quantity
 	UsedSize   resource.Quantity
+	Ready      bool
+	Message    string
 }
 
 type LVMVGDevice struct {

--- a/images/agent/pkg/controller/block_device.go
+++ b/images/agent/pkg/controller/block_device.go
@@ -56,6 +56,7 @@ func RunBlockDeviceController(
 	c, err := controller.New(BlockDeviceCtrlName, mgr, controller.Options{
 		Reconciler: reconcile.Func(func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 			log.Info("[RunLVMVolumeGroupDiscoverController] Reconciler starts BlockDevice resources reconciliation")
+
 			shouldRequeue := BlockDeviceReconcile(ctx, cl, log, metrics, cfg, sdsCache)
 			if shouldRequeue {
 				log.Warning(fmt.Sprintf("[RunBlockDeviceController] an error occured while run the Reconciler func, retry in %f", cfg.BlockDeviceScanIntervalSec.Seconds()))

--- a/images/agent/pkg/controller/lvm_logical_volume_bench_test.go
+++ b/images/agent/pkg/controller/lvm_logical_volume_bench_test.go
@@ -27,8 +27,8 @@ var (
 
 	resizeOn = false
 
-	ctx = context.Background()
-	cl  client.Client
+	ctx   = context.Background()
+	e2eCL client.Client
 
 	resourcesSchemeFuncs = []func(*apiruntime.Scheme) error{
 		v1alpha1.AddToScheme,
@@ -46,7 +46,7 @@ func BenchmarkRunThickLLVCreationSingleThread(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < lvCount; i++ {
 		llv := configureTestThickLLV(fmt.Sprintf("test-llv-%d", i), lvgName)
-		err := cl.Create(ctx, llv)
+		err := e2eCL.Create(ctx, llv)
 		if err != nil {
 			b.Logf("unable to create test LLV %s, err: %s", llv.Name, err.Error())
 		}
@@ -56,7 +56,7 @@ func BenchmarkRunThickLLVCreationSingleThread(b *testing.B) {
 
 	succeeded := 0
 	for succeeded < len(llvNames) {
-		llvs, err := getAllLLV(ctx, cl)
+		llvs, err := getAllLLV(ctx, e2eCL)
 		if err != nil {
 			b.Error(err)
 			continue
@@ -86,7 +86,7 @@ func BenchmarkRunThickLLVCreationSingleThread(b *testing.B) {
 						}
 
 						llv.Spec.Size.Add(add)
-						err = cl.Update(ctx, &llv)
+						err = e2eCL.Update(ctx, &llv)
 						if err != nil {
 							b.Logf(err.Error())
 							continue
@@ -110,7 +110,7 @@ func BenchmarkRunThinLLVCreationSingleThread(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < lvCount; i++ {
 		llv := configureTestThinLLV(fmt.Sprintf("test-llv-%d", i), lvgName, poolName)
-		err := cl.Create(ctx, llv)
+		err := e2eCL.Create(ctx, llv)
 		if err != nil {
 			b.Logf("unable to create test LLV %s, err: %s", llv.Name, err.Error())
 			continue
@@ -121,7 +121,7 @@ func BenchmarkRunThinLLVCreationSingleThread(b *testing.B) {
 
 	succeeded := 0
 	for succeeded < len(llvNames) {
-		llvs, err := getAllLLV(ctx, cl)
+		llvs, err := getAllLLV(ctx, e2eCL)
 		if err != nil {
 			b.Error(err)
 			continue
@@ -151,7 +151,7 @@ func BenchmarkRunThinLLVCreationSingleThread(b *testing.B) {
 						}
 
 						llv.Spec.Size.Add(add)
-						err = cl.Update(ctx, &llv)
+						err = e2eCL.Update(ctx, &llv)
 						if err != nil {
 							b.Logf(err.Error())
 							continue
@@ -242,7 +242,7 @@ func init() {
 		Scheme: scheme,
 	}
 
-	cl, err = client.New(config, options)
+	e2eCL, err = client.New(config, options)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/images/agent/pkg/controller/lvm_logical_volume_watcher.go
+++ b/images/agent/pkg/controller/lvm_logical_volume_watcher.go
@@ -138,10 +138,10 @@ func RunLVMLogicalVolumeWatcherController(
 		// 	}
 		// 	log.Trace("[RunLVMLogicalVolumeWatcherController] DeleteFunc got LVMLogicalVolume: ", llv.Name, llv)
 
-		// 	lvg, err := getLVMVolumeGroup(ctx, cl, metrics, "", llv.Spec.LvmVolumeGroupName)
+		// 	lvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, "", llv.Spec.LvmVolumeGroupName)
 		// 	if err != nil {
 		// 		log.Error(err, fmt.Sprintf("[DeleteFunc] unable to get the LVMVolumeGroup, name: %q. Skip deletion of the LVMLogicalVolume %q", llv.Spec.LvmVolumeGroupName, llv.Name))
-		// 		err = updateLVMLogicalVolumePhase(ctx, cl, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Unable to get selected LVMVolumeGroup, err: %s", err.Error()))
+		// 		err = updateLVMLogicalVolumePhase(ctx, e2eCL, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Unable to get selected LVMVolumeGroup, err: %s", err.Error()))
 		// 		if err != nil {
 		// 			log.Error(err, "[DeleteFunc] unable to update LVMLogicalVolume Phase")
 		// 		}
@@ -347,7 +347,7 @@ func reconcileLLVUpdateFunc(
 		// freeSpace, err := getFreeLVSpace(log, llv.Spec.Thin.PoolName)
 		// if err != nil {
 		// 	log.Error(err, fmt.Sprintf("[reconcileLLVUpdateFunc] unable to count free space in Thin-pool, name: %s", llv.Spec.Thin.PoolName))
-		// 	err = updateLVMLogicalVolumePhase(ctx, cl, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Unable to count free Thin-pool space, err: %s", err.Error()))
+		// 	err = updateLVMLogicalVolumePhase(ctx, e2eCL, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Unable to count free Thin-pool space, err: %s", err.Error()))
 		// 	if err != nil {
 		// 		log.Error(err, fmt.Sprintf("[reconcileLLVUpdateFunc] unable to update the LVMLogicalVolume %s", llv.Name))
 		// 	}
@@ -359,7 +359,7 @@ func reconcileLLVUpdateFunc(
 		// if freeSpace.Value() < extendingSize.Value() {
 		// 	err = errors.New("not enough space")
 		// 	log.Error(err, fmt.Sprintf("[reconcileLLVUpdateFunc] the LVMLogicalVolume %s requested size is more than the Thin-pool %s free space", llv.Name, llv.Spec.Thin.PoolName))
-		// 	err = updateLVMLogicalVolumePhase(ctx, cl, log, metrics, llv, failedStatusPhase, "Not enough space in a Thin-pool")
+		// 	err = updateLVMLogicalVolumePhase(ctx, e2eCL, log, metrics, llv, failedStatusPhase, "Not enough space in a Thin-pool")
 		// 	if err != nil {
 		// 		log.Error(err, fmt.Sprintf("[reconcileLLVUpdateFunc] unable to update the LVMLogicalVolume %s", llv.Name))
 		// 	}
@@ -513,7 +513,7 @@ func reconcileLLVCreateFunc(
 		// freeSpace, err := getFreeLVSpace(log, llv.Spec.Thin.PoolName)
 		// if err != nil {
 		// 	log.Error(err, fmt.Sprintf("[reconcileLLVCreateFunc] unable to count free space in LV, name: %s", llv.Spec.Thin.PoolName))
-		// 	err = updateLVMLogicalVolumePhase(ctx, cl, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Unable to get free LV space, err: %s", err.Error()))
+		// 	err = updateLVMLogicalVolumePhase(ctx, e2eCL, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Unable to get free LV space, err: %s", err.Error()))
 		// 	if err != nil {
 		// 		log.Error(err, fmt.Sprintf("[reconcileLLVCreateFunc] unable to update the LVMLogicalVolume, name: %s", llv.Name))
 		// 	}
@@ -525,7 +525,7 @@ func reconcileLLVCreateFunc(
 		// if freeSpace.Value() < llv.Spec.Size.Value() {
 		// 	err = errors.New("not enough space")
 		// 	log.Error(err, fmt.Sprintf("[reconcileLLVCreateFunc] the LVMLogicalVolume %s requested size is more than the Thin-pool %s free space", llv.Name, llv.Spec.Thin.PoolName))
-		// 	err = updateLVMLogicalVolumePhase(ctx, cl, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Not enough space in Thin-pool %s in LVMVolumeGroup %s", llv.Spec.Thin.PoolName, lvg.Name))
+		// 	err = updateLVMLogicalVolumePhase(ctx, e2eCL, log, metrics, llv, failedStatusPhase, fmt.Sprintf("Not enough space in Thin-pool %s in LVMVolumeGroup %s", llv.Spec.Thin.PoolName, lvg.Name))
 		// 	if err != nil {
 		// 		log.Error(err, fmt.Sprintf("[reconcileLLVCreateFunc] unable to update the LVMLogicalVolume, name: %s", llv.Name))
 		// 	}

--- a/images/agent/pkg/controller/lvm_volume_group_discover_test.go
+++ b/images/agent/pkg/controller/lvm_volume_group_discover_test.go
@@ -1070,7 +1070,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 		})
 	})
 
-	t.Run("addConditionToLVG", func(t *testing.T) {
+	t.Run("updateLVGConditionIfNeeded", func(t *testing.T) {
 		const (
 			lvgName = "test-lvg"
 			conType = "test-type"
@@ -1088,7 +1088,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			t.Error(err)
 		}
 
-		err = addConditionToLVG(ctx, cl, logger.Logger{}, lvg, metav1.ConditionTrue, conType, reason, message)
+		err = updateLVGConditionIfNeeded(ctx, cl, logger.Logger{}, lvg, metav1.ConditionTrue, conType, reason, message)
 		if assert.NoError(t, err) {
 			err = cl.Get(ctx, client.ObjectKey{
 				Name: lvgName,

--- a/images/agent/pkg/controller/lvm_volume_group_discover_test.go
+++ b/images/agent/pkg/controller/lvm_volume_group_discover_test.go
@@ -843,7 +843,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			},
 		}
 
-		actual := filterResourcesByNode(ctx, cl, testLogger, lvs, blockDevices, currentNode)
+		actual := filterLVGsByNode(ctx, cl, testLogger, lvs, blockDevices, currentNode)
 
 		assert.Equal(t, expected, actual)
 	})
@@ -896,7 +896,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			}
 		)
 
-		actual := filterResourcesByNode(ctx, cl, testLogger, lvs, blockDevices, currentNode)
+		actual := filterLVGsByNode(ctx, cl, testLogger, lvs, blockDevices, currentNode)
 
 		assert.Equal(t, 0, len(actual))
 	})

--- a/images/agent/pkg/controller/lvm_volume_group_test.go
+++ b/images/agent/pkg/controller/lvm_volume_group_test.go
@@ -206,6 +206,7 @@ func TestLvmVolumeGroupAPIObjects(t *testing.T) {
        "type": "local"
    },
    "status": {
+       "conditions": null,
        "allocatedSize": "20G",
        "health": "operational",
        "message": "all-good",
@@ -242,11 +243,14 @@ func TestLvmVolumeGroupAPIObjects(t *testing.T) {
                "name": "node2"
            }
        ],
+       "phase": "",
        "thinPools": [
            {
                "name": "test-name",
                "actualSize": "1G",
-				"usedSize": "500M"
+				"usedSize": "500M",
+               "ready": true,
+               "message": ""
            }
        ],
        "vgSize": "30G",
@@ -319,6 +323,8 @@ func TestLvmVolumeGroupAPIObjects(t *testing.T) {
 						Name:       "test-name",
 						ActualSize: *convertSize("1G", t),
 						UsedSize:   resource.MustParse("500M"),
+						Ready:      true,
+						Message:    "",
 					},
 				},
 				VGSize: resource.MustParse("30G"),

--- a/images/agent/pkg/controller/lvm_volume_group_watcher_func.go
+++ b/images/agent/pkg/controller/lvm_volume_group_watcher_func.go
@@ -58,7 +58,7 @@ func updateLVMVolumeGroupHealthStatus(ctx context.Context, cl client.Client, met
 	lvg.Status.Message = message
 
 	start := time.Now()
-	err := cl.Update(ctx, lvg)
+	err := cl.Status().Update(ctx, lvg)
 	metrics.ApiMethodsDuration(LVMVolumeGroupWatcherCtrlName, "update").Observe(metrics.GetEstimatedTimeInSeconds(start))
 	metrics.ApiMethodsExecutionCount(LVMVolumeGroupWatcherCtrlName, "update").Inc()
 	if err != nil {

--- a/images/agent/pkg/controller/lvm_volume_group_watcher_test.go
+++ b/images/agent/pkg/controller/lvm_volume_group_watcher_test.go
@@ -13,7 +13,7 @@ package controller
 //)
 //
 //func TestLVMVolumeGroupWatcherCtrl(t *testing.T) {
-//	cl := NewFakeClient()
+//	e2eCL := NewFakeClient()
 //	ctx := context.Background()
 //	metrics := monitoring.GetMetrics("")
 //	namespace := "test"
@@ -27,19 +27,19 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, testObj)
+//		err := e2eCL.Create(ctx, testObj)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testObj)
+//				err = e2eCL.Delete(ctx, testObj)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		actual, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		actual, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //
 //		if assert.NoError(t, err) {
 //			assert.NotNil(t, actual)
@@ -57,19 +57,19 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, testObj)
+//		err := e2eCL.Create(ctx, testObj)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testObj)
+//				err = e2eCL.Delete(ctx, testObj)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		actual, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, "another-name")
+//		actual, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, "another-name")
 //
 //		if assert.EqualError(t, err, "lvmvolumegroups.storage.deckhouse.io \"another-name\" not found") {
 //			assert.Nil(t, actual)
@@ -92,29 +92,29 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, testObj)
+//		err := e2eCL.Create(ctx, testObj)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testObj)
+//				err = e2eCL.Delete(ctx, testObj)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		oldLvg, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		oldLvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, oldLvg.Name)
 //			assert.Equal(t, Operational, oldLvg.Status.Health)
 //			assert.Equal(t, message, oldLvg.Status.Message)
 //		}
 //
-//		err = updateLVMVolumeGroupHealthStatus(ctx, cl, metrics, name, namespace, "new message", Operational)
+//		err = updateLVMVolumeGroupHealthStatus(ctx, e2eCL, metrics, name, namespace, "new message", Operational)
 //		assert.Nil(t, err)
 //
-//		updatedLvg, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		updatedLvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, updatedLvg.Name)
 //			assert.Equal(t, Operational, updatedLvg.Status.Health)
@@ -138,29 +138,29 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, testObj)
+//		err := e2eCL.Create(ctx, testObj)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testObj)
+//				err = e2eCL.Delete(ctx, testObj)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		oldLvg, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		oldLvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, oldLvg.Name)
 //			assert.Equal(t, NonOperational, oldLvg.Status.Health)
 //			assert.Equal(t, message, oldLvg.Status.Message)
 //		}
 //
-//		err = updateLVMVolumeGroupHealthStatus(ctx, cl, metrics, name, namespace, message, NonOperational)
+//		err = updateLVMVolumeGroupHealthStatus(ctx, e2eCL, metrics, name, namespace, message, NonOperational)
 //		assert.Nil(t, err)
 //
-//		updatedLvg, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		updatedLvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, updatedLvg.Name)
 //			assert.Equal(t, NonOperational, updatedLvg.Status.Health)
@@ -185,29 +185,29 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, testObj)
+//		err := e2eCL.Create(ctx, testObj)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testObj)
+//				err = e2eCL.Delete(ctx, testObj)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		oldLvg, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		oldLvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, oldLvg.Name)
 //			assert.Equal(t, NonOperational, oldLvg.Status.Health)
 //			assert.Equal(t, oldMessage, oldLvg.Status.Message)
 //		}
 //
-//		err = updateLVMVolumeGroupHealthStatus(ctx, cl, metrics, name, namespace, newMessage, NonOperational)
+//		err = updateLVMVolumeGroupHealthStatus(ctx, e2eCL, metrics, name, namespace, newMessage, NonOperational)
 //		assert.Nil(t, err)
 //
-//		updatedLvg, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		updatedLvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, updatedLvg.Name)
 //			assert.Equal(t, NonOperational, updatedLvg.Status.Health)
@@ -232,29 +232,29 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, testObj)
+//		err := e2eCL.Create(ctx, testObj)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testObj)
+//				err = e2eCL.Delete(ctx, testObj)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		oldLvg, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		oldLvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, oldLvg.Name)
 //			assert.Equal(t, NonOperational, oldLvg.Status.Health)
 //			assert.Equal(t, oldMessage, oldLvg.Status.Message)
 //		}
 //
-//		err = updateLVMVolumeGroupHealthStatus(ctx, cl, metrics, name, namespace, newMessage, Operational)
+//		err = updateLVMVolumeGroupHealthStatus(ctx, e2eCL, metrics, name, namespace, newMessage, Operational)
 //		assert.Nil(t, err)
 //
-//		updatedLvg, err := getLVMVolumeGroup(ctx, cl, metrics, namespace, name)
+//		updatedLvg, err := getLVMVolumeGroup(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, updatedLvg.Name)
 //			assert.Equal(t, Operational, updatedLvg.Status.Health)
@@ -272,19 +272,19 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, testObj)
+//		err := e2eCL.Create(ctx, testObj)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testObj)
+//				err = e2eCL.Delete(ctx, testObj)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		bd, err := getBlockDevice(ctx, cl, metrics, namespace, name)
+//		bd, err := getBlockDevice(ctx, e2eCL, metrics, namespace, name)
 //		if assert.NoError(t, err) {
 //			assert.Equal(t, name, bd.Name)
 //			assert.Equal(t, namespace, bd.Namespace)
@@ -301,26 +301,26 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, testObj)
+//		err := e2eCL.Create(ctx, testObj)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testObj)
+//				err = e2eCL.Delete(ctx, testObj)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		bd, err := getBlockDevice(ctx, cl, metrics, namespace, "another-name")
+//		bd, err := getBlockDevice(ctx, e2eCL, metrics, namespace, "another-name")
 //		if assert.EqualError(t, err, "blockdevices.storage.deckhouse.io \"another-name\" not found") {
 //			assert.Nil(t, bd)
 //		}
 //	})
 //
 //	t.Run("ValidateLVMGroup_lvg_is_nil_returns_error", func(t *testing.T) {
-//		valid, obj, err := CheckLVMVGNodeOwnership(ctx, cl, metrics, nil, "test_ns", "test_node")
+//		valid, obj, err := CheckLVMVGNodeOwnership(ctx, e2eCL, metrics, nil, "test_ns", "test_node")
 //		assert.False(t, valid)
 //		assert.Nil(t, obj)
 //		assert.EqualError(t, err, "lvmVolumeGroup is nil")
@@ -340,19 +340,19 @@ package controller
 //			},
 //		}
 //
-//		err := cl.Create(ctx, lvg)
+//		err := e2eCL.Create(ctx, lvg)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, lvg)
+//				err = e2eCL.Delete(ctx, lvg)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		valid, status, err := CheckLVMVGNodeOwnership(ctx, cl, metrics, lvg, namespace, "test_node")
+//		valid, status, err := CheckLVMVGNodeOwnership(ctx, e2eCL, metrics, lvg, namespace, "test_node")
 //		assert.False(t, valid)
 //		if assert.NotNil(t, status) {
 //			assert.Equal(t, NonOperational, status.Health)
@@ -393,7 +393,7 @@ package controller
 //
 //		var err error
 //		for _, bd := range bds.Items {
-//			err = cl.Create(ctx, &bd)
+//			err = e2eCL.Create(ctx, &bd)
 //			if err != nil {
 //				t.Error(err)
 //			}
@@ -402,7 +402,7 @@ package controller
 //		if err == nil {
 //			defer func() {
 //				for _, bd := range bds.Items {
-//					err = cl.Delete(ctx, &bd)
+//					err = e2eCL.Delete(ctx, &bd)
 //					if err != nil {
 //						t.Error(err)
 //					}
@@ -421,19 +421,19 @@ package controller
 //			},
 //		}
 //
-//		err = cl.Create(ctx, testLvg)
+//		err = e2eCL.Create(ctx, testLvg)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testLvg)
+//				err = e2eCL.Delete(ctx, testLvg)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		valid, status, err := CheckLVMVGNodeOwnership(ctx, cl, metrics, testLvg, namespace, testNode)
+//		valid, status, err := CheckLVMVGNodeOwnership(ctx, e2eCL, metrics, testLvg, namespace, testNode)
 //		assert.False(t, valid)
 //		if assert.NotNil(t, status) {
 //			assert.Equal(t, NonOperational, status.Health)
@@ -475,7 +475,7 @@ package controller
 //
 //		var err error
 //		for _, bd := range bds.Items {
-//			err = cl.Create(ctx, &bd)
+//			err = e2eCL.Create(ctx, &bd)
 //			if err != nil {
 //				t.Error(err)
 //			}
@@ -484,7 +484,7 @@ package controller
 //		if err == nil {
 //			defer func() {
 //				for _, bd := range bds.Items {
-//					err = cl.Delete(ctx, &bd)
+//					err = e2eCL.Delete(ctx, &bd)
 //					if err != nil {
 //						t.Error(err)
 //					}
@@ -504,19 +504,19 @@ package controller
 //			},
 //		}
 //
-//		err = cl.Create(ctx, testLvg)
+//		err = e2eCL.Create(ctx, testLvg)
 //		if err != nil {
 //			t.Error(err)
 //		} else {
 //			defer func() {
-//				err = cl.Delete(ctx, testLvg)
+//				err = e2eCL.Delete(ctx, testLvg)
 //				if err != nil {
 //					t.Error(err)
 //				}
 //			}()
 //		}
 //
-//		valid, status, err := CheckLVMVGNodeOwnership(ctx, cl, metrics, testLvg, namespace, testNode)
+//		valid, status, err := CheckLVMVGNodeOwnership(ctx, e2eCL, metrics, testLvg, namespace, testNode)
 //		assert.True(t, valid)
 //		if assert.NotNil(t, status) {
 //			assert.Equal(t, "", status.Health)
@@ -546,10 +546,10 @@ package controller
 //			},
 //		}
 //
-//		err := CreateEventLVMVolumeGroup(ctx, cl, metrics, EventReasonDeleting, EventActionDeleting, nodeName, testLvg)
+//		err := CreateEventLVMVolumeGroup(ctx, e2eCL, metrics, EventReasonDeleting, EventActionDeleting, nodeName, testLvg)
 //		if assert.NoError(t, err) {
 //			events := &v1.EventList{}
-//			err = cl.List(ctx, events)
+//			err = e2eCL.List(ctx, events)
 //			if err != nil {
 //				t.Error(err)
 //			}
@@ -570,7 +570,7 @@ package controller
 //				assert.Equal(t, LVMVolumeGroupWatcherCtrlName, event.ReportingController)
 //				assert.Equal(t, "Event Message", event.Message)
 //
-//				err = cl.Delete(ctx, &event)
+//				err = e2eCL.Delete(ctx, &event)
 //				if err != nil {
 //					t.Error(err)
 //				}
@@ -613,7 +613,7 @@ package controller
 //
 //		var err error
 //		for _, bd := range bds.Items {
-//			err = cl.Create(ctx, &bd)
+//			err = e2eCL.Create(ctx, &bd)
 //			if err != nil {
 //				t.Error(err)
 //			}
@@ -622,7 +622,7 @@ package controller
 //		if err == nil {
 //			defer func() {
 //				for _, bd := range bds.Items {
-//					err = cl.Delete(ctx, &bd)
+//					err = e2eCL.Delete(ctx, &bd)
 //					if err != nil {
 //						t.Error(err)
 //					}
@@ -641,7 +641,7 @@ package controller
 //			},
 //		}
 //
-//		passed, err := ValidateConsumableDevices(ctx, cl, metrics, testLvg)
+//		passed, err := ValidateConsumableDevices(ctx, e2eCL, metrics, testLvg)
 //		if assert.NoError(t, err) {
 //			assert.True(t, passed)
 //		}
@@ -682,7 +682,7 @@ package controller
 //
 //		var err error
 //		for _, bd := range bds.Items {
-//			err = cl.Create(ctx, &bd)
+//			err = e2eCL.Create(ctx, &bd)
 //			if err != nil {
 //				t.Error(err)
 //			}
@@ -691,7 +691,7 @@ package controller
 //		if err == nil {
 //			defer func() {
 //				for _, bd := range bds.Items {
-//					err = cl.Delete(ctx, &bd)
+//					err = e2eCL.Delete(ctx, &bd)
 //					if err != nil {
 //						t.Error(err)
 //					}
@@ -710,21 +710,21 @@ package controller
 //			},
 //		}
 //
-//		passed, err := ValidateConsumableDevices(ctx, cl, metrics, testLvg)
+//		passed, err := ValidateConsumableDevices(ctx, e2eCL, metrics, testLvg)
 //		if assert.NoError(t, err) {
 //			assert.False(t, passed)
 //		}
 //	})
 //
 //	t.Run("ValidateConsumableDevices_lvg_is_nil_validation_fails", func(t *testing.T) {
-//		passed, err := ValidateConsumableDevices(ctx, cl, metrics, nil)
+//		passed, err := ValidateConsumableDevices(ctx, e2eCL, metrics, nil)
 //		if assert.EqualError(t, err, "lvmVolumeGroup is nil") {
 //			assert.False(t, passed)
 //		}
 //	})
 //
 //	t.Run("GetPathsConsumableDevicesFromLVMVG_lvg_is_nil_returns_error", func(t *testing.T) {
-//		paths, err := GetPathsConsumableDevicesFromLVMVG(ctx, cl, metrics, nil)
+//		paths, err := GetPathsConsumableDevicesFromLVMVG(ctx, e2eCL, metrics, nil)
 //
 //		if assert.EqualError(t, err, "lvmVolumeGroup is nil") {
 //			assert.Nil(t, paths)
@@ -770,7 +770,7 @@ package controller
 //
 //		var err error
 //		for _, bd := range bds.Items {
-//			err = cl.Create(ctx, &bd)
+//			err = e2eCL.Create(ctx, &bd)
 //			if err != nil {
 //				t.Error(err)
 //			}
@@ -779,7 +779,7 @@ package controller
 //		if err == nil {
 //			defer func() {
 //				for _, bd := range bds.Items {
-//					err = cl.Delete(ctx, &bd)
+//					err = e2eCL.Delete(ctx, &bd)
 //					if err != nil {
 //						t.Error(err)
 //					}
@@ -800,7 +800,7 @@ package controller
 //
 //		expected := []string{firstPath, secondPath}
 //
-//		actual, err := GetPathsConsumableDevicesFromLVMVG(ctx, cl, metrics, testLvg)
+//		actual, err := GetPathsConsumableDevicesFromLVMVG(ctx, e2eCL, metrics, testLvg)
 //		if assert.NoError(t, err) {
 //			assert.ElementsMatch(t, expected, actual)
 //		}

--- a/images/agent/pkg/utils/units.go
+++ b/images/agent/pkg/utils/units.go
@@ -22,19 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func BytesToQuantity(size int64) string {
-	tmp := resource.NewQuantity(size, resource.BinarySI)
-	return tmp.String()
-}
-
-func QuantityToBytes(quantity string) (int64, error) {
-	b, err := resource.ParseQuantity(quantity)
-	if err != nil {
-		return 0, err
-	}
-	return b.Value(), nil
-}
-
 func AreSizesEqualWithinDelta(leftSize, rightSize, allowedDelta resource.Quantity) bool {
 	leftSizeFloat := float64(leftSize.Value())
 	rightSizeFloat := float64(rightSize.Value())

--- a/templates/agent/rbac.yaml
+++ b/templates/agent/rbac.yaml
@@ -29,6 +29,7 @@ rules:
     resources:
       - blockdevices
       - lvmvolumegroups
+      - lvmvolumegroups/status
       - lvmlogicalvolumes
     verbs:
       - get


### PR DESCRIPTION
## Description
Two LVMVolumeGroup conditions are adding into the resource's status during controller's reconciliation depends on its status and operations results.

1. VGConfigurationApplied condition says that a resource's VG configuration matches the node's VG configuration.
2. VGReady condition says that a resource is completely configured and is ready to use.

## Why do we need it, and what problem does it solve?
It provides UI support to show to clients different resources stages.

## What is the expected result?
A LVMVolumeGroup resource has two conditions (described above), each one has its own type and correct status, which tells a user if everything is fine or not.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
