### PR TITLE
[controller] Fix a block device extension

### DIFF
--- a/images/agent/pkg/controller/lvm_volume_group_watcher_func.go
+++ b/images/agent/pkg/controller/lvm_volume_group_watcher_func.go
@@ -84,6 +84,15 @@ func shouldReconcileUpdateEvent(log logger.Logger, oldLVG, newLVG *v1alpha1.LvmV
 		return true
 	}
 
+	for _, n := range newLVG.Status.Nodes {
+		for _, d := range n.Devices {
+			if !utils.AreSizesEqualWithinDelta(d.PVSize, d.DevSize, internal.ResizeDelta) {
+				log.Debug(fmt.Sprintf("[shouldLVGWatcherReconcileUpdateEvent] update event should be reconciled as the LVMVolumeGroup %s PV size is different to device size", newLVG.Name))
+				return true
+			}
+		}
+	}
+
 	return false
 }
 


### PR DESCRIPTION
## Description
Fixed a bug in which a block device extension doesn't result in auto PV extension.

## Why do we need it, and what problem does it solve?
PV and VG did not got extended if an included block device was extended.

## What is the expected result?
If a user extends a block device on the node, a PV and VG will be auto extended as well.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
