### PR TITLE
[internal] Migrate to ALT P11

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -9,14 +9,17 @@ env:
   MODULES_REGISTRY_PASSWORD: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
   SOURCE_REPO: "${{ secrets.SOURCE_REPO }}"
 
+
+
 on:
-  pull_request:
+  #pull_request:
   push:
     branches:
       - main
   # make this job as dependency for trivy_image_check workflow
   # https://stackoverflow.com/a/71489231
   workflow_call:
+
 
 jobs:
   dev_setup_build:

--- a/images/agent/src/go.mod
+++ b/images/agent/src/go.mod
@@ -3,7 +3,7 @@ module agent
 go 1.22.2
 
 require (
-	github.com/deckhouse/sds-node-configurator/api v0.0.0-20241205120718-db6ffba1689b
+	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
 	github.com/gosimple/slug v1.14.0

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -1,4 +1,5 @@
-{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic" }}
+{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic" }}
+#{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic" }}
 {{ $UTIL_LINUX_VERSION := "2.39.3" }}
 
 # Do not remove. It's used in external tests.

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic /lib64/ld-linux-aarch64.so.1" }}
+{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic /usr/lib/x86_64-linux-gnu/sys-root/lib64/ld-linux-x86-64.so.2" }}
 #{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic" }}
 {{ $UTIL_LINUX_VERSION := "2.39.3" }}
 
@@ -76,9 +76,9 @@ shell:
   - cp /lib64/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1
   - cp /lib64/libc.so.6 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libc.so.6
   - cp /lib64/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2
-  # There is no more such file in P11 with glibc-core that it's a part of
+  # There is no more such file in P11 with glibc-core that it was a part of. Now it's /usr/lib/x86_64-linux-gnu/sys-root/lib64/ld-linux-x86-64.so.2
   #- cp /lib64/ld-2.32.so /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
-  - cp /lib64/ld-linux-aarch64.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-aarch64.so.1
+  - cp /usr/lib/x86_64-linux-gnu/sys-root/lib64/ld-linux-x86-64.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
   - cp /opt/deckhouse/sds/bin/lsblk /opt/deckhouse/sds/bin/lsblk.dynamic
   - chmod +x /binary_replace.sh
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -4,7 +4,7 @@
 # Do not remove. It's used in external tests.
 ---
 image: {{ $.ImageName }}-src-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ $.Root.BASE_ALT_P11 }}
 final: false
 
 git:
@@ -29,7 +29,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-binaries-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ $.Root.BASE_ALT_P11 }}
 final: false
 
 import:
@@ -75,7 +75,8 @@ shell:
   - cp /lib64/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1
   - cp /lib64/libc.so.6 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libc.so.6
   - cp /lib64/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2
-  - cp /lib64/ld-2.32.so /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+  # No more such file in P11 with glibc-core that it's a part of
+  #- cp /lib64/ld-2.32.so /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
   - cp /opt/deckhouse/sds/bin/lsblk /opt/deckhouse/sds/bin/lsblk.dynamic
   - chmod +x /binary_replace.sh
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
@@ -103,7 +104,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-distroless-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ $.Root.BASE_ALT_P11 }}
 final: false
 
 shell:

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -64,7 +64,8 @@ shell:
     automake \
     gettext \
     flex \
-    glibc-core
+    glibc-core \
+    cross-glibc-x86_64
   - cd /src/util-linux
   - ./autogen.sh
   - ./configure LDFLAGS="-static" --enable-static-programs -disable-all-programs --enable-nsenter

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic" }}
+{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic /lib/ld-linux-aarch64.so.1" }}
 #{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic" }}
 {{ $UTIL_LINUX_VERSION := "2.39.3" }}
 
@@ -76,8 +76,9 @@ shell:
   - cp /lib64/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1
   - cp /lib64/libc.so.6 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libc.so.6
   - cp /lib64/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2
-  # No more such file in P11 with glibc-core that it's a part of
+  # There is no more such file in P11 with glibc-core that it's a part of
   #- cp /lib64/ld-2.32.so /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+  - cp /lib/ld-linux-aarch64.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-aarch64.so.1
   - cp /opt/deckhouse/sds/bin/lsblk /opt/deckhouse/sds/bin/lsblk.dynamic
   - chmod +x /binary_replace.sh
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic /lib/ld-linux-aarch64.so.1" }}
+{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic /lib64/ld-linux-aarch64.so.1" }}
 #{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic" }}
 {{ $UTIL_LINUX_VERSION := "2.39.3" }}
 
@@ -78,7 +78,7 @@ shell:
   - cp /lib64/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2
   # There is no more such file in P11 with glibc-core that it's a part of
   #- cp /lib64/ld-2.32.so /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
-  - cp /lib/ld-linux-aarch64.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-aarch64.so.1
+  - cp /lib64/ld-linux-aarch64.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-aarch64.so.1
   - cp /opt/deckhouse/sds/bin/lsblk /opt/deckhouse/sds/bin/lsblk.dynamic
   - chmod +x /binary_replace.sh
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -1,5 +1,4 @@
 {{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic /usr/lib/x86_64-linux-gnu/sys-root/lib64/ld-linux-x86-64.so.2" }}
-#{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic" }}
 {{ $UTIL_LINUX_VERSION := "2.39.3" }}
 
 # Do not remove. It's used in external tests.

--- a/images/sds-health-watcher-controller/src/go.mod
+++ b/images/sds-health-watcher-controller/src/go.mod
@@ -4,7 +4,7 @@ go 1.22.3
 
 require (
 	github.com/cloudflare/cfssl v1.5.0
-	github.com/deckhouse/sds-node-configurator/api v0.0.0-20241205120718-db6ffba1689b
+	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d
 	github.com/go-logr/logr v1.4.2
 	github.com/prometheus/client_golang v1.19.1
 	github.com/stretchr/testify v1.9.0

--- a/images/sds-health-watcher-controller/src/pkg/kubutils/kubernetes.go
+++ b/images/sds-health-watcher-controller/src/pkg/kubutils/kubernetes.go
@@ -24,6 +24,7 @@ import (
 )
 
 func KubernetesDefaultConfigCreate() (*rest.Config, error) {
+	// err is either nil and we return config or its value doesn't matter for us here
 	config, err := rest.InClusterConfig()
 	if err == nil {
 		return config, nil
@@ -35,9 +36,10 @@ func KubernetesDefaultConfigCreate() (*rest.Config, error) {
 	)
 
 	// Get a config to talk to API server
-	cconfig, err := clientConfig.ClientConfig()
+	config, err = clientConfig.ClientConfig()
+
 	if err != nil {
 		return nil, fmt.Errorf("config kubernetes error %w", err)
 	}
-	return cconfig, nil
+	return config, nil
 }

--- a/images/sds-health-watcher-controller/src/pkg/kubutils/kubernetes.go
+++ b/images/sds-health-watcher-controller/src/pkg/kubutils/kubernetes.go
@@ -36,9 +36,9 @@ func KubernetesDefaultConfigCreate() (*rest.Config, error) {
 	)
 
 	// Get a config to talk to API server
-	config, err := clientConfig.ClientConfig()
+	cconfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("config kubernetes error %w", err)
 	}
-	return config, nil
+	return cconfig, nil
 }

--- a/images/sds-health-watcher-controller/src/pkg/kubutils/kubernetes.go
+++ b/images/sds-health-watcher-controller/src/pkg/kubutils/kubernetes.go
@@ -24,6 +24,12 @@ import (
 )
 
 func KubernetesDefaultConfigCreate() (*rest.Config, error) {
+
+	config, err := rest.InClusterConfig()
+	if err == nil {
+		return config, nil
+	}
+
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{},

--- a/images/sds-health-watcher-controller/src/pkg/kubutils/kubernetes.go
+++ b/images/sds-health-watcher-controller/src/pkg/kubutils/kubernetes.go
@@ -24,7 +24,6 @@ import (
 )
 
 func KubernetesDefaultConfigCreate() (*rest.Config, error) {
-
 	config, err := rest.InClusterConfig()
 	if err == nil {
 		return config, nil

--- a/images/sds-health-watcher-controller/werf.inc.yaml
+++ b/images/sds-health-watcher-controller/werf.inc.yaml
@@ -3,7 +3,7 @@
 # Do not remove. It's used in external tests.
 ---
 image: {{ $.ImageName }}-src-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ $.Root.BASE_ALT_P11 }}
 final: false
 
 git:
@@ -46,7 +46,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-distroless-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ $.Root.BASE_ALT_P11 }}
 final: false
 
 shell:

--- a/images/sds-utils-installer/werf.inc.yaml
+++ b/images/sds-utils-installer/werf.inc.yaml
@@ -4,7 +4,7 @@
 # Do not remove. It's used in external tests.
 ---
 image: {{ $.ImageName }}-src-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ $.Root.BASE_ALT_P11 }}
 final: false
 
 git:
@@ -30,7 +30,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-binaries-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ $.Root.BASE_ALT_P11 }}
 final: false
 
 import:
@@ -94,7 +94,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-distroless-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ $.Root.BASE_ALT_P11 }}
 final: false
 
 shell:


### PR DESCRIPTION
## Description
Migration from ALT P10 to ALT P11

## Why do we need it, and what problem does it solve?
ALT P10 is becoming outdated soon. We need to update the image version.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
