### PR TITLE
[ci] Update snc api package versions in images

### DIFF
--- a/images/agent/src/go.mod
+++ b/images/agent/src/go.mod
@@ -3,7 +3,7 @@ module agent
 go 1.22.2
 
 require (
-	github.com/deckhouse/sds-node-configurator/api v0.0.0-20241104200552-c02b44d9b6a0
+	github.com/deckhouse/sds-node-configurator/api v0.0.0-20241205120718-db6ffba1689b
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
 	github.com/gosimple/slug v1.14.0

--- a/images/sds-health-watcher-controller/src/go.mod
+++ b/images/sds-health-watcher-controller/src/go.mod
@@ -4,7 +4,7 @@ go 1.22.3
 
 require (
 	github.com/cloudflare/cfssl v1.5.0
-	github.com/deckhouse/sds-node-configurator/api v0.0.0-20241104200552-c02b44d9b6a0
+	github.com/deckhouse/sds-node-configurator/api v0.0.0-20241205120718-db6ffba1689b
 	github.com/go-logr/logr v1.4.2
 	github.com/prometheus/client_golang v1.19.1
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
## Description
Developing in two separate go modules simultaneously requires this step to be done after the merge has happened in the base package

## Why do we need it, and what problem does it solve?
This fixes CI step failure

## What is the expected result?
Build step to become green
