### PR TITLE
[controller] Fix sds-health-watcher controller's incorrect used nodes count 

### DIFF
--- a/images/agent/src/pkg/controller/lvm_volume_group_discover.go
+++ b/images/agent/src/pkg/controller/lvm_volume_group_discover.go
@@ -960,8 +960,9 @@ func convertSpecThinPools(thinPools map[string]resource.Quantity) []v1alpha1.Lvm
 	result := make([]v1alpha1.LvmVolumeGroupThinPoolSpec, 0, len(thinPools))
 	for name, size := range thinPools {
 		result = append(result, v1alpha1.LvmVolumeGroupThinPoolSpec{
-			Name: name,
-			Size: size.String(),
+			Name:            name,
+			AllocationLimit: "150%",
+			Size:            size.String(),
 		})
 	}
 

--- a/images/sds-health-watcher-controller/src/pkg/controller/sds_infra_watcher.go
+++ b/images/sds-health-watcher-controller/src/pkg/controller/sds_infra_watcher.go
@@ -73,11 +73,11 @@ func RunSdsInfraWatcher(
 
 			log.Info("[RunSdsInfraWatcher] LVMVolumeGroups found. Starts to check their health")
 			log.Info("[RunSdsInfraWatcher] check if every LVMVolumeGroup node does exist")
-			lvgNodes := getNodeNamesFromLVGs(lvgs)
-			log.Trace(fmt.Sprintf("[RunSdsInfraWatcher] used nodes %v", lvgNodes))
+			lvgNodeNames := getNodeNamesFromLVGs(lvgs)
+			log.Trace(fmt.Sprintf("[RunSdsInfraWatcher] used nodes %v", lvgNodeNames))
 
 			log.Debug("[RunSdsInfraWatcher] tries to collect nodes used by LVMVolumeGroups")
-			usedNodes, missedNodes, err := getNodesByNames(ctx, cl, lvgNodes)
+			usedNodes, missedNodes, err := getNodesByNames(ctx, cl, lvgNodeNames)
 			if err != nil {
 				log.Error(err, "[RunSdsInfraWatcher] unable to get nodes")
 				continue

--- a/images/sds-health-watcher-controller/src/pkg/controller/sds_infra_watcher_funcs.go
+++ b/images/sds-health-watcher-controller/src/pkg/controller/sds_infra_watcher_funcs.go
@@ -116,7 +116,7 @@ func findLVMVolumeGroupsByNodeNames(lvgs map[string]v1alpha1.LvmVolumeGroup, nod
 	return result
 }
 
-func getNodesByNames(ctx context.Context, cl client.Client, names []string) (map[string]v1.Node, []string, error) {
+func getNodesByNames(ctx context.Context, cl client.Client, lvgNodeNames []string) (map[string]v1.Node, []string, error) {
 	nodeList := &v1.NodeList{}
 
 	err := cl.List(ctx, nodeList)
@@ -129,14 +129,16 @@ func getNodesByNames(ctx context.Context, cl client.Client, names []string) (map
 		nodes[n.Name] = n
 	}
 
-	missedNodes := make([]string, 0, len(names))
-	for _, name := range names {
+	missedNodes := make([]string, 0, len(lvgNodeNames))
+	usedNodes := make(map[string]v1.Node, len(lvgNodeNames))
+	for _, name := range lvgNodeNames {
 		if _, exist := nodes[name]; !exist {
 			missedNodes = append(missedNodes, name)
 		}
+		usedNodes[name] = nodes[name]
 	}
 
-	return nodes, missedNodes, nil
+	return usedNodes, missedNodes, nil
 }
 
 func getNodeNamesFromLVGs(lvgs map[string]v1alpha1.LvmVolumeGroup) []string {


### PR DESCRIPTION
## Description
Fixed the way the controller count the nodes used by LVMVolumeGroup resources

## Why do we need it, and what problem does it solve?
It prevents the case when the controller gets some nodes without a LVMVolumeGroup resource, but still used to count as there should be a sds-node-configurator pod on the node.

## What is the expected result?
The controller operates only with LVMVolumeGroup used nodes.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
