### PR TITLE
Fixes cgroup mount errors

### DIFF
--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -129,7 +129,7 @@ spec:
         volumeMounts:
           - mountPath: /dev/
             name: host-device-dir
-          - mountPath: /sys/
+          - mountPath: /sys/fs/cgroup
             name: host-sys-dir
           - mountPath: /run/udev/
             name: host-run-udev-dir
@@ -193,7 +193,7 @@ spec:
         volumeMounts:
         - mountPath: /dev/
           name: host-device-dir
-        - mountPath: /sys/
+        - mountPath: /sys/fs/cgroup
           name: host-sys-dir
         - mountPath: /run/udev/
           name: host-run-udev-dir
@@ -213,7 +213,7 @@ spec:
           type: ""
         name: host-device-dir
       - hostPath:
-          path: /sys/
+          path: /sys/fs/cgroup
           type: Directory
         name: host-sys-dir
       - hostPath:

--- a/templates/sds-health-watcher-controller/deployment.yaml
+++ b/templates/sds-health-watcher-controller/deployment.yaml
@@ -117,7 +117,7 @@ spec:
             - name: host-device-dir
               mountPath: /dev/
             - name: host-sys-dir
-              mountPath: /sys/
+              mountPath: /sys/fs/cgroup
             - name: host-root
               mountPath: /host-root/
               mountPropagation: HostToContainer
@@ -128,7 +128,7 @@ spec:
             type: ""
         - name: host-sys-dir
           hostPath:
-            path: /sys/
+            path: /sys/fs/cgroup
             type: Directory
         - name: host-root
           hostPath:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add exactly `/sys/fs/cgroup` mounts
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fixes errors like:
`Warning  Failed          23m (x4 over 24m)    kubelet  Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "cgroup" to rootfs at "/sys/fs/cgroup": create mountpoint for /sys/fs/cgroup mount: mkdirat /run/containerd/io.containerd.runtime.v2.task/k8s.io/sds-node-configurator-agent/rootfs/sys/fs: read-only file system`
