### PR TITLE
[controller] Added free space field to LVMVolumeGroup VG and ThinPools

### DIFF
--- a/crds/doc-ru-lvmvolumegroup.yaml
+++ b/crds/doc-ru-lvmvolumegroup.yaml
@@ -77,6 +77,9 @@ spec:
                 vgSize:
                   description: |
                     Ёмкость Volume Group.
+                vgFree:
+                  description: |
+                    Свободное пространство Volume Group.
                 allocatedSize:
                   description: |
                     Текущее занятое место на Volume Group.
@@ -96,6 +99,9 @@ spec:
                       usedSize:
                         description: |
                           Используемый размер Thin-pool.
+                      availableSpace:
+                        description: |
+                          Свободное место в Thin-pool.
                       ready:
                         description: |
                           Текущее состояние Thin-pool.

--- a/crds/lvmlogicalvolume.yaml
+++ b/crds/lvmlogicalvolume.yaml
@@ -137,6 +137,10 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
+        - jsonPath: .spec.actualLVNameOnTheNode
+          name: LV Name
+          type: string
+          description: Actual LV name on the node.
         - jsonPath: .status.phase
           name: Phase
           type: string

--- a/crds/lvmvolumegroup.yaml
+++ b/crds/lvmvolumegroup.yaml
@@ -151,6 +151,10 @@ spec:
                   type: string
                   description: |
                     The Volume Group capacity.
+                vgFree:
+                  type: string
+                  description: |
+                    The Volume Group free space.
                 allocatedSize:
                   type: string
                   description: |
@@ -190,6 +194,10 @@ spec:
                           Thin pool oversize limit. Default is 150%.
                         default: "150%"
                         pattern: '^[1-9][0-9]{2,3}%$'
+                      availableSpace:
+                        type: string
+                        description: |
+                          Thin pool free space available.
                       ready:
                         type: boolean
                         description: |

--- a/images/agent/api/v1alpha1/lvm_volume_group.go
+++ b/images/agent/api/v1alpha1/lvm_volume_group.go
@@ -53,6 +53,7 @@ type LvmVolumeGroupStatus struct {
 	Conditions           []metav1.Condition             `json:"conditions"`
 	ThinPoolReady        string                         `json:"thinPoolReady"`
 	ConfigurationApplied string                         `json:"configurationApplied"`
+	VGFree               resource.Quantity              `json:"vgFree"`
 }
 
 type LvmVolumeGroupDevice struct {
@@ -73,6 +74,7 @@ type LvmVolumeGroupThinPoolStatus struct {
 	ActualSize      resource.Quantity `json:"actualSize"`
 	UsedSize        resource.Quantity `json:"usedSize"`
 	AllocatedSize   resource.Quantity `json:"allocatedSize"`
+	AvailableSpace  resource.Quantity `json:"availableSpace"`
 	AllocationLimit string            `json:"allocationLimit"`
 	Ready           bool              `json:"ready"`
 	Message         string            `json:"message"`

--- a/images/agent/internal/type.go
+++ b/images/agent/internal/type.go
@@ -53,6 +53,7 @@ type LVMVolumeGroupCandidate struct {
 	Message               string
 	StatusThinPools       []LVMVGStatusThinPool
 	VGSize                resource.Quantity
+	VGFree                resource.Quantity
 	VGUuid                string
 	Nodes                 map[string][]LVMVGDevice
 }

--- a/images/agent/pkg/controller/lvm_logical_volume_watcher.go
+++ b/images/agent/pkg/controller/lvm_logical_volume_watcher.go
@@ -325,7 +325,7 @@ func reconcileLLVCreateFunc(
 	if updated {
 		log.Info(fmt.Sprintf("[reconcileLLVCreateFunc] successfully updated the LVMLogicalVolume %s status phase to Created", llv.Name))
 	} else {
-		log.Warning(fmt.Sprintf("[reconcileLLVCreateFunc] LVMLogicalVolume %s status phase was not updated to Created", llv.Name))
+		log.Warning(fmt.Sprintf("[reconcileLLVCreateFunc] LVMLogicalVolume %s status phase was not updated to Created due to the resource has already have the same phase", llv.Name))
 	}
 
 	log.Info(fmt.Sprintf("[reconcileLLVCreateFunc] successfully ended the reconciliation for the LVMLogicalVolume %s", llv.Name))
@@ -439,8 +439,6 @@ func reconcileLLVUpdateFunc(
 
 	log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] successfully got LVMLogicalVolume %s actual size before the extension", llv.Name))
 	log.Trace(fmt.Sprintf("[reconcileLLVUpdateFunc] the LV %s in VG %s actual size %s", llv.Spec.ActualLVNameOnTheNode, lvg.Spec.ActualVGNameOnTheNode, newActualSize.String()))
-
-	// need this here as a user might create the LLV with existing LV
 
 	updated, err := updateLLVPhaseToCreatedIfNeeded(ctx, cl, llv, newActualSize)
 	if err != nil {

--- a/images/agent/pkg/controller/lvm_logical_volume_watcher_test.go
+++ b/images/agent/pkg/controller/lvm_logical_volume_watcher_test.go
@@ -217,19 +217,17 @@ func TestLVMLogicaVolumeWatcher(t *testing.T) {
 
 	})
 
-	t.Run("getFreeThinPoolSpace", func(t *testing.T) {
+	t.Run("getThinPoolAvailableSpace", func(t *testing.T) {
 		const tpName = "test-tp"
-		tps := []v1alpha1.LvmVolumeGroupThinPoolStatus{
-			{
-				Name:            tpName,
-				ActualSize:      resource.MustParse("10Gi"),
-				UsedSize:        resource.MustParse("1Gi"),
-				AllocatedSize:   resource.MustParse("5Gi"),
-				AllocationLimit: "150%",
-			},
+		tp := v1alpha1.LvmVolumeGroupThinPoolStatus{
+			Name:            tpName,
+			ActualSize:      resource.MustParse("10Gi"),
+			UsedSize:        resource.MustParse("1Gi"),
+			AllocatedSize:   resource.MustParse("5Gi"),
+			AllocationLimit: "150%",
 		}
 
-		free, err := getFreeThinPoolSpace(tps, tpName)
+		free, err := getThinPoolAvailableSpace(tp.ActualSize, tp.AllocatedSize, tpName)
 		if err != nil {
 			t.Error(err)
 		}
@@ -618,42 +616,6 @@ func TestLVMLogicaVolumeWatcher(t *testing.T) {
 				assert.Contains(t, newLLV.Finalizers, internal.SdsNodeConfiguratorFinalizer)
 			}
 		})
-	})
-
-	// t.Run("getVirtualLVSize", func(t *testing.T) {
-	// 	const (
-	// 		tpName = "test_tp"
-	// 	)
-	// 	lvs := []internal.LVData{
-	// 		{
-	// 			PoolName: tpName,
-	// 			LVSize: *resource.NewQuantity(1000, resource.BinarySI),
-	// 		},
-	// 		{
-	// 			PoolName: tpName,
-	// 			LVSize: *resource.NewQuantity(1000, resource.BinarySI),
-	// 		},
-	// 		{
-	// 			PoolName: tpName,
-	// 			LVSize: *resource.NewQuantity(1000, resource.BinarySI),
-	// 		},
-	// 	}
-
-	// 	size := getVirtualLVSize(tpName, lvs)
-
-	// 	assert.Equal(t, int64(3000), size.Value())
-	// })
-
-	t.Run("getFreeVGSpace", func(t *testing.T) {
-		lvg := &v1alpha1.LvmVolumeGroup{
-			Status: v1alpha1.LvmVolumeGroupStatus{
-				VGSize:        resource.MustParse("2G"),
-				AllocatedSize: resource.MustParse("1G"),
-			},
-		}
-
-		free := getFreeVGSpace(lvg)
-		assert.Equal(t, int64(1000000000), free.Value())
 	})
 
 	t.Run("updateLVMLogicalVolume", func(t *testing.T) {

--- a/images/agent/pkg/controller/lvm_volume_group_discover_test.go
+++ b/images/agent/pkg/controller/lvm_volume_group_discover_test.go
@@ -470,6 +470,10 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			Nodes:                 nodes,
 		}
 
+		thinPools, err := convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, statusThinPools)
+		if err != nil {
+			t.Error(err)
+		}
 		expected := v1alpha1.LvmVolumeGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            LVMVGName,
@@ -485,7 +489,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			Status: v1alpha1.LvmVolumeGroupStatus{
 				AllocatedSize: size10G,
 				Nodes:         convertLVMVGNodes(nodes),
-				ThinPools:     convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, statusThinPools),
+				ThinPools:     thinPools,
 				VGSize:        size10G,
 				VGUuid:        VGUuid,
 			},
@@ -555,6 +559,11 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			Nodes:                 nodes,
 		}
 
+		thinPools, err := convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, statusThinPools)
+		if err != nil {
+			t.Error(err)
+		}
+
 		expected := map[string]v1alpha1.LvmVolumeGroup{
 			LVMVGName: {
 				ObjectMeta: metav1.ObjectMeta{
@@ -571,7 +580,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 				Status: v1alpha1.LvmVolumeGroupStatus{
 					AllocatedSize: size10G,
 					Nodes:         convertLVMVGNodes(nodes),
-					ThinPools:     convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, statusThinPools),
+					ThinPools:     thinPools,
 					VGSize:        size10G,
 					VGUuid:        VGUuid,
 				},
@@ -755,6 +764,11 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			Nodes:                 newNodes,
 		}
 
+		thinPools, err := convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, StatusThinPools)
+		if err != nil {
+			t.Error(err)
+		}
+
 		expected := v1alpha1.LvmVolumeGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            LVMVGName,
@@ -770,7 +784,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			Status: v1alpha1.LvmVolumeGroupStatus{
 				AllocatedSize: size10G,
 				Nodes:         convertLVMVGNodes(newNodes),
-				ThinPools:     convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, StatusThinPools),
+				ThinPools:     thinPools,
 				VGSize:        size10G,
 				VGUuid:        VGUuid,
 			},
@@ -964,6 +978,10 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 				Nodes:             nodes,
 			}
 
+			thinPools, err := convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, statusThinPools)
+			if err != nil {
+				t.Error(err)
+			}
 			lvmVolumeGroup := v1alpha1.LvmVolumeGroup{
 				Spec: v1alpha1.LvmVolumeGroupSpec{
 					BlockDeviceNames: blockDevicesNames,
@@ -973,7 +991,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 				Status: v1alpha1.LvmVolumeGroupStatus{
 					AllocatedSize: resource.MustParse("9765625Ki"),
 					Nodes:         convertLVMVGNodes(nodes),
-					ThinPools:     convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, statusThinPools),
+					ThinPools:     thinPools,
 					VGSize:        resource.MustParse("9765625Ki"),
 				},
 			}
@@ -1045,6 +1063,11 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 				Nodes:             nodes,
 			}
 
+			thinPools, err := convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, statusThinPools)
+			if err != nil {
+				t.Error(err)
+			}
+
 			lvmVolumeGroup := v1alpha1.LvmVolumeGroup{
 				Spec: v1alpha1.LvmVolumeGroupSpec{
 					BlockDeviceNames: blockDevicesNames,
@@ -1054,7 +1077,7 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 				Status: v1alpha1.LvmVolumeGroupStatus{
 					AllocatedSize: allocatedSize,
 					Nodes:         convertLVMVGNodes(nodes),
-					ThinPools:     convertStatusThinPools(v1alpha1.LvmVolumeGroup{}, statusThinPools),
+					ThinPools:     thinPools,
 					VGSize:        vgSize,
 				},
 			}

--- a/images/agent/pkg/controller/lvm_volume_group_watcher_func.go
+++ b/images/agent/pkg/controller/lvm_volume_group_watcher_func.go
@@ -464,10 +464,12 @@ func ReconcileThinPoolsIfNeeded(ctx context.Context, cl client.Client, log logge
 				continue
 			}
 			log.Debug(fmt.Sprintf("[ReconcileThinPoolsIfNeeded] thin-pool %s of the LVMVolumeGroup %s is not created yet. Create it", specTp.Name, lvg.Name))
-			err := updateLVGConditionIfNeeded(ctx, cl, log, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, internal.ReasonUpdating, "trying to apply the configuration")
-			if err != nil {
-				log.Error(err, fmt.Sprintf("[UpdateVGTagIfNeeded] unable to add the condition %s status False reason %s to the LVMVolumeGroup %s", internal.TypeVGConfigurationApplied, internal.ReasonUpdating, lvg.Name))
-				return err
+			if checkIfConditionIsTrue(lvg, internal.TypeVGConfigurationApplied) {
+				err := updateLVGConditionIfNeeded(ctx, cl, log, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, internal.ReasonUpdating, "trying to apply the configuration")
+				if err != nil {
+					log.Error(err, fmt.Sprintf("[UpdateVGTagIfNeeded] unable to add the condition %s status False reason %s to the LVMVolumeGroup %s", internal.TypeVGConfigurationApplied, internal.ReasonUpdating, lvg.Name))
+					return err
+				}
 			}
 
 			start := time.Now()
@@ -535,11 +537,14 @@ func ResizePVIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, 
 	for _, n := range lvg.Status.Nodes {
 		for _, d := range n.Devices {
 			if d.DevSize.Value()-d.PVSize.Value() > delta.Value() {
-				err = updateLVGConditionIfNeeded(ctx, cl, log, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, internal.ReasonUpdating, "trying to apply the configuration")
-				if err != nil {
-					log.Error(err, fmt.Sprintf("[UpdateVGTagIfNeeded] unable to add the condition %s status False reason %s to the LVMVolumeGroup %s", internal.TypeVGConfigurationApplied, internal.ReasonUpdating, lvg.Name))
-					return err
+				if checkIfConditionIsTrue(lvg, internal.TypeVGConfigurationApplied) {
+					err = updateLVGConditionIfNeeded(ctx, cl, log, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, internal.ReasonUpdating, "trying to apply the configuration")
+					if err != nil {
+						log.Error(err, fmt.Sprintf("[UpdateVGTagIfNeeded] unable to add the condition %s status False reason %s to the LVMVolumeGroup %s", internal.TypeVGConfigurationApplied, internal.ReasonUpdating, lvg.Name))
+						return err
+					}
 				}
+
 				log.Debug(fmt.Sprintf("[ResizePVIfNeeded] the LVMVolumeGroup %s BlockDevice %s PVSize is less than actual device size. Resize PV", lvg.Name, d.BlockDevice))
 
 				start := time.Now()
@@ -593,15 +598,17 @@ func ExtendVGIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, 
 		return nil
 	}
 
-	err := updateLVGConditionIfNeeded(ctx, cl, log, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, internal.ReasonUpdating, "trying to apply the configuration")
-	if err != nil {
-		log.Error(err, fmt.Sprintf("[UpdateVGTagIfNeeded] unable to add the condition %s status False reason %s to the LVMVolumeGroup %s", internal.TypeVGConfigurationApplied, internal.ReasonUpdating, lvg.Name))
-		return err
+	if checkIfConditionIsTrue(lvg, internal.TypeVGConfigurationApplied) {
+		err := updateLVGConditionIfNeeded(ctx, cl, log, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, internal.ReasonUpdating, "trying to apply the configuration")
+		if err != nil {
+			log.Error(err, fmt.Sprintf("[UpdateVGTagIfNeeded] unable to add the condition %s status False reason %s to the LVMVolumeGroup %s", internal.TypeVGConfigurationApplied, internal.ReasonUpdating, lvg.Name))
+			return err
+		}
 	}
 
 	log.Debug(fmt.Sprintf("[ExtendVGIfNeeded] VG %s should be extended as there are some BlockDevices were added to Spec field of the LVMVolumeGroup %s", vg.VGName, lvg.Name))
 	paths := extractPathsFromBlockDevices(devicesToExtend, blockDevices)
-	err = ExtendVGComplex(metrics, paths, vg.VGName, log)
+	err := ExtendVGComplex(metrics, paths, vg.VGName, log)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("[ExtendVGIfNeeded] unable to extend VG %s of the LVMVolumeGroup %s", vg.VGName, lvg.Name))
 		return err
@@ -794,10 +801,12 @@ func CreateVGComplex(metrics monitoring.Metrics, log logger.Logger, lvg *v1alpha
 func UpdateVGTagIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, metrics monitoring.Metrics, lvg *v1alpha1.LvmVolumeGroup, vg internal.VGData) (bool, error) {
 	found, tagName := CheckTag(vg.VGTags)
 	if found && lvg.Name != tagName {
-		err := updateLVGConditionIfNeeded(ctx, cl, log, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, internal.ReasonUpdating, "trying to apply the configuration")
-		if err != nil {
-			log.Error(err, fmt.Sprintf("[UpdateVGTagIfNeeded] unable to add the condition %s status False reason %s to the LVMVolumeGroup %s", internal.TypeVGConfigurationApplied, internal.ReasonUpdating, lvg.Name))
-			return false, err
+		if checkIfConditionIsTrue(lvg, internal.TypeVGConfigurationApplied) {
+			err := updateLVGConditionIfNeeded(ctx, cl, log, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, internal.ReasonUpdating, "trying to apply the configuration")
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[UpdateVGTagIfNeeded] unable to add the condition %s status False reason %s to the LVMVolumeGroup %s", internal.TypeVGConfigurationApplied, internal.ReasonUpdating, lvg.Name))
+				return false, err
+			}
 		}
 
 		start := time.Now()

--- a/images/sds-health-watcher-controller/api/v1alpha1/lvm_volume_group.go
+++ b/images/sds-health-watcher-controller/api/v1alpha1/lvm_volume_group.go
@@ -36,17 +36,24 @@ type LvmVolumeGroup struct {
 	Status LvmVolumeGroupStatus `json:"status,omitempty"`
 }
 
-type SpecThinPool struct {
-	Name            string            `json:"name"`
-	Size            resource.Quantity `json:"size"`
-	AllocationLimit string            `json:"allocationLimit"`
+type LvmVolumeGroupSpec struct {
+	ActualVGNameOnTheNode string                       `json:"actualVGNameOnTheNode"`
+	BlockDeviceNames      []string                     `json:"blockDeviceNames"`
+	ThinPools             []LvmVolumeGroupThinPoolSpec `json:"thinPools"`
+	Type                  string                       `json:"type"`
 }
 
-type LvmVolumeGroupSpec struct {
-	ActualVGNameOnTheNode string         `json:"actualVGNameOnTheNode"`
-	BlockDeviceNames      []string       `json:"blockDeviceNames"`
-	ThinPools             []SpecThinPool `json:"thinPools"`
-	Type                  string         `json:"type"`
+type LvmVolumeGroupStatus struct {
+	AllocatedSize        resource.Quantity              `json:"allocatedSize"`
+	Nodes                []LvmVolumeGroupNode           `json:"nodes"`
+	ThinPools            []LvmVolumeGroupThinPoolStatus `json:"thinPools"`
+	VGSize               resource.Quantity              `json:"vgSize"`
+	VGUuid               string                         `json:"vgUUID"`
+	Phase                string                         `json:"phase"`
+	Conditions           []metav1.Condition             `json:"conditions"`
+	ThinPoolReady        string                         `json:"thinPoolReady"`
+	ConfigurationApplied string                         `json:"configurationApplied"`
+	VGFree               resource.Quantity              `json:"vgFree"`
 }
 
 type LvmVolumeGroupDevice struct {
@@ -62,24 +69,19 @@ type LvmVolumeGroupNode struct {
 	Name    string                 `json:"name"`
 }
 
-type StatusThinPool struct {
+type LvmVolumeGroupThinPoolStatus struct {
 	Name            string            `json:"name"`
 	ActualSize      resource.Quantity `json:"actualSize"`
 	UsedSize        resource.Quantity `json:"usedSize"`
 	AllocatedSize   resource.Quantity `json:"allocatedSize"`
+	AvailableSpace  resource.Quantity `json:"availableSpace"`
 	AllocationLimit string            `json:"allocationLimit"`
 	Ready           bool              `json:"ready"`
 	Message         string            `json:"message"`
 }
 
-type LvmVolumeGroupStatus struct {
-	AllocatedSize        resource.Quantity    `json:"allocatedSize"`
-	Nodes                []LvmVolumeGroupNode `json:"nodes"`
-	ThinPools            []StatusThinPool     `json:"thinPools"`
-	VGSize               resource.Quantity    `json:"vgSize"`
-	VGUuid               string               `json:"vgUUID"`
-	Phase                string               `json:"phase"`
-	Conditions           []metav1.Condition   `json:"conditions"`
-	ThinPoolReady        string               `json:"thinPoolReady"`
-	ConfigurationApplied string               `json:"configurationApplied"`
+type LvmVolumeGroupThinPoolSpec struct {
+	Name            string            `json:"name"`
+	Size            resource.Quantity `json:"size"`
+	AllocationLimit string            `json:"allocationLimit"`
 }

--- a/images/sds-health-watcher-controller/pkg/controller/lvg_status_watcher.go
+++ b/images/sds-health-watcher-controller/pkg/controller/lvg_status_watcher.go
@@ -116,7 +116,7 @@ func reconcileLVGStatus(ctx context.Context, cl client.Client, log logger.Logger
 	return err
 }
 
-func getActualThinPoolReadyCount(statusTp []v1alpha1.StatusThinPool) int {
+func getActualThinPoolReadyCount(statusTp []v1alpha1.LvmVolumeGroupThinPoolStatus) int {
 	count := 0
 
 	for _, tp := range statusTp {
@@ -128,7 +128,7 @@ func getActualThinPoolReadyCount(statusTp []v1alpha1.StatusThinPool) int {
 	return count
 }
 
-func getUniqueThinPoolCount(specTp []v1alpha1.SpecThinPool, statusTp []v1alpha1.StatusThinPool) int {
+func getUniqueThinPoolCount(specTp []v1alpha1.LvmVolumeGroupThinPoolSpec, statusTp []v1alpha1.LvmVolumeGroupThinPoolStatus) int {
 	unique := make(map[string]struct{}, len(specTp)+len(statusTp))
 
 	for _, tp := range specTp {


### PR DESCRIPTION
## Description
Add VG FreeVG and Thin pool AvailableSpace fields, to store free spaces of VG and Thin pool in LVMVolumeGroup resources.
Notice, that AvailableSpace field is counted dynamically according to AllocationLimit field's value.

## Why do we need it, and what problem does it solve?
These fields allow the different controllers to get needed information straight from the resource, and do not count it by themselves from different places.
Also, those fields might be helpful to users and UI to show the VG and Thin Pool free spaces.

## What is the expected result?
Users might see VGFree in the LVMVolumeGroup's Status and AvailableSpace in the LVMVolumeGroup Thin-pool Status.
AvailableSpace field is counted dynamically according to AllocationLimit field's value.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
