### PR TITLE
[controller] Move LVMVolumeGroup resource deletion logic from Discover to Watcher

### DIFF
--- a/images/agent/pkg/controller/block_device.go
+++ b/images/agent/pkg/controller/block_device.go
@@ -59,7 +59,7 @@ func RunBlockDeviceController(
 
 			shouldRequeue := BlockDeviceReconcile(ctx, cl, log, metrics, cfg, sdsCache)
 			if shouldRequeue {
-				log.Warning(fmt.Sprintf("[RunBlockDeviceController] an error occured while run the Reconciler func, retry in %f", cfg.BlockDeviceScanIntervalSec.Seconds()))
+				log.Warning(fmt.Sprintf("[RunBlockDeviceController] Reconciler needs a retry in %f", cfg.BlockDeviceScanIntervalSec.Seconds()))
 				return reconcile.Result{
 					RequeueAfter: cfg.BlockDeviceScanIntervalSec,
 				}, nil

--- a/images/agent/pkg/controller/lvm_logical_volume_watcher.go
+++ b/images/agent/pkg/controller/lvm_logical_volume_watcher.go
@@ -440,6 +440,7 @@ func reconcileLLVUpdateFunc(
 	log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] successfully got LVMLogicalVolume %s actual size before the extension", llv.Name))
 	log.Trace(fmt.Sprintf("[reconcileLLVUpdateFunc] the LV %s in VG %s actual size %s", llv.Spec.ActualLVNameOnTheNode, lvg.Spec.ActualVGNameOnTheNode, newActualSize.String()))
 
+	// need this here as a user might create the LLV with existing LV
 	updated, err := updateLLVPhaseToCreatedIfNeeded(ctx, cl, llv, newActualSize)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("[reconcileLLVUpdateFunc] unable to update the LVMLogicalVolume %s", llv.Name))

--- a/images/agent/pkg/controller/lvm_volume_group_watcher_constants.go
+++ b/images/agent/pkg/controller/lvm_volume_group_watcher_constants.go
@@ -23,31 +23,8 @@ const (
 	Failed = "Failed"
 
 	NonOperational = "NonOperational"
-	Operational    = "Operational"
 
-	delAnnotation  = "storage.deckhouse.io/sds-delete-vg"
-	nameSpaceEvent = "default"
-
-	EventActionDeleting = "Deleting"
-	EventReasonDeleting = "Deleting"
-
-	EventActionProvisioning = "Provisioning"
-	EventReasonProvisioning = "Provisioning"
-
-	EventActionCreating = "Creating"
-	EventReasonCreating = "Creating"
-
-	EventActionExtending = "Extending"
-	EventReasonExtending = "Extending"
-
-	EventActionShrinking = "Shrinking"
-	EventReasonShrinking = "Shrinking"
-
-	EventActionResizing = "Resizing"
-	EventReasonResizing = "Resizing"
-
-	EventActionReady = "Ready"
-	EventReasonReady = "Ready"
+	delAnnotation = "storage.deckhouse.io/sds-delete-vg"
 
 	LVMVolumeGroupTag = "storage.deckhouse.io/lvmVolumeGroupName"
 )


### PR DESCRIPTION
## Description
LVMVolumeGroupDiscover controller no longer deletes the resources if corresponding VG on the node was deleted. Now it turns the resource Ready state to False as VGReady condition turned false due to missed VG. 
LVMVolumeGroupWatcher controller deletes a resource, if a user annotate the resource with delete-annotation.

## Why do we need it, and what problem does it solve?
Users don't miss LVMVolumeGroup resource if corresponding VG was deleted, but can see if the resource turned to Ready false state. This behaviour prevents automatic VG creation with generated name (if VG was recreated on the node), so the work-flow becomes more reasonable and clear for the users.  

## What is the expected result?
Created LVMVolumeGroup resources got no deleted if corresponding VG was deleted on the node, but their Ready phases got False. 
If a user recreates VG on the node with special tag (so the controller can see the VG), the corresponding LVMVolumeGroup resource got its Ready phase to True as well.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
