### PR TITLE
[docs] Fix indentation for the spec.actualVGNameOnTheNode field

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -81,7 +81,7 @@ There are two ways to create an `LVMVolumeGroup` resource:
           values:
           - dev-07ad52cef2348996b72db262011f1b5f896bb68f
           - dev-e90e8915902bd6c371e59f89254c0fd644126da7
-    actualVGNameOnTheNode: "vg-0"
+      actualVGNameOnTheNode: "vg-0"
     ```
 
   ```yaml
@@ -96,7 +96,7 @@ There are two ways to create an `LVMVolumeGroup` resource:
       blockDeviceSelector:
         matchLabels:
           kubernetes.io/hostname: node-0
-    actualVGNameOnTheNode: "vg-0"
+      actualVGNameOnTheNode: "vg-0"
     ```
   
   * An example of a resource for creating a local `LVM Volume Group` and a `Thin-pool` on it from multiple `BlockDevices`:

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -81,7 +81,7 @@ description: Использование и примеры работы конт�
           values:
           - dev-07ad52cef2348996b72db262011f1b5f896bb68f
           - dev-e90e8915902bd6c371e59f89254c0fd644126da7
-    actualVGNameOnTheNode: "vg-0"
+      actualVGNameOnTheNode: "vg-0"
     ```
 
     ```yaml
@@ -96,7 +96,7 @@ description: Использование и примеры работы конт�
       blockDeviceSelector:
         matchLabels:
           kubernetes.io/hostname: node-0
-    actualVGNameOnTheNode: "vg-0"
+      actualVGNameOnTheNode: "vg-0"
     ```
 
   * Пример ресурса для создания локальной `LVM Volume Group` и `Thin-pool` на ней из нескольких `BlockDevice`:


### PR DESCRIPTION
## Description
Fixed indentation for the spec.actualVGNameOnTheNode in the LVMVolumeGroup resource listing

## Why do we need it, and what problem does it solve?
When trying to apply a resource from the module documentation, the LVMVolumeGroup resource is not validated and is not created. This patch fixes this issue