### PR TITLE
[controller] Fix a bug with labels containing spaces.

### DIFF
--- a/images/agent/src/go.mod
+++ b/images/agent/src/go.mod
@@ -40,6 +40,8 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gosimple/slug v1.14.0 // indirect
+	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/images/agent/src/go.sum
+++ b/images/agent/src/go.sum
@@ -51,6 +51,10 @@ github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gosimple/slug v1.14.0 h1:RtTL/71mJNDfpUbCOmnf/XFkzKRtD6wL6Uy+3akm4Es=
+github.com/gosimple/slug v1.14.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
+github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
+github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/images/agent/src/internal/const.go
+++ b/images/agent/src/internal/const.go
@@ -49,6 +49,26 @@ const (
 	ReasonTerminating      = "Terminating"
 	ReasonScanFailed       = "ScanFailed"
 	ReasonUpdated          = "Updated"
+
+	BlockDeviceLabelPrefix = "status.blockdevice.storage.deckhouse.io"
+
+	MetadataNameLabelKey = "kubernetes.io/metadata.name"
+	HostNameLabelKey     = "kubernetes.io/hostname"
+
+	BlockDeviceTypeLabelKey               = BlockDeviceLabelPrefix + "/type"
+	BlockDeviceFSTypeLabelKey             = BlockDeviceLabelPrefix + "/fstype"
+	BlockDevicePVUUIDLabelKey             = BlockDeviceLabelPrefix + "/pvuuid"
+	BlockDeviceVGUUIDLabelKey             = BlockDeviceLabelPrefix + "/vguuid"
+	BlockDevicePartUUIDLabelKey           = BlockDeviceLabelPrefix + "/partuuid"
+	BlockDeviceLVMVolumeGroupNameLabelKey = BlockDeviceLabelPrefix + "/lvmvolumegroupname"
+	BlockDeviceActualVGNameLabelKey       = BlockDeviceLabelPrefix + "/actualvgnameonthenode"
+	BlockDeviceWWNLabelKey                = BlockDeviceLabelPrefix + "/wwn"
+	BlockDeviceSerialLabelKey             = BlockDeviceLabelPrefix + "/serial"
+	BlockDeviceSizeLabelKey               = BlockDeviceLabelPrefix + "/size"
+	BlockDeviceModelLabelKey              = BlockDeviceLabelPrefix + "/model"
+	BlockDeviceRotaLabelKey               = BlockDeviceLabelPrefix + "/rota"
+	BlockDeviceHotPlugLabelKey            = BlockDeviceLabelPrefix + "/hotplug"
+	BlockDeviceMachineIDLabelKey          = BlockDeviceLabelPrefix + "/machineid"
 )
 
 var (

--- a/images/agent/src/pkg/controller/block_device.go
+++ b/images/agent/src/pkg/controller/block_device.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
+	"github.com/gosimple/slug"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -548,22 +549,23 @@ func ConfigureBlockDeviceLabels(blockDevice v1alpha1.BlockDevice) map[string]str
 		labels[key] = value
 	}
 
-	labels[internal.MetadataNameLabelKey] = strings.ReplaceAll(blockDevice.ObjectMeta.Name, " ", "_")
-	labels[internal.HostNameLabelKey] = strings.ReplaceAll(blockDevice.Status.NodeName, " ", "_")
-	labels[internal.BlockDeviceTypeLabelKey] = strings.ReplaceAll(blockDevice.Status.Type, " ", "_")
-	labels[internal.BlockDeviceFSTypeLabelKey] = strings.ReplaceAll(blockDevice.Status.FsType, " ", "_")
+	slug.Lowercase = false
+	labels[internal.MetadataNameLabelKey] = slug.Make(blockDevice.ObjectMeta.Name)
+	labels[internal.HostNameLabelKey] = slug.Make(blockDevice.Status.NodeName)
+	labels[internal.BlockDeviceTypeLabelKey] = slug.Make(blockDevice.Status.Type)
+	labels[internal.BlockDeviceFSTypeLabelKey] = slug.Make(blockDevice.Status.FsType)
 	labels[internal.BlockDevicePVUUIDLabelKey] = blockDevice.Status.PVUuid
 	labels[internal.BlockDeviceVGUUIDLabelKey] = blockDevice.Status.VGUuid
 	labels[internal.BlockDevicePartUUIDLabelKey] = blockDevice.Status.PartUUID
-	labels[internal.BlockDeviceLVMVolumeGroupNameLabelKey] = strings.ReplaceAll(blockDevice.Status.LvmVolumeGroupName, " ", "_")
-	labels[internal.BlockDeviceActualVGNameLabelKey] = strings.ReplaceAll(blockDevice.Status.ActualVGNameOnTheNode, " ", "_")
-	labels[internal.BlockDeviceWWNLabelKey] = strings.ReplaceAll(blockDevice.Status.Wwn, " ", "_")
-	labels[internal.BlockDeviceSerialLabelKey] = strings.ReplaceAll(blockDevice.Status.Serial, " ", "_")
+	labels[internal.BlockDeviceLVMVolumeGroupNameLabelKey] = slug.Make(blockDevice.Status.LvmVolumeGroupName)
+	labels[internal.BlockDeviceActualVGNameLabelKey] = slug.Make(blockDevice.Status.ActualVGNameOnTheNode)
+	labels[internal.BlockDeviceWWNLabelKey] = slug.Make(blockDevice.Status.Wwn)
+	labels[internal.BlockDeviceSerialLabelKey] = slug.Make(blockDevice.Status.Serial)
 	labels[internal.BlockDeviceSizeLabelKey] = blockDevice.Status.Size.String()
-	labels[internal.BlockDeviceModelLabelKey] = strings.ReplaceAll(blockDevice.Status.Model, " ", "_")
+	labels[internal.BlockDeviceModelLabelKey] = slug.Make(blockDevice.Status.Model)
 	labels[internal.BlockDeviceRotaLabelKey] = strconv.FormatBool(blockDevice.Status.Rota)
 	labels[internal.BlockDeviceHotPlugLabelKey] = strconv.FormatBool(blockDevice.Status.HotPlug)
-	labels[internal.BlockDeviceMachineIDLabelKey] = strings.ReplaceAll(blockDevice.Status.MachineID, " ", "_")
+	labels[internal.BlockDeviceMachineIDLabelKey] = slug.Make(blockDevice.Status.MachineID)
 
 	return labels
 }

--- a/images/agent/src/pkg/controller/block_device.go
+++ b/images/agent/src/pkg/controller/block_device.go
@@ -44,8 +44,7 @@ import (
 )
 
 const (
-	BlockDeviceCtrlName    = "block-device-controller"
-	BlockDeviceLabelPrefix = "status.blockdevice.storage.deckhouse.io"
+	BlockDeviceCtrlName = "block-device-controller"
 )
 
 func RunBlockDeviceController(
@@ -549,22 +548,22 @@ func ConfigureBlockDeviceLabels(blockDevice v1alpha1.BlockDevice) map[string]str
 		labels[key] = value
 	}
 
-	labels["kubernetes.io/metadata.name"] = blockDevice.ObjectMeta.Name
-	labels["kubernetes.io/hostname"] = blockDevice.Status.NodeName
-	labels[BlockDeviceLabelPrefix+"/type"] = blockDevice.Status.Type
-	labels[BlockDeviceLabelPrefix+"/fstype"] = blockDevice.Status.FsType
-	labels[BlockDeviceLabelPrefix+"/pvuuid"] = blockDevice.Status.PVUuid
-	labels[BlockDeviceLabelPrefix+"/vguuid"] = blockDevice.Status.VGUuid
-	labels[BlockDeviceLabelPrefix+"/partuuid"] = blockDevice.Status.PartUUID
-	labels[BlockDeviceLabelPrefix+"/lvmvolumegroupname"] = blockDevice.Status.LvmVolumeGroupName
-	labels[BlockDeviceLabelPrefix+"/actualvgnameonthenode"] = blockDevice.Status.ActualVGNameOnTheNode
-	labels[BlockDeviceLabelPrefix+"/wwn"] = blockDevice.Status.Wwn
-	labels[BlockDeviceLabelPrefix+"/serial"] = blockDevice.Status.Serial
-	labels[BlockDeviceLabelPrefix+"/size"] = blockDevice.Status.Size.String()
-	labels[BlockDeviceLabelPrefix+"/model"] = blockDevice.Status.Model
-	labels[BlockDeviceLabelPrefix+"/rota"] = strconv.FormatBool(blockDevice.Status.Rota)
-	labels[BlockDeviceLabelPrefix+"/hotplug"] = strconv.FormatBool(blockDevice.Status.HotPlug)
-	labels[BlockDeviceLabelPrefix+"/machineid"] = blockDevice.Status.MachineID
+	labels[internal.MetadataNameLabelKey] = strings.ReplaceAll(blockDevice.ObjectMeta.Name, " ", "_")
+	labels[internal.HostNameLabelKey] = strings.ReplaceAll(blockDevice.Status.NodeName, " ", "_")
+	labels[internal.BlockDeviceTypeLabelKey] = strings.ReplaceAll(blockDevice.Status.Type, " ", "_")
+	labels[internal.BlockDeviceFSTypeLabelKey] = strings.ReplaceAll(blockDevice.Status.FsType, " ", "_")
+	labels[internal.BlockDevicePVUUIDLabelKey] = blockDevice.Status.PVUuid
+	labels[internal.BlockDeviceVGUUIDLabelKey] = blockDevice.Status.VGUuid
+	labels[internal.BlockDevicePartUUIDLabelKey] = blockDevice.Status.PartUUID
+	labels[internal.BlockDeviceLVMVolumeGroupNameLabelKey] = strings.ReplaceAll(blockDevice.Status.LvmVolumeGroupName, " ", "_")
+	labels[internal.BlockDeviceActualVGNameLabelKey] = strings.ReplaceAll(blockDevice.Status.ActualVGNameOnTheNode, " ", "_")
+	labels[internal.BlockDeviceWWNLabelKey] = strings.ReplaceAll(blockDevice.Status.Wwn, " ", "_")
+	labels[internal.BlockDeviceSerialLabelKey] = strings.ReplaceAll(blockDevice.Status.Serial, " ", "_")
+	labels[internal.BlockDeviceSizeLabelKey] = blockDevice.Status.Size.String()
+	labels[internal.BlockDeviceModelLabelKey] = strings.ReplaceAll(blockDevice.Status.Model, " ", "_")
+	labels[internal.BlockDeviceRotaLabelKey] = strconv.FormatBool(blockDevice.Status.Rota)
+	labels[internal.BlockDeviceHotPlugLabelKey] = strconv.FormatBool(blockDevice.Status.HotPlug)
+	labels[internal.BlockDeviceMachineIDLabelKey] = strings.ReplaceAll(blockDevice.Status.MachineID, " ", "_")
 
 	return labels
 }

--- a/images/agent/src/pkg/controller/block_device_test.go
+++ b/images/agent/src/pkg/controller/block_device_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
@@ -334,7 +335,7 @@ func TestBlockDeviceCtrl(t *testing.T) {
 				Serial:                "testSERIAL",
 				Path:                  "testPATH",
 				Size:                  resource.MustParse("0"),
-				Model:                 "testMODEL",
+				Model:                 "Very good model-1241",
 				Rota:                  false,
 				HotPlug:               false,
 				MachineID:             "testMACHINE",
@@ -346,24 +347,24 @@ func TestBlockDeviceCtrl(t *testing.T) {
 		}
 
 		expectedLabels := map[string]string{
-			"kubernetes.io/metadata.name":                     blockDevice.ObjectMeta.Name,
-			"kubernetes.io/hostname":                          blockDevice.Status.NodeName,
-			BlockDeviceLabelPrefix + "/type":                  blockDevice.Status.Type,
-			BlockDeviceLabelPrefix + "/fstype":                blockDevice.Status.FsType,
-			BlockDeviceLabelPrefix + "/pvuuid":                blockDevice.Status.PVUuid,
-			BlockDeviceLabelPrefix + "/vguuid":                blockDevice.Status.VGUuid,
-			BlockDeviceLabelPrefix + "/partuuid":              blockDevice.Status.PartUUID,
-			BlockDeviceLabelPrefix + "/lvmvolumegroupname":    blockDevice.Status.LvmVolumeGroupName,
-			BlockDeviceLabelPrefix + "/actualvgnameonthenode": blockDevice.Status.ActualVGNameOnTheNode,
-			BlockDeviceLabelPrefix + "/wwn":                   blockDevice.Status.Wwn,
-			BlockDeviceLabelPrefix + "/serial":                blockDevice.Status.Serial,
-			BlockDeviceLabelPrefix + "/size":                  blockDevice.Status.Size.String(),
-			BlockDeviceLabelPrefix + "/model":                 blockDevice.Status.Model,
-			BlockDeviceLabelPrefix + "/rota":                  strconv.FormatBool(blockDevice.Status.Rota),
-			BlockDeviceLabelPrefix + "/hotplug":               strconv.FormatBool(blockDevice.Status.HotPlug),
-			BlockDeviceLabelPrefix + "/machineid":             blockDevice.Status.MachineID,
-			"some-custom-label1":                              "v",
-			"some-custom-label2":                              "v",
+			internal.MetadataNameLabelKey:                  blockDevice.ObjectMeta.Name,
+			internal.HostNameLabelKey:                      blockDevice.Status.NodeName,
+			internal.BlockDeviceTypeLabelKey:               blockDevice.Status.Type,
+			internal.BlockDeviceFSTypeLabelKey:             blockDevice.Status.FsType,
+			internal.BlockDevicePVUUIDLabelKey:             blockDevice.Status.PVUuid,
+			internal.BlockDeviceVGUUIDLabelKey:             blockDevice.Status.VGUuid,
+			internal.BlockDevicePartUUIDLabelKey:           blockDevice.Status.PartUUID,
+			internal.BlockDeviceLVMVolumeGroupNameLabelKey: blockDevice.Status.LvmVolumeGroupName,
+			internal.BlockDeviceActualVGNameLabelKey:       blockDevice.Status.ActualVGNameOnTheNode,
+			internal.BlockDeviceWWNLabelKey:                blockDevice.Status.Wwn,
+			internal.BlockDeviceSerialLabelKey:             blockDevice.Status.Serial,
+			internal.BlockDeviceSizeLabelKey:               blockDevice.Status.Size.String(),
+			internal.BlockDeviceModelLabelKey:              strings.ReplaceAll(blockDevice.Status.Model, " ", "_"),
+			internal.BlockDeviceRotaLabelKey:               strconv.FormatBool(blockDevice.Status.Rota),
+			internal.BlockDeviceHotPlugLabelKey:            strconv.FormatBool(blockDevice.Status.HotPlug),
+			internal.BlockDeviceMachineIDLabelKey:          blockDevice.Status.MachineID,
+			"some-custom-label1":                           "v",
+			"some-custom-label2":                           "v",
 		}
 
 		assert.Equal(t, expectedLabels, ConfigureBlockDeviceLabels(blockDevice))

--- a/images/agent/src/pkg/controller/block_device_test.go
+++ b/images/agent/src/pkg/controller/block_device_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
@@ -359,7 +358,7 @@ func TestBlockDeviceCtrl(t *testing.T) {
 			internal.BlockDeviceWWNLabelKey:                blockDevice.Status.Wwn,
 			internal.BlockDeviceSerialLabelKey:             blockDevice.Status.Serial,
 			internal.BlockDeviceSizeLabelKey:               blockDevice.Status.Size.String(),
-			internal.BlockDeviceModelLabelKey:              strings.ReplaceAll(blockDevice.Status.Model, " ", "_"),
+			internal.BlockDeviceModelLabelKey:              "Very-good-model-1241",
 			internal.BlockDeviceRotaLabelKey:               strconv.FormatBool(blockDevice.Status.Rota),
 			internal.BlockDeviceHotPlugLabelKey:            strconv.FormatBool(blockDevice.Status.HotPlug),
 			internal.BlockDeviceMachineIDLabelKey:          blockDevice.Status.MachineID,

--- a/images/agent/src/pkg/controller/controller_reconcile_test.go
+++ b/images/agent/src/pkg/controller/controller_reconcile_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Storage Controller", func() {
 			Path:                  deviceName,
 			Size:                  resource.Quantity{},
 			Rota:                  false,
-			Model:                 "",
+			Model:                 "very good-model",
 			Name:                  "/dev/sda",
 			HotPlug:               false,
 			KName:                 "/dev/sda",


### PR DESCRIPTION
## Description
As some of BlockDevice status values might have spaces within themselves, and the CR labels do not support spaces, we have to replace them with "-" sign with slug pkg.

## Why do we need it, and what problem does it solve?
Because of the bug some of BlockDevice resources are not able to be created.

## What is the expected result?
Any BlockDevice resource might be created.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
