### PR TITLE
[controller] Change type for Spec.Size field of LVMVolumeGroup and LVMLogicalVolume from Quantity to String

### DIFF
--- a/api/v1alpha1/lvm_logical_volume.go
+++ b/api/v1alpha1/lvm_logical_volume.go
@@ -39,7 +39,7 @@ type LVMLogicalVolume struct {
 type LVMLogicalVolumeSpec struct {
 	ActualLVNameOnTheNode string                     `json:"actualLVNameOnTheNode"`
 	Type                  string                     `json:"type"`
-	Size                  resource.Quantity          `json:"size"`
+	Size                  string                     `json:"size"`
 	LvmVolumeGroupName    string                     `json:"lvmVolumeGroupName"`
 	Thin                  *LVMLogicalVolumeThinSpec  `json:"thin"`
 	Thick                 *LVMLogicalVolumeThickSpec `json:"thick"`

--- a/api/v1alpha1/lvm_volume_group.go
+++ b/api/v1alpha1/lvm_volume_group.go
@@ -81,7 +81,7 @@ type LvmVolumeGroupThinPoolStatus struct {
 }
 
 type LvmVolumeGroupThinPoolSpec struct {
-	Name            string            `json:"name"`
-	Size            resource.Quantity `json:"size"`
-	AllocationLimit string            `json:"allocationLimit"`
+	Name            string `json:"name"`
+	Size            string `json:"size"`
+	AllocationLimit string `json:"allocationLimit"`
 }

--- a/crds/lvmlogicalvolume.yaml
+++ b/crds/lvmlogicalvolume.yaml
@@ -68,7 +68,7 @@ spec:
                   description: |
                     Desired LV size.
                   minLength: 1
-                  pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                  pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$|^[1-9][0-9]?%$|100%'
                 lvmVolumeGroupName:
                   type: string
                   description: |

--- a/crds/lvmvolumegroup.yaml
+++ b/crds/lvmvolumegroup.yaml
@@ -74,7 +74,7 @@ spec:
                           > This field is immutable.
                       size:
                         x-kubernetes-int-or-string: true
-                        pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                        pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$|^[1-9][0-9]?%$|100%'
                         description: |
                           The desired Thin-pool size.
                       allocationLimit:


### PR DESCRIPTION
## Description
Change the Spec.Size fields type to string to be able to specify percentage space for LV.

## Why do we need it, and what problem does it solve?
It allows autoscaling space, so LV will automatically scale if its VG or Thin-pool scales.

## What is the expected result?
Users might specify regular size or percent one.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
