### PR TITLE
[controller] Fix LVMVolumeGroup spec.blockDeviceSelector update Issue

### DIFF
--- a/images/agent/internal/controller/lvg/discoverer.go
+++ b/images/agent/internal/controller/lvg/discoverer.go
@@ -480,6 +480,29 @@ func (d *Discoverer) UpdateLVMVolumeGroupByCandidate(
 		return updErr
 	}
 
+	// Persist the spec.BlockDeviceSelector update (if any) first: Status().Update() below
+	// cannot write to spec, and the regular Update() preserves status on the API side, so
+	// touching spec after we've populated the status fields would wipe them. Update()
+	// refreshes lvg.ResourceVersion in place, so the subsequent Status().Update() picks up
+	// the new revision.
+	updatedSelector, err := updateBlockDeviceSelectorIfNeeded(lvg.Spec.BlockDeviceSelector, candidate.BlockDevicesNames)
+	if err != nil {
+		return fmt.Errorf("updating block device selector for LVMVolumeGroup %q: %w", lvg.Name, err)
+	}
+	if updatedSelector != nil {
+		lvg.Spec.BlockDeviceSelector = updatedSelector
+		d.log.Debug(fmt.Sprintf("[UpdateLVMVolumeGroupByCandidate] update LVMVolumeGroup %q spec.blockDeviceSelector", lvg.Name))
+
+		start := time.Now()
+		err = d.cl.Update(ctx, lvg)
+		d.metrics.APIMethodsDuration(DiscovererName, "update").Observe(d.metrics.GetEstimatedTimeInSeconds(start))
+		d.metrics.APIMethodsExecutionCount(DiscovererName, "update").Inc()
+		if err != nil {
+			d.metrics.APIMethodsErrors(DiscovererName, "update").Inc()
+			return fmt.Errorf(`[UpdateLVMVolumeGroupByCandidate] unable to update LVMVolumeGroup spec, name: %q, err: %w`, lvg.Name, err)
+		}
+	}
+
 	// The resource.Status.Nodes can not be just re-written, it needs to be updated directly by a node.
 	// We take all current resources nodes and convert them to map for better performance further.
 	resourceNodes := make(map[string][]v1alpha1.LVMVolumeGroupDevice, len(lvg.Status.Nodes))
@@ -513,11 +536,6 @@ func (d *Discoverer) UpdateLVMVolumeGroupByCandidate(
 	lvg.Status.VGFree = candidate.VGFree
 	lvg.Status.VGUuid = candidate.VGUUID
 	lvg.Status.ExtentSize = candidate.ExtentSize
-
-	_, err = updateBlockDeviceSelectorIfNeeded(lvg.Spec.BlockDeviceSelector, candidate.BlockDevicesNames)
-	if err != nil {
-		return fmt.Errorf("updating block device selectors: %w", err)
-	}
 
 	d.log.Trace(fmt.Sprintf("[UpdateLVMVolumeGroupByCandidate] updated LVMVolumeGroup: %+v", lvg))
 

--- a/images/agent/internal/controller/lvg/discoverer.go
+++ b/images/agent/internal/controller/lvg/discoverer.go
@@ -21,11 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -124,14 +126,19 @@ func (d *Discoverer) LVMVolumeGroupDiscoverReconcile(ctx context.Context) bool {
 		d.log.Info("[RunLVMVolumeGroupDiscoverController] no BlockDevices were found")
 		return false
 	}
+	d.log.Trace(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] BlockDevices: %+v", blockDevices))
 
 	filteredLVGs := filterLVGsByNode(currentLVMVGs, d.cfg.NodeName)
+	filteredBlockDevices := filterBlockDevicesByNodeName(blockDevices, d.cfg.NodeName)
+	d.log.Trace(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] Filtered LVMVolumeGroups: %+v", filteredLVGs))
+	d.log.Trace(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] Filtered BlockDevices: %+v", filteredBlockDevices))
 
 	// Store managed VG names in cache for metrics filtering
 	d.sdsCache.StoreManagedVGs(maps.Keys(filteredLVGs))
 
 	d.log.Debug("[RunLVMVolumeGroupDiscoverController] tries to get LVMVolumeGroup candidates")
-	candidates, err := d.GetLVMVolumeGroupCandidates(blockDevices)
+
+	candidates, err := d.GetLVMVolumeGroupCandidates(filteredBlockDevices)
 	if err != nil {
 		d.log.Error(err, "[RunLVMVolumeGroupDiscoverController] unable to run GetLVMVolumeGroupCandidates")
 		for _, lvg := range filteredLVGs {
@@ -157,9 +164,9 @@ func (d *Discoverer) LVMVolumeGroupDiscoverReconcile(ctx context.Context) bool {
 
 	shouldRequeue := false
 	for _, candidate := range candidates {
+		d.log.Trace(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] candidate: %+v", candidate))
 		if lvg, exist := filteredLVGs[candidate.ActualVGNameOnTheNode]; exist {
 			d.log.Debug(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] the LVMVolumeGroup %s is already exist. Tries to update it", lvg.Name))
-			d.log.Trace(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] candidate: %+v", candidate))
 			d.log.Trace(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] lvg: %+v", lvg))
 
 			if !hasLVMVolumeGroupDiff(d.log, lvg, candidate) {
@@ -507,6 +514,13 @@ func (d *Discoverer) UpdateLVMVolumeGroupByCandidate(
 	lvg.Status.VGUuid = candidate.VGUUID
 	lvg.Status.ExtentSize = candidate.ExtentSize
 
+	_, err = updateBlockDeviceSelectorIfNeeded(lvg.Spec.BlockDeviceSelector, candidate.BlockDevicesNames)
+	if err != nil {
+		return fmt.Errorf("updating block device selectors: %w", err)
+	}
+
+	d.log.Trace(fmt.Sprintf("[UpdateLVMVolumeGroupByCandidate] updated LVMVolumeGroup: %+v", lvg))
+
 	start := time.Now()
 	err = d.cl.Status().Update(ctx, lvg)
 	d.metrics.APIMethodsDuration(DiscovererName, "update").Observe(d.metrics.GetEstimatedTimeInSeconds(start))
@@ -836,13 +850,20 @@ func hasLVMVolumeGroupDiff(log logger.Logger, lvg v1alpha1.LVMVolumeGroup, candi
 	log.Trace(fmt.Sprintf(`VGUUID, candidate: %s, lvg: %s`, candidate.VGUUID, lvg.Status.VGUuid))
 	log.Trace(fmt.Sprintf(`Nodes, candidate: %+v, lvg: %+v`, convertLVMVGNodes(candidate.Nodes), lvg.Status.Nodes))
 
+	notMatchedBlockDeviceNames, err := notMatchedBlockDeviceNames(lvg.Spec.BlockDeviceSelector, candidate.BlockDevicesNames)
+	if err != nil {
+		log.Error(err, "[hasLVMVolumeGroupDiff] unable to parse blockDeviceSelector")
+		notMatchedBlockDeviceNames = []string{}
+	}
+
 	return candidate.AllocatedSize.Value() != lvg.Status.AllocatedSize.Value() ||
 		hasStatusPoolDiff(convertedStatusPools, lvg.Status.ThinPools) ||
 		candidate.VGSize.Value() != lvg.Status.VGSize.Value() ||
 		candidate.VGFree.Value() != lvg.Status.VGFree.Value() ||
 		candidate.VGUUID != lvg.Status.VGUuid ||
 		candidate.ExtentSize.Value() != lvg.Status.ExtentSize.Value() ||
-		hasStatusNodesDiff(log, convertLVMVGNodes(candidate.Nodes), lvg.Status.Nodes)
+		hasStatusNodesDiff(log, convertLVMVGNodes(candidate.Nodes), lvg.Status.Nodes) ||
+		len(notMatchedBlockDeviceNames) > 0
 }
 
 func hasStatusNodesDiff(log logger.Logger, first, second []v1alpha1.LVMVolumeGroupNode) bool {
@@ -905,6 +926,99 @@ func configureBlockDeviceSelector(candidate internal.LVMVolumeGroupCandidate) *m
 			},
 		},
 	}
+}
+
+func notMatchedBlockDeviceNames(labelSelector *metav1.LabelSelector, blockDeviceNames []string) ([]string, error) {
+	fullSelector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("parsing label selector: %w", err)
+	}
+
+	requirements, _ := fullSelector.Requirements()
+	blockDeviceRequirements := requirements[0:0]
+	for _, requirement := range requirements {
+		if requirement.Key() == internal.MetadataNameLabelKey {
+			blockDeviceRequirements = append(blockDeviceRequirements, requirement)
+		}
+	}
+
+	blockDeviceNameSelector := labels.NewSelector().Add(blockDeviceRequirements...)
+	var notMatchedBlockDeviceNames []string
+	for _, blockDeviceName := range blockDeviceNames {
+		if blockDeviceNameSelector.Matches(labels.Set{
+			internal.MetadataNameLabelKey: blockDeviceName,
+		}) {
+			continue
+		}
+		notMatchedBlockDeviceNames = append(notMatchedBlockDeviceNames, blockDeviceName)
+	}
+	return notMatchedBlockDeviceNames, nil
+}
+
+func appendDeviceNamesToLabelSelector(labelSelector *metav1.LabelSelector, blockDeviceNames []string) {
+	if len(blockDeviceNames) == 0 {
+		return
+	}
+
+	var expressionToAddTo *[]string
+
+	// find existing expression to add
+	for i, expression := range labelSelector.MatchExpressions {
+		if expression.Key == internal.MetadataNameLabelKey && expression.Operator == metav1.LabelSelectorOpIn {
+			expressionToAddTo = &labelSelector.MatchExpressions[i].Values
+			break
+		}
+	}
+
+	if expressionToAddTo == nil {
+		// Create new expression in list
+		labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+			Key:      internal.MetadataNameLabelKey,
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{},
+		})
+		expressionToAddTo = &labelSelector.MatchExpressions[len(labelSelector.MatchExpressions)-1].Values
+	}
+
+	*expressionToAddTo = append(*expressionToAddTo, blockDeviceNames...)
+	value, exists := labelSelector.MatchLabels[internal.MetadataNameLabelKey]
+	if exists {
+		*expressionToAddTo = append(*expressionToAddTo, value)
+		delete(labelSelector.MatchLabels, internal.MetadataNameLabelKey)
+	}
+}
+
+// Add missing block device to label selector.
+//
+// If labelSelector is provided it will be changed by this call.
+//
+// If labelSelector is created or updated it will be returned in updatedLabelSelector argument.
+//
+// If labelSelector was not changed the updatedLabelSelector will be nil.
+func updateBlockDeviceSelectorIfNeeded(labelSelector *metav1.LabelSelector, blockDeviceNames []string) (updatedLabelSelector *metav1.LabelSelector, err error) {
+	if labelSelector == nil {
+		return &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      internal.MetadataNameLabelKey,
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   slices.Clone(blockDeviceNames),
+				},
+			},
+		}, nil
+	}
+
+	notMatchedBlockDeviceNames, err := notMatchedBlockDeviceNames(labelSelector, blockDeviceNames)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(notMatchedBlockDeviceNames) == 0 {
+		return nil, nil
+	}
+
+	appendDeviceNamesToLabelSelector(labelSelector, notMatchedBlockDeviceNames)
+	return labelSelector, nil
 }
 
 func convertLVMVGNodes(nodes map[string][]internal.LVMVGDevice) []v1alpha1.LVMVolumeGroupNode {

--- a/images/agent/internal/controller/lvg/discoverer_test.go
+++ b/images/agent/internal/controller/lvg/discoverer_test.go
@@ -620,6 +620,94 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 		}
 	})
 
+	t.Run("UpdateLVMVolumeGroup_persists_spec_blockDeviceSelector", func(t *testing.T) {
+		// Regression test: the discoverer must persist Spec.BlockDeviceSelector to the API
+		// server. Status().Update() cannot write to spec, so a separate Update() is required.
+
+		const LVMVGName = "test_lvm_selector_persist"
+
+		d := setupDiscoverer(nil)
+
+		// Pre-existing LVG with a selector that already covers dev1.
+		lvg := &v1alpha1.LVMVolumeGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: LVMVGName},
+			Spec: v1alpha1.LVMVolumeGroupSpec{
+				BlockDeviceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      internal.MetadataNameLabelKey,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"dev1"},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.LVMVolumeGroupStatus{
+				AllocatedSize: *resource.NewQuantity(500, resource.BinarySI),
+			},
+		}
+		assert.NoError(t, d.cl.Create(ctx, lvg))
+
+		stored := &v1alpha1.LVMVolumeGroup{}
+		assert.NoError(t, d.cl.Get(ctx, client.ObjectKey{Name: LVMVGName}, stored))
+
+		// Candidate adds two new devices not yet covered by the selector and bumps the
+		// allocated size; both spec and status must end up updated on the API server.
+		candidate := internal.LVMVolumeGroupCandidate{
+			LVMVGName:         LVMVGName,
+			AllocatedSize:     *resource.NewQuantity(1500, resource.BinarySI),
+			BlockDevicesNames: []string{"dev1", "dev2", "dev3"},
+		}
+		assert.NoError(t, d.UpdateLVMVolumeGroupByCandidate(ctx, stored, candidate))
+
+		got := &v1alpha1.LVMVolumeGroup{}
+		assert.NoError(t, d.cl.Get(ctx, client.ObjectKey{Name: LVMVGName}, got))
+
+		assert.Equal(t, candidate.AllocatedSize.Value(), got.Status.AllocatedSize.Value(),
+			"status should be updated")
+
+		notMatched, err := notMatchedBlockDeviceNames(got.Spec.BlockDeviceSelector, candidate.BlockDevicesNames)
+		assert.NoError(t, err)
+		assert.Empty(t, notMatched,
+			"Spec.BlockDeviceSelector must cover all candidate devices; got selector=%+v",
+			got.Spec.BlockDeviceSelector)
+	})
+
+	t.Run("UpdateLVMVolumeGroup_creates_spec_blockDeviceSelector_when_nil", func(t *testing.T) {
+		// Regression test: when an existing LVG has no selector at all (legacy), the
+		// discoverer should populate it on the next reconcile so the controller-runtime
+		// watcher can correlate BlockDevices to this LVG.
+
+		const LVMVGName = "test_lvm_selector_create"
+
+		d := setupDiscoverer(nil)
+
+		lvg := &v1alpha1.LVMVolumeGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: LVMVGName},
+		}
+		assert.NoError(t, d.cl.Create(ctx, lvg))
+
+		stored := &v1alpha1.LVMVolumeGroup{}
+		assert.NoError(t, d.cl.Get(ctx, client.ObjectKey{Name: LVMVGName}, stored))
+
+		candidate := internal.LVMVolumeGroupCandidate{
+			LVMVGName:         LVMVGName,
+			AllocatedSize:     *resource.NewQuantity(2000, resource.BinarySI),
+			BlockDevicesNames: []string{"devA", "devB"},
+		}
+		assert.NoError(t, d.UpdateLVMVolumeGroupByCandidate(ctx, stored, candidate))
+
+		got := &v1alpha1.LVMVolumeGroup{}
+		assert.NoError(t, d.cl.Get(ctx, client.ObjectKey{Name: LVMVGName}, got))
+
+		if assert.NotNil(t, got.Spec.BlockDeviceSelector,
+			"Spec.BlockDeviceSelector must be created from candidate devices") {
+			notMatched, err := notMatchedBlockDeviceNames(got.Spec.BlockDeviceSelector, candidate.BlockDevicesNames)
+			assert.NoError(t, err)
+			assert.Empty(t, notMatched)
+		}
+	})
+
 	t.Run("filterResourcesByNode_returns_current_node_resources", func(t *testing.T) {
 		var (
 			currentNode  = "test_node"

--- a/images/agent/internal/controller/lvg/discoverer_test.go
+++ b/images/agent/internal/controller/lvg/discoverer_test.go
@@ -34,6 +34,8 @@ limitations under the License.
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -773,6 +775,15 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 				Spec: v1alpha1.LVMVolumeGroupSpec{
 					ThinPools: convertSpecThinPools(specThinPools),
 					Type:      specType,
+					BlockDeviceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      internal.MetadataNameLabelKey,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   blockDevicesNames,
+							},
+						},
+					},
 				},
 				Status: v1alpha1.LVMVolumeGroupStatus{
 					AllocatedSize: resource.MustParse("9765625Ki"),
@@ -906,6 +917,188 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 			assert.Equal(t, conType, lvg.Status.Conditions[0].Type)
 			assert.Equal(t, reason, lvg.Status.Conditions[0].Reason)
 			assert.Equal(t, message, lvg.Status.Conditions[0].Message)
+		}
+	})
+
+	t.Run("labelSelectorUpdates", func(t *testing.T) {
+		allDeviceNames := []string{"dev1", "dev_2", "dev-3"}
+		t.Run("doNotUpdate", func(t *testing.T) {
+			t.Run("inMatchExpressions", func(t *testing.T) {
+				selector := metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      internal.MetadataNameLabelKey,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   allDeviceNames,
+						},
+					},
+				}
+				selectorCopy := selector.DeepCopy()
+				newSelector, err := updateBlockDeviceSelectorIfNeeded(selectorCopy, allDeviceNames)
+				assert.NoError(t, err)
+				assert.Nil(t, newSelector)
+				assert.EqualValues(t, selector, *selectorCopy)
+			})
+
+			t.Run("withOtherRequirements", func(t *testing.T) {
+				selector := metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      internal.MetadataNameLabelKey,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   allDeviceNames,
+						}, {
+							Key:      "otherKey",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"foo", "bar"},
+						},
+					},
+				}
+				selectorCopy := selector.DeepCopy()
+				newSelector, err := updateBlockDeviceSelectorIfNeeded(selectorCopy, allDeviceNames)
+				assert.NoError(t, err)
+				assert.Nil(t, newSelector)
+				assert.EqualValues(t, selector, *selectorCopy)
+			})
+
+			t.Run("withOtherDevices", func(t *testing.T) {
+				otherDevices := []string{"otherDevice1", "otherDevice2"}
+				selector := metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      internal.MetadataNameLabelKey,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   append(allDeviceNames, otherDevices...),
+						},
+					},
+				}
+				selectorCopy := selector.DeepCopy()
+				newSelector, err := updateBlockDeviceSelectorIfNeeded(selectorCopy, allDeviceNames)
+				assert.NoError(t, err)
+				assert.Nil(t, newSelector)
+				assert.EqualValues(t, selector, *selectorCopy)
+			})
+		})
+		t.Run("createIfNil", func(t *testing.T) {
+			newSelector, err := updateBlockDeviceSelectorIfNeeded(nil, allDeviceNames)
+			assert.NoError(t, err)
+			assert.NotNil(t, newSelector)
+			assert.Len(t, newSelector.MatchExpressions, 1)
+			assert.Equal(t, internal.MetadataNameLabelKey, newSelector.MatchExpressions[0].Key)
+			assert.Equal(t, metav1.LabelSelectorOpIn, newSelector.MatchExpressions[0].Operator)
+			assert.EqualValues(t, allDeviceNames, newSelector.MatchExpressions[0].Values)
+
+			t.Run("doNotUpdateSecondTime", func(t *testing.T) {
+				newSelector2, err := updateBlockDeviceSelectorIfNeeded(newSelector, allDeviceNames)
+				assert.NoError(t, err)
+				assert.Nil(t, newSelector2)
+			})
+		})
+
+		for i := range allDeviceNames {
+			notExistingDevices := allDeviceNames[0:i]
+			existingDevices := allDeviceNames[i:]
+			selectors := map[string]metav1.LabelSelector{
+				"onlyOurKeys": {
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      internal.MetadataNameLabelKey,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   slices.Clone(existingDevices),
+						},
+					},
+				},
+				// TODO: We don't cover this case yet
+				// "onlyOurKeysTwice": {
+				// 	MatchExpressions: []metav1.LabelSelectorRequirement{
+				// 		{
+				// 			Key:      internal.MetadataNameLabelKey,
+				// 			Operator: metav1.LabelSelectorOpIn,
+				// 			Values:   slices.Clone(existingDevices),
+				// 		}, {
+				// 			Key:      internal.MetadataNameLabelKey,
+				// 			Operator: metav1.LabelSelectorOpIn,
+				// 			Values:   slices.Clone(existingDevices),
+				// 		},
+				// 	},
+				// },
+				"withOtherKeys": {
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      internal.MetadataNameLabelKey,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   slices.Clone(existingDevices),
+						},
+						{
+							Key:      "other/key",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"foo", "bar"},
+						},
+					},
+				},
+			}
+
+			for selectorName, selectorToTest := range selectors {
+				selector := selectorToTest.DeepCopy()
+				t.Run(fmt.Sprintf("missingDevices %v with selector %s", notExistingDevices, selectorName), func(t *testing.T) {
+					if len(existingDevices) == 1 {
+						t.Run("inMatchLabels", func(t *testing.T) {
+							newSelector, err := updateBlockDeviceSelectorIfNeeded(&metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									internal.MetadataNameLabelKey: existingDevices[0],
+								},
+							}, allDeviceNames)
+							assert.NoError(t, err)
+							assert.NotNil(t, newSelector)
+
+							t.Run("doNotUpdateSecondTime", func(t *testing.T) {
+								newSelector2, err := updateBlockDeviceSelectorIfNeeded(newSelector.DeepCopy(), allDeviceNames)
+								assert.NoError(t, err)
+								assert.Nil(t, newSelector2)
+							})
+						})
+					}
+
+					for i := range notExistingDevices {
+						notExistingDevicesToAdd := notExistingDevices[i:]
+						t.Run(fmt.Sprintf("notMatchedBlockDeviceNames %v", notExistingDevicesToAdd), func(t *testing.T) {
+							notMatched, err := notMatchedBlockDeviceNames(selector.DeepCopy(), notExistingDevicesToAdd)
+							assert.NoError(t, err)
+							assert.EqualValues(t, notExistingDevicesToAdd, notMatched)
+						})
+
+						for _, devicesToAdd := range [][]string{
+							notExistingDevicesToAdd,
+							append(notExistingDevicesToAdd, existingDevices...),
+							append(existingDevices, notExistingDevicesToAdd...),
+						} {
+							t.Run(fmt.Sprintf("append %v to %v", devicesToAdd, existingDevices), func(t *testing.T) {
+								newSelector, err := updateBlockDeviceSelectorIfNeeded(selector.DeepCopy(), devicesToAdd)
+								assert.NoError(t, err)
+								if len(devicesToAdd) == 0 {
+									assert.Nil(t, newSelector)
+								} else {
+									assert.NotNil(t, newSelector)
+								}
+
+								if newSelector != nil {
+									t.Run("doNotUpdateSecondTime", func(t *testing.T) {
+										newSelector2, err := updateBlockDeviceSelectorIfNeeded(newSelector.DeepCopy(), devicesToAdd)
+										assert.NoError(t, err)
+										assert.Nil(t, newSelector2)
+									})
+
+									t.Run("notMatchedIsEmpty", func(t *testing.T) {
+										notMatched, err := notMatchedBlockDeviceNames(newSelector.DeepCopy(), devicesToAdd)
+										assert.NoError(t, err)
+										assert.Empty(t, notMatched)
+									})
+								}
+							})
+						}
+					}
+				})
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR addresses an issue where the `spec.blockDeviceSelector` field of an existing `LVMVolumeGroup` resource was not updating during reconciliation, even when new physical volumes (PVs) were manually added on the node to the corresponding LVM Volume Group. With this fix, the `spec.blockDeviceSelector` now correctly reflects all associated `BlockDevice` resources, ensuring accurate representation of the volume group's state.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Previously, when new `BlockDevice` resources were manually introduced to an existing LVM Volume Group on a node, the `spec.blockDeviceSelector` field in the corresponding `LVMVolumeGroup` resource remained unchanged. This discrepancy could lead to mismanagement of storage resources and potential inconsistencies in volume group configurations. By ensuring that `spec.blockDeviceSelector` is updated appropriately, we maintain consistency between the actual state of the LVM Volume Group and its representation within Kubernetes.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
