### PR TITLE
[controller] Fix the migration_script bug with none LVMVolumeGroups labels

### DIFF
--- a/hooks/convert_bd_names_to_selector.py
+++ b/hooks/convert_bd_names_to_selector.py
@@ -253,13 +253,13 @@ def main(ctx: hook.Context):
                               'name':
                                   lvg['metadata'][
                                       'name'],
-                              'labels':
-                                  lvg['metadata'][
-                                      'labels'],
                               'finalizers':
                                   lvg['metadata'][
                                       'finalizers']},
                           'spec': lvg['spec']}
+            if 'labels' in lvg['metadata']:
+                lvg_backup['metadata']['labels'] = lvg['metadata']['labels']
+
             lvg_backup['metadata']['labels']['kubernetes.io/hostname'] = lvg['status']['nodes'][0]['name']
             lvg_backup['metadata']['labels'][migration_completed_label] = 'false'
             try:


### PR DESCRIPTION
## Description
Fixed the error of migration_script, if some LVMVolumeGroup resource does not have any label.

## Why do we need it, and what problem does it solve?
If a LVMVolumeGroup resource does not have any label, the migration script results into error every time and blocks sds-node-configurator deploying process.

## What is the expected result?
Even if a LVMVolumeGroup resource does not have any label, the script and migration go fine.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
