### PR TITLE
[internal] Fix sys-fs-cgroup error for containerdv2 support

### DIFF
--- a/templates/sds-health-watcher-controller/deployment.yaml
+++ b/templates/sds-health-watcher-controller/deployment.yaml
@@ -118,6 +118,8 @@ spec:
               mountPath: /dev/
             - name: host-sys-dir
               mountPath: /sys/
+            - name: host-sys-fs-cgroup
+              mountPath: /sys/fs/cgroup
             - name: host-root
               mountPath: /host-root/
               mountPropagation: HostToContainer
@@ -129,6 +131,10 @@ spec:
         - name: host-sys-dir
           hostPath:
             path: /sys/
+            type: Directory
+        - name: host-sys-fs-cgroup
+          hostPath:
+            path: /sys/fs/cgroup
             type: Directory
         - name: host-root
           hostPath:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix sys-fs-cgroup error for containerdv2 support
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
`failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "cgroup" to rootfs at "/sys/fs/cgroup": create mountpoint for /sys/fs/cgroup mount: mkdirat /run/containerd/io.containerd.runtime.v2.task/k8s.io/5dd95fd1ed881fe5035da4377e63f357b62c9c3175b22c414c9b7aa7b3d52b8e/rootfs/sys/fs: read-only file system`
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
