### PR TITLE
[docs] Change the module status to preview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 title: "The sds-node-configurator module"
 description: "General Concepts and Principles of  the sds-node-configurator module. Deckhouse Kubernetes Platform."
-moduleStatus: experimental
+moduleStatus: preview
 ---
 
 {{< alert level="warning" >}}

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -1,7 +1,7 @@
 ---
 title: "Модуль sds-node-configurator"
 description: "Концепция и принцип работы модуля sds-node-configurator, Deckhouse Kubernetes Platform."
-moduleStatus: experimental
+moduleStatus: preview
 ---
 {{< alert level="warning" >}}
 Работоспособность модуля гарантируется только при использовании стоковых ядер, поставляемых вместе с [поддерживаемыми дистрибутивами](https://deckhouse.ru/documentation/v1/supported_versions.html#linux).


### PR DESCRIPTION
## Description
Change the module status from `experimental` to `preview`.

## What is the expected result?
The status of the module in the documentation is `preview`.
