### PR TITLE
[internal] Fix possible labels miss

### DIFF
--- a/hooks/convert_bd_names_to_selector.py
+++ b/hooks/convert_bd_names_to_selector.py
@@ -253,6 +253,7 @@ def main(ctx: hook.Context):
                               'name':
                                   lvg['metadata'][
                                       'name'],
+                              'labels': {},
                               'finalizers':
                                   lvg['metadata'][
                                       'finalizers']},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

There can be situation while LvmVolumeGroup migration when labels is missing, so hook will be failed

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This PR fixes this situation.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Working migration hook.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
