### PR TITLE
fix: remove label heritage:deckhouse from agent pods

### DIFF
--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -50,7 +50,8 @@ spec:
     metadata:
       name: sds-node-configurator
       namespace: d8-{{ .Chart.Name }}
-      {{- include "helm_lib_module_labels" (list . (dict "app" "sds-node-configurator")) | nindent 6 }}
+      labels:
+        app: sds-node-configurator
     spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | nindent 6 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove label heritage:deckhouse from agent pods

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

It's no more block from agent pod deletion or rollout

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
