### PR TITLE
[internal] add sys fs cgroup mount for containerd v2 support

### DIFF
--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -131,6 +131,8 @@ spec:
             name: host-device-dir
           - mountPath: /sys/
             name: host-sys-dir
+          - mountPath: /sys/fs/cgroup
+            name: host-sys-fs-cgroup
           - mountPath: /run/udev/
             name: host-run-udev-dir
         resources:
@@ -195,6 +197,8 @@ spec:
           name: host-device-dir
         - mountPath: /sys/
           name: host-sys-dir
+        - mountPath: /sys/fs/cgroup
+          name: host-sys-fs-cgroup
         - mountPath: /run/udev/
           name: host-run-udev-dir
         resources:
@@ -216,6 +220,10 @@ spec:
           path: /sys/
           type: Directory
         name: host-sys-dir
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: host-sys-fs-cgroup
       - hostPath:
           path: /run/udev/
           type: Directory


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add /sys/fs/cgroup mount for containerd v2 support

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Containerd v2 support for module

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
