### PR TITLE
[controller] Limit the length of label values for `BlockDevice` resources to 63 symbols

### DIFF
--- a/images/agent/src/internal/controller/bd/discoverer.go
+++ b/images/agent/src/internal/controller/bd/discoverer.go
@@ -588,6 +588,7 @@ func configureBlockDeviceLabels(blockDevice v1alpha1.BlockDevice) map[string]str
 	}
 
 	slug.Lowercase = false
+	slug.MaxLength = 63
 	lbls[internal.MetadataNameLabelKey] = slug.Make(blockDevice.ObjectMeta.Name)
 	lbls[internal.HostNameLabelKey] = slug.Make(blockDevice.Status.NodeName)
 	lbls[internal.BlockDeviceTypeLabelKey] = slug.Make(blockDevice.Status.Type)

--- a/images/agent/src/internal/controller/bd/discoverer.go
+++ b/images/agent/src/internal/controller/bd/discoverer.go
@@ -589,6 +589,7 @@ func configureBlockDeviceLabels(blockDevice v1alpha1.BlockDevice) map[string]str
 
 	slug.Lowercase = false
 	slug.MaxLength = 63
+	slug.EnableSmartTruncate = false
 	lbls[internal.MetadataNameLabelKey] = slug.Make(blockDevice.ObjectMeta.Name)
 	lbls[internal.HostNameLabelKey] = slug.Make(blockDevice.Status.NodeName)
 	lbls[internal.BlockDeviceTypeLabelKey] = slug.Make(blockDevice.Status.Type)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR limits the length of label values for `BlockDevice` resources to 63 symbols. If a label value exceeds this limit, it is truncated to comply with Kubernetes restrictions, as Kubernetes does not allow label values longer than 63 characters.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Kubernetes enforces a strict 63-character limit for label values. Without this change, `BlockDevice` resources with label values exceeding this limit could cause errors during resource creation or updates. By truncating values, this fix ensures compliance and prevents such errors.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Label values for `BlockDevice` resources are truncated to 63 characters if they exceed the limit.
- Successful creation and management of `BlockDevice` resources, even when original label values are longer than 63 characters.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
