### PR TITLE
[controller] Filter loop devices

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -15,6 +15,9 @@ on:
   push:
     branches:
       - main
+  # make this job as dependency for trivy_image_check workflow
+  # https://stackoverflow.com/a/71489231
+  workflow_call:
 
 jobs:
   dev_setup_build:

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -15,6 +15,7 @@ jobs:
   test:
     name: Trivy images check
     runs-on: [self-hosted, regular]
+    needs: dev_setup_build
 
     steps:
       - uses: actions/checkout@v4
@@ -53,9 +54,9 @@ jobs:
           exit_code=0
           image_name=$MODULES_MODULE_SOURCE/$MODULES_MODULE_NAME
           image_name_with_tag=$MODULES_MODULE_SOURCE/$MODULES_MODULE_NAME:pr$PR_NUMBER
-          
+
           crane_output=$(crane export $image_name_with_tag | tar -xOf - images_digests.json | jq -c 'to_entries[]')
-          
+
           while read -r item; do
             key=$(echo "$item" | jq -r '.key')
             value=$(echo "$item" | jq -r '.value')

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   build_dev:
     uses: ./.github/workflows/build_dev.yml
+    secrets: inherit
   test:
     name: Trivy images check
     runs-on: [self-hosted, regular]

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -12,10 +12,12 @@ on:
   pull_request:
 
 jobs:
+  build_dev:
+    uses: ./.github/workflows/build_dev.yml
   test:
     name: Trivy images check
     runs-on: [self-hosted, regular]
-    needs: dev_setup_build
+    needs: [build_dev]
 
     steps:
       - uses: actions/checkout@v4

--- a/templates/agent/bashible-filter-loop-devices.yaml
+++ b/templates/agent/bashible-filter-loop-devices.yaml
@@ -1,0 +1,63 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: NodeGroupConfiguration
+metadata:
+  name: add-loop-devices-to-blacklist.sh
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+spec:
+  weight: 100
+  nodeGroups: ["*"]
+  bundles: ["*"]
+  content: |
+    # Copyright 2024 Flant JSC
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    # Loop devices should not be queried by the LVM and multipath commands.
+    # So we add loop devices into blacklist for multipath and configure
+    # global_filter in lvm.conf for them
+
+    bb-event-on 'bb-sync-file-changed' '_on_multipath_config_changed'
+    _on_multipath_config_changed() {
+      if systemctl is-enabled --quiet multipathd 2>/dev/null; then
+        systemctl reload multipathd
+      fi
+    }
+
+    configure_lvm() {
+      command -V lvmconfig >/dev/null 2>&1 || return 0
+      test -f /etc/lvm/lvm.conf || return 0
+      current_global_filter=$(lvmconfig devices/global_filter 2>/dev/null || true)
+
+      case "${current_global_filter}" in
+        '' ) new_global_filter='["r|^/dev/loop[0-9]+|"]' ;;
+        */dev/loop*) return 0 ;;
+        'global_filter="'*) new_global_filter='["r|^/dev/loop[0-9]+|",'${current_global_filter#*=}] ;;
+        'global_filter=['*) new_global_filter='["r|^/dev/loop[0-9]+|",'${current_global_filter#*[} ;;
+        *) echo error parsing global_filter >&2; return 1 ;;
+      esac
+
+      lvmconfig --config "devices/global_filter=$new_global_filter" --withcomments --merge > /etc/lvm/lvm.conf.$$
+      mv /etc/lvm/lvm.conf.$$ /etc/lvm/lvm.conf
+    }
+
+    configure_multipath() {
+      mkdir -p /etc/multipath/conf.d
+      bb-sync-file /etc/multipath/conf.d/loop-blacklist.conf - <<EOF
+    blacklist {
+        devnode "^loop[0-9]+"
+    }
+    EOF
+    }
+
+    configure_lvm
+    configure_multipath

--- a/templates/agent/bashible-filter-loop-devices.yaml
+++ b/templates/agent/bashible-filter-loop-devices.yaml
@@ -4,7 +4,7 @@ metadata:
   name: add-loop-devices-to-blacklist.sh
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 spec:
-  weight: 100
+  weight: 99
   nodeGroups: ["*"]
   bundles: ["*"]
   content: |

--- a/templates/agent/bashible-filter-loop-devices.yaml
+++ b/templates/agent/bashible-filter-loop-devices.yaml
@@ -4,7 +4,7 @@ metadata:
   name: add-loop-devices-to-blacklist.sh
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 spec:
-  weight: 99
+  weight: 100
   nodeGroups: ["*"]
   bundles: ["*"]
   content: |

--- a/templates/agent/bashible-filter-loop-devices.yaml
+++ b/templates/agent/bashible-filter-loop-devices.yaml
@@ -59,5 +59,6 @@ spec:
     EOF
     }
 
+    bb-log-info "Blacklisting loop-devices"
     configure_lvm
     configure_multipath

--- a/templates/agent/nodegroupconfiguration-blacklist-loop-devices.yaml
+++ b/templates/agent/nodegroupconfiguration-blacklist-loop-devices.yaml
@@ -59,6 +59,5 @@ spec:
     EOF
     }
 
-    bb-log-info "Blacklisting loop-devices"
     configure_lvm
     configure_multipath

--- a/templates/agent/nodegroupconfiguration-blacklist-loop-devices.yaml
+++ b/templates/agent/nodegroupconfiguration-blacklist-loop-devices.yaml
@@ -1,7 +1,7 @@
 apiVersion: deckhouse.io/v1alpha1
 kind: NodeGroupConfiguration
 metadata:
-  name: add-loop-devices-to-blacklist.sh
+  name: sds-node-configurator-add-loop-devices-to-blacklist.sh
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 spec:
   weight: 100


### PR DESCRIPTION
## Description
Blacklist (filter out) 'loop' devices from LVM and Multipath utilities (like pvscan, lvscan, etc)
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We have LVM devices in VMs (KubeVirt) and we do not want the contents of these devices (in the VMs) to be scanned by the physical host.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Add `global_filter="r|^/dev/loop[0-9]+|"` in `/etc/lvm/lvm.conf` on each node.
Also add `/etc/multipath/conf.d/loop-blacklist.conf` with blacklist-filter for multipath.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
