### PR TITLE
[internal] Backport: Fix access to missing finalizers, always add default finalizer

### DIFF
--- a/hooks/convert_bd_names_to_selector.py
+++ b/hooks/convert_bd_names_to_selector.py
@@ -248,18 +248,18 @@ def main(ctx: hook.Context):
         print(f"{migrate_script} starts to create backups and add 'kubernetes.io/hostname' to store the node name")
         for lvg in lvg_list.get('items', []):
             lvg_backup = {'apiVersion': lvg['apiVersion'],
-                          'kind': 'LvmVolumeGroupBackup',
-                          'metadata': {
-                              'name':
-                                  lvg['metadata'][
-                                      'name'],
-                              'labels': {},
-                              'finalizers':
-                                  lvg['metadata'][
-                                      'finalizers']},
-                          'spec': lvg['spec']}
+                            'kind': 'LvmVolumeGroupBackup',
+                            'metadata': {
+                                'name':
+                                    lvg['metadata'][
+                                        'name'],
+                                'labels': {},
+                                'finalizers': lvg['metadata'].get('finalizers', [])},
+                            'spec': lvg['spec']}
             if 'labels' in lvg['metadata']:
                 lvg_backup['metadata']['labels'] = lvg['metadata']['labels']
+            if default_finalizer not in lvg_backup['metadata']['finalizers']:
+                lvg_backup['metadata']['finalizers'].append('storage.deckhouse.io/sds-node-configurator')
 
             lvg_backup['metadata']['labels']['kubernetes.io/hostname'] = lvg['status']['nodes'][0]['name']
             lvg_backup['metadata']['labels'][migration_completed_label] = 'false'

--- a/hooks/convert_bd_names_to_selector.py
+++ b/hooks/convert_bd_names_to_selector.py
@@ -247,15 +247,16 @@ def main(ctx: hook.Context):
         # we store the using node name as a label due to we will lose the status for the backup resource
         print(f"{migrate_script} starts to create backups and add 'kubernetes.io/hostname' to store the node name")
         for lvg in lvg_list.get('items', []):
-            lvg_backup = {'apiVersion': lvg['apiVersion'],
-                            'kind': 'LvmVolumeGroupBackup',
-                            'metadata': {
-                                'name':
-                                    lvg['metadata'][
-                                        'name'],
-                                'labels': {},
-                                'finalizers': lvg['metadata'].get('finalizers', [])},
-                            'spec': lvg['spec']}
+            lvg_backup = {
+                'apiVersion': lvg['apiVersion'],
+                'kind': 'LvmVolumeGroupBackup',
+                'metadata': {
+                    'name': lvg['metadata']['name'],
+                    'labels': {},
+                    'finalizers': lvg['metadata'].get('finalizers', [])
+                },
+                'spec': lvg['spec']
+            }
             if 'labels' in lvg['metadata']:
                 lvg_backup['metadata']['labels'] = lvg['metadata']['labels']
             if default_finalizer not in lvg_backup['metadata']['finalizers']:

--- a/hooks/convert_bd_names_to_selector.py
+++ b/hooks/convert_bd_names_to_selector.py
@@ -259,8 +259,9 @@ def main(ctx: hook.Context):
             }
             if 'labels' in lvg['metadata']:
                 lvg_backup['metadata']['labels'] = lvg['metadata']['labels']
+            default_finalizer = 'storage.deckhouse.io/sds-node-configurator'
             if default_finalizer not in lvg_backup['metadata']['finalizers']:
-                lvg_backup['metadata']['finalizers'].append('storage.deckhouse.io/sds-node-configurator')
+                lvg_backup['metadata']['finalizers'].append(default_finalizer)
 
             lvg_backup['metadata']['labels']['kubernetes.io/hostname'] = lvg['status']['nodes'][0]['name']
             lvg_backup['metadata']['labels'][migration_completed_label] = 'false'


### PR DESCRIPTION
## Description

This is backport of the fix to v0.4 branch.

Fixes `convert_bd_names_to_selector.py` to handle LVGs without finalizers.

## Why do we need it, and what problem does it solve?
Client upgrading from <=0.2.3 to >=0.4.0 may see errors in `convert_bd_names_to_selector.py` related to LVG finalizers being empty. After the current change, script will handle this case properly and add the default finalizer, if it doesn't exist.

## What is the expected result?
- clients with errors will update to current fix and see errors are gone
- LVGs without the default finalizer will have one after the migration

## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.
