### PR TITLE
[controller] Add dm_snapshot loading 

### DIFF
--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -6,10 +6,6 @@ properties:
     type: boolean
     default: false
     description: Disable sds-node-configurator daemonset
-  disableSnapshotKernelModuleLoading:
-    type: boolean
-    default: false
-    description: Disable loading of the snapshot kernel module
   logLevel:
     type: string
     enum:

--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -6,6 +6,10 @@ properties:
     type: boolean
     default: false
     description: Disable sds-node-configurator daemonset
+  disableSnapshotKernelModuleLoading:
+    type: boolean
+    default: false
+    description: Disable loading of the snapshot kernel module
   logLevel:
     type: string
     enum:

--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -90,7 +90,7 @@ spec:
           - modprobe
           - -a
           - dm_thin_pool
-{{- if and (.Values.global.enabledModules | has "snapshot-controller")  (not .Values.sdsNodeConfigurator.disableSnapshotKernelModuleLoading) }}
+{{- if  (.Values.global.enabledModules | has "snapshot-controller") }}
           - dm_snapshot
 {{- end }}
         # Privileged mode is required to use nsenter and access the host's mount namespace.

--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -88,7 +88,11 @@ spec:
           - -p
           - --
           - modprobe
+          - -a
           - dm_thin_pool
+{{- if and (.Values.global.enabledModules | has "snapshot-controller")  (not .Values.sdsNodeConfigurator.disableSnapshotKernelModuleLoading) }}
+          - dm_snapshot
+{{- end }}
         # Privileged mode is required to use nsenter and access the host's mount namespace.
         # This is necessary to run modprobe and load the dm_thin_pool kernel module on the host.
         securityContext:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

When the snapshot-controller is enabled and thin pools are in use, the dm_snapshot module should be loaded automatically.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct work with volume snapshots

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
