### PR TITLE
[fix] prevent mass LLV failures and negative available space in scheduler extender

### DIFF
--- a/images/agent/internal/controller/llv/reconciler.go
+++ b/images/agent/internal/controller/llv/reconciler.go
@@ -298,6 +298,15 @@ func (r *Reconciler) ReconcileLVMLogicalVolume(ctx context.Context, llv *v1alpha
 	return false, nil
 }
 
+// llvExtentSize returns the LVG extent size, falling back to 4Mi (LVM default)
+// when the discoverer has not yet populated Status.ExtentSize.
+func llvExtentSize(lvg *v1alpha1.LVMVolumeGroup) resource.Quantity {
+	if lvg.Status.ExtentSize.Value() > 0 {
+		return lvg.Status.ExtentSize
+	}
+	return resource.MustParse("4Mi")
+}
+
 func (r *Reconciler) reconcileLLVCreateFunc(
 	ctx context.Context,
 	llv *v1alpha1.LVMLogicalVolume,
@@ -319,7 +328,7 @@ func (r *Reconciler) reconcileLLVCreateFunc(
 		return false, err
 	}
 
-	alignedRequestSize, err := utils.AlignSizeToExtent(llvRequestSize, lvg.Status.ExtentSize)
+	alignedRequestSize, err := utils.AlignSizeToExtent(llvRequestSize, llvExtentSize(lvg))
 	if err != nil {
 		r.log.Error(err, fmt.Sprintf("[reconcileLLVCreateFunc] unable to align size for LVMLogicalVolume %s", llv.Name))
 		return true, err
@@ -429,7 +438,7 @@ func (r *Reconciler) reconcileLLVUpdateFunc(
 	}
 	r.log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] successfully counted the LVMLogicalVolume %s requested size: %s", llv.Name, llvRequestSize.String()))
 
-	alignedRequestSize, err := utils.AlignSizeToExtent(llvRequestSize, lvg.Status.ExtentSize)
+	alignedRequestSize, err := utils.AlignSizeToExtent(llvRequestSize, llvExtentSize(lvg))
 	if err != nil {
 		r.log.Error(err, fmt.Sprintf("[reconcileLLVUpdateFunc] unable to align size for LVMLogicalVolume %s", llv.Name))
 		return true, err

--- a/images/agent/internal/controller/llv/reconciler.go
+++ b/images/agent/internal/controller/llv/reconciler.go
@@ -704,17 +704,6 @@ func (r *Reconciler) validateLVMLogicalVolume(llv *v1alpha1.LVMLogicalVolume, lv
 		reason.WriteString("Zero size for LV. ")
 	}
 
-	if llv.Status != nil {
-		alignedReqSize, alignErr := utils.AlignSizeToExtent(llvRequestedSize, lvg.Status.ExtentSize)
-		if alignErr != nil {
-			if llvRequestedSize.Value() < llv.Status.ActualSize.Value() {
-				reason.WriteString("Desired LV size is less than actual one. ")
-			}
-		} else if alignedReqSize.Value() < llv.Status.ActualSize.Value() {
-			reason.WriteString("Desired LV size is less than actual one. ")
-		}
-	}
-
 	switch llv.Spec.Type {
 	case internal.Thin:
 		if llv.Spec.Thin == nil {

--- a/images/agent/internal/controller/llv/reconciler_test.go
+++ b/images/agent/internal/controller/llv/reconciler_test.go
@@ -235,6 +235,49 @@ func TestLVMLogicalVolumeWatcher(t *testing.T) {
 				assert.Equal(t, "No LV name specified. Zero size for LV. No thin pool specified. ", reason)
 			}
 		})
+
+		t.Run("actual_size_larger_than_requested_is_valid", func(t *testing.T) {
+			const (
+				lvgName = "test-lvg"
+				tpName  = "data-thin"
+			)
+
+			r := setupReconciler()
+
+			lvg := &v1alpha1.LVMVolumeGroup{
+				ObjectMeta: v1.ObjectMeta{
+					Name: lvgName,
+				},
+				Status: v1alpha1.LVMVolumeGroupStatus{
+					ExtentSize: resource.MustParse("4Mi"),
+					ThinPools: []v1alpha1.LVMVolumeGroupThinPoolStatus{
+						{
+							Name:            tpName,
+							AllocationLimit: internal.AllocationLimitDefaultValue,
+						},
+					},
+				},
+			}
+
+			llv := &v1alpha1.LVMLogicalVolume{
+				Spec: v1alpha1.LVMLogicalVolumeSpec{
+					ActualLVNameOnTheNode: "test-lv",
+					Type:                  internal.Thin,
+					Size:                  "40Gi",
+					LVMVolumeGroupName:    lvgName,
+					Thin:                  &v1alpha1.LVMLogicalVolumeThinSpec{PoolName: tpName},
+				},
+				Status: &v1alpha1.LVMLogicalVolumeStatus{
+					Phase:      v1alpha1.PhaseCreated,
+					ActualSize: resource.MustParse("40972Mi"),
+				},
+			}
+
+			v, reason := r.validateLVMLogicalVolume(llv, lvg)
+			if assert.True(t, v) {
+				assert.Equal(t, 0, len(reason))
+			}
+		})
 	})
 
 	t.Run("getThinPoolAvailableSpace", func(t *testing.T) {

--- a/images/agent/internal/controller/llv/reconciler_test.go
+++ b/images/agent/internal/controller/llv/reconciler_test.go
@@ -280,6 +280,22 @@ func TestLVMLogicalVolumeWatcher(t *testing.T) {
 		})
 	})
 
+	t.Run("llvExtentSize", func(t *testing.T) {
+		t.Run("returns_status_extent_size_when_positive", func(t *testing.T) {
+			lvg := &v1alpha1.LVMVolumeGroup{
+				Status: v1alpha1.LVMVolumeGroupStatus{
+					ExtentSize: resource.MustParse("8Mi"),
+				},
+			}
+			assert.Equal(t, resource.MustParse("8Mi"), llvExtentSize(lvg))
+		})
+
+		t.Run("falls_back_to_4Mi_when_zero", func(t *testing.T) {
+			lvg := &v1alpha1.LVMVolumeGroup{}
+			assert.Equal(t, resource.MustParse("4Mi"), llvExtentSize(lvg))
+		})
+	})
+
 	t.Run("getThinPoolAvailableSpace", func(t *testing.T) {
 		free, err := utils.GetThinPoolAvailableSpace(
 			resource.MustParse("10Gi"),

--- a/images/agent/internal/controller/lvg/discoverer.go
+++ b/images/agent/internal/controller/lvg/discoverer.go
@@ -841,7 +841,8 @@ func hasLVMVolumeGroupDiff(log logger.Logger, lvg v1alpha1.LVMVolumeGroup, candi
 		candidate.VGSize.Value() != lvg.Status.VGSize.Value() ||
 		candidate.VGFree.Value() != lvg.Status.VGFree.Value() ||
 		candidate.VGUUID != lvg.Status.VGUuid ||
-		hasStatusNodesDiff(log, convertLVMVGNodes(candidate.Nodes), lvg.Status.Nodes)
+		hasStatusNodesDiff(log, convertLVMVGNodes(candidate.Nodes), lvg.Status.Nodes) ||
+		candidate.ExtentSize.Value() != lvg.Status.ExtentSize.Value()
 }
 
 func hasStatusNodesDiff(log logger.Logger, first, second []v1alpha1.LVMVolumeGroupNode) bool {

--- a/images/agent/internal/controller/lvg/discoverer_test.go
+++ b/images/agent/internal/controller/lvg/discoverer_test.go
@@ -850,6 +850,25 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 
 			assert.True(t, hasLVMVolumeGroupDiff(logger.Logger{}, lvmVolumeGroup, candidate))
 		})
+
+		t.Run("should_return_true_when_extent_size_differs", func(t *testing.T) {
+			size10G := resource.MustParse("10G")
+
+			candidate := internal.LVMVolumeGroupCandidate{
+				AllocatedSize: size10G,
+				VGSize:        size10G,
+				ExtentSize:    resource.MustParse("4Mi"),
+			}
+
+			lvmVolumeGroup := v1alpha1.LVMVolumeGroup{
+				Status: v1alpha1.LVMVolumeGroupStatus{
+					AllocatedSize: resource.MustParse("9765625Ki"),
+					VGSize:        resource.MustParse("9765625Ki"),
+				},
+			}
+
+			assert.True(t, hasLVMVolumeGroupDiff(logger.Logger{}, lvmVolumeGroup, candidate))
+		})
 	})
 
 	t.Run("updateLVGConditionIfNeeded", func(t *testing.T) {

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -197,10 +197,13 @@ func getLVGsOnNode(ctx context.Context, cl client.Client, nodeName string) ([]sn
 // --- LLV space computation ---
 
 // sumLLVSpace sums spec.size for all LLVs on the given storage pool.
-// If onlyCreated is true, only LLVs with status.phase == Created are included.
+// If onlyOnDisk is true, only LLVs whose space is reflected on disk are included:
+// phase == Created OR status.actualSize > 0 (e.g. Failed LLVs that were already
+// provisioned). This prevents double-counting of on-disk LLVs that are not in
+// Created phase (their space is already captured by reportedFree / availableSpace).
 // For thick pools (key.ThinPoolName == ""), only LLVs without a thin spec are counted.
 // For thin pools, only LLVs matching the thin pool name are counted.
-func sumLLVSpace(ctx context.Context, cl client.Client, key cache.StoragePoolKey, onlyCreated bool) (int64, error) {
+func sumLLVSpace(ctx context.Context, cl client.Client, key cache.StoragePoolKey, onlyOnDisk bool) (int64, error) {
 	var llvList snc.LVMLogicalVolumeList
 	if err := cl.List(ctx, &llvList, client.MatchingFields{IndexFieldLLVLVGName: key.LVGName}); err != nil {
 		return 0, fmt.Errorf("unable to list LLVs for LVG %s: %w", key.LVGName, err)
@@ -220,8 +223,11 @@ func sumLLVSpace(ctx context.Context, cl client.Client, key cache.StoragePoolKey
 			}
 		}
 
-		if onlyCreated {
-			if llv.Status == nil || llv.Status.Phase != snc.PhaseCreated {
+		if onlyOnDisk {
+			if llv.Status == nil {
+				continue
+			}
+			if llv.Status.Phase != snc.PhaseCreated && llv.Status.ActualSize.IsZero() {
 				continue
 			}
 		}
@@ -238,8 +244,9 @@ func sumLLVSpace(ctx context.Context, cl client.Client, key cache.StoragePoolKey
 // --- Unaccounted space calibration ---
 
 // CalibratePoolUnaccountedSpace computes the space occupied by non-LLV volumes
-// on the given storage pool and stores it in the cache. Uses only Created LLVs
-// (whose sizes are reflected in VGFree/AvailableSpace) for calibration.
+// on the given storage pool and stores it in the cache. Uses on-disk LLVs
+// (Created phase OR actualSize > 0) whose sizes are reflected in
+// VGFree/AvailableSpace for calibration.
 func CalibratePoolUnaccountedSpace(
 	ctx context.Context,
 	cl client.Client,
@@ -247,9 +254,9 @@ func CalibratePoolUnaccountedSpace(
 	lvg *snc.LVMVolumeGroup,
 	key cache.StoragePoolKey,
 ) error {
-	sumCreated, err := sumLLVSpace(ctx, cl, key, true)
+	sumOnDisk, err := sumLLVSpace(ctx, cl, key, true)
 	if err != nil {
-		return fmt.Errorf("unable to compute created LLV space for pool %s: %w", key, err)
+		return fmt.Errorf("unable to compute on-disk LLV space for pool %s: %w", key, err)
 	}
 
 	var totalCapacity int64
@@ -267,7 +274,7 @@ func CalibratePoolUnaccountedSpace(
 		reportedFree = tp.AvailableSpace.Value()
 	}
 
-	unaccounted := totalCapacity - sumCreated - reportedFree
+	unaccounted := totalCapacity - sumOnDisk - reportedFree
 	if unaccounted < 0 {
 		unaccounted = 0
 	}

--- a/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
@@ -122,6 +122,39 @@ func thinLLV(name, thinPoolName, size, phase string) *snc.LVMLogicalVolume {
 	return llv
 }
 
+func thickFailedLLVOnDisk(name, lvgName, specSize string, actualSize int64) *snc.LVMLogicalVolume {
+	return &snc.LVMLogicalVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: snc.LVMLogicalVolumeSpec{
+			LVMVolumeGroupName: lvgName,
+			Size:               specSize,
+			Type:               "Thick",
+		},
+		Status: &snc.LVMLogicalVolumeStatus{
+			Phase:      "Failed",
+			Reason:     "Desired LV size is less than actual one.",
+			ActualSize: *resource.NewQuantity(actualSize, resource.BinarySI),
+		},
+	}
+}
+
+func thinFailedLLVOnDisk(name, thinPoolName, specSize string, actualSize int64) *snc.LVMLogicalVolume {
+	return &snc.LVMLogicalVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: snc.LVMLogicalVolumeSpec{
+			LVMVolumeGroupName: "lvg1",
+			Size:               specSize,
+			Type:               "Thin",
+			Thin:               &snc.LVMLogicalVolumeThinSpec{PoolName: thinPoolName},
+		},
+		Status: &snc.LVMLogicalVolumeStatus{
+			Phase:      "Failed",
+			Reason:     "Desired LV size is less than actual one.",
+			ActualSize: *resource.NewQuantity(actualSize, resource.BinarySI),
+		},
+	}
+}
+
 func newFakeClient(objects ...client.Object) client.Client {
 	return fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).

--- a/images/sds-common-scheduler-extender/pkg/scheduler/space_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/space_test.go
@@ -48,9 +48,9 @@ func TestSumLLVSpace_ThickOnly(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(30)*oneGiB, total)
 
-	created, err := sumLLVSpace(ctx, cl, key, true)
+	onDisk, err := sumLLVSpace(ctx, cl, key, true)
 	require.NoError(t, err)
-	assert.Equal(t, int64(10)*oneGiB, created)
+	assert.Equal(t, int64(10)*oneGiB, onDisk)
 }
 
 func TestSumLLVSpace_ThinOnly(t *testing.T) {
@@ -67,9 +67,9 @@ func TestSumLLVSpace_ThinOnly(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(12)*oneGiB, total)
 
-	created, err := sumLLVSpace(ctx, cl, key, true)
+	onDisk, err := sumLLVSpace(ctx, cl, key, true)
 	require.NoError(t, err)
-	assert.Equal(t, int64(8)*oneGiB, created)
+	assert.Equal(t, int64(8)*oneGiB, onDisk)
 }
 
 func TestSumLLVSpace_NoLLVs(t *testing.T) {
@@ -93,9 +93,62 @@ func TestSumLLVSpace_NilStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(10)*oneGiB, total)
 
-	created, err := sumLLVSpace(ctx, cl, key, true)
+	onDisk, err := sumLLVSpace(ctx, cl, key, true)
 	require.NoError(t, err)
-	assert.Equal(t, int64(0), created)
+	assert.Equal(t, int64(0), onDisk)
+}
+
+func TestSumLLVSpace_FailedWithActualSize(t *testing.T) {
+	ctx := context.Background()
+	cl := newFakeClient(
+		readyLVG("lvg1", hundredGiB, hundredGiB),
+		thickLLV("llv-created", "lvg1", "20Gi", "Created"),
+		thickFailedLLVOnDisk("llv-failed", "lvg1", "40Gi", 41*oneGiB),
+	)
+	key := cache.StoragePoolKey{LVGName: "lvg1"}
+
+	total, err := sumLLVSpace(ctx, cl, key, false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(60)*oneGiB, total, "sumAll should include both Created and Failed LLVs")
+
+	onDisk, err := sumLLVSpace(ctx, cl, key, true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(60)*oneGiB, onDisk, "onlyOnDisk should include Failed LLV with actualSize > 0")
+}
+
+func TestSumLLVSpace_FailedWithoutActualSize(t *testing.T) {
+	ctx := context.Background()
+	cl := newFakeClient(
+		readyLVG("lvg1", hundredGiB, hundredGiB),
+		thickLLV("llv-created", "lvg1", "20Gi", "Created"),
+		thickLLV("llv-failed", "lvg1", "10Gi", "Failed"),
+	)
+	key := cache.StoragePoolKey{LVGName: "lvg1"}
+
+	total, err := sumLLVSpace(ctx, cl, key, false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(30)*oneGiB, total)
+
+	onDisk, err := sumLLVSpace(ctx, cl, key, true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(20)*oneGiB, onDisk, "onlyOnDisk should NOT include Failed LLV with zero actualSize")
+}
+
+func TestSumLLVSpace_ThinFailedWithActualSize(t *testing.T) {
+	ctx := context.Background()
+	cl := newFakeClient(
+		thinLLV("llv-created", "tp0", "10Gi", "Created"),
+		thinFailedLLVOnDisk("llv-failed", "tp0", "8Gi", 9*oneGiB),
+	)
+	key := cache.StoragePoolKey{LVGName: "lvg1", ThinPoolName: "tp0"}
+
+	total, err := sumLLVSpace(ctx, cl, key, false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(18)*oneGiB, total)
+
+	onDisk, err := sumLLVSpace(ctx, cl, key, true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(18)*oneGiB, onDisk, "onlyOnDisk should include thin Failed LLV with actualSize > 0")
 }
 
 // --- CalibratePoolUnaccountedSpace tests ---
@@ -138,7 +191,7 @@ func TestCalibratePool_InFlightLLVsIgnoredForCalibration(t *testing.T) {
 	ctx := context.Background()
 	// VGSize=100Gi, VGFree=80Gi
 	// Created LLV: 20Gi (reflected in VGFree), Pending LLV: 10Gi (not reflected)
-	// Calibration uses only Created: unaccounted = (100-20) - 80 = 0
+	// Calibration uses only on-disk LLVs: unaccounted = (100-20) - 80 = 0
 	lvg := readyLVG("lvg1", hundredGiB, 80*oneGiB)
 	cl := newFakeClient(
 		lvg,
@@ -409,7 +462,7 @@ func TestCalibratePool_ThinPool_InFlightIgnored(t *testing.T) {
 	ctx := context.Background()
 	// Thin pool: AllocatedSize=10Gi, AvailableSpace=40Gi → totalCapacity=50Gi
 	// Created LLV: 10Gi, Pending LLV: 8Gi (not reflected in AllocatedSize yet)
-	// Calibration uses only Created: unaccounted = (50 - 10) - 40 = 0
+	// Calibration uses only on-disk LLVs: unaccounted = (50 - 10) - 40 = 0
 	lvg := readyLVGWithThinPool("lvg1", 10*oneGiB, 40*oneGiB)
 	cl := newFakeClient(
 		lvg,
@@ -422,6 +475,97 @@ func TestCalibratePool_ThinPool_InFlightIgnored(t *testing.T) {
 	err := CalibratePoolUnaccountedSpace(ctx, cl, c, lvg, key)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), c.GetUnaccountedSpace(key))
+}
+
+func TestCalibratePool_FailedLLVOnDisk(t *testing.T) {
+	ctx := context.Background()
+	// VGSize=100Gi, VGFree=40Gi
+	// Created LLV: 20Gi, Failed LLV (on disk): 40Gi (actualSize=41Gi due to rounding)
+	// Both are on disk → sumOnDisk = 20 + 40 = 60Gi
+	// unaccounted = 100 - 60 - 40 = 0
+	lvg := readyLVG("lvg1", hundredGiB, 40*oneGiB)
+	cl := newFakeClient(
+		lvg,
+		thickLLV("llv-created", "lvg1", "20Gi", "Created"),
+		thickFailedLLVOnDisk("llv-failed", "lvg1", "40Gi", 41*oneGiB),
+	)
+	c := newTestCache()
+	key := cache.StoragePoolKey{LVGName: "lvg1"}
+
+	err := CalibratePoolUnaccountedSpace(ctx, cl, c, lvg, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), c.GetUnaccountedSpace(key))
+}
+
+func TestCalibratePool_ThinPool_FailedLLVOnDisk(t *testing.T) {
+	ctx := context.Background()
+	// Thin pool: AllocatedSize=30Gi (2 LVs on disk), AvailableSpace=20Gi
+	// totalCapacity = 30 + 20 = 50Gi
+	// Created LLV: 10Gi, Failed LLV (on disk): 20Gi → sumOnDisk = 30Gi
+	// unaccounted = 50 - 30 - 20 = 0
+	lvg := readyLVGWithThinPool("lvg1", 30*oneGiB, 20*oneGiB)
+	cl := newFakeClient(
+		lvg,
+		thinLLV("llv-created", "tp0", "10Gi", "Created"),
+		thinFailedLLVOnDisk("llv-failed", "tp0", "20Gi", 21*oneGiB),
+	)
+	c := newTestCache()
+	key := cache.StoragePoolKey{LVGName: "lvg1", ThinPoolName: "tp0"}
+
+	err := CalibratePoolUnaccountedSpace(ctx, cl, c, lvg, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), c.GetUnaccountedSpace(key))
+}
+
+func TestGetAvailableSpace_FailedLLVOnDisk_NoDoubleCount(t *testing.T) {
+	ctx := context.Background()
+	// Thin pool: AllocatedSize=30Gi, AvailableSpace=20Gi → totalCapacity=50Gi
+	// Created LLV: 10Gi, Failed LLV on disk: 20Gi
+	// sumAll = 30Gi, sumOnDisk = 30Gi (Failed LLV has actualSize)
+	// unaccounted = 50 - 30 - 20 = 0
+	// llvBased = 50 - 30 - 0 = 20Gi
+	// baseFree = min(20, 20) = 20Gi → available = 20Gi
+	// Previously this would be: sumOnDisk=10Gi (only Created), unaccounted=20,
+	// llvBased = 50-30-20 = 0, available = 0 (or negative with more Failed LLVs)
+	cl := newFakeClient(
+		readyLVGWithThinPool("lvg1", 30*oneGiB, 20*oneGiB),
+		thinLLV("llv-created", "tp0", "10Gi", "Created"),
+		thinFailedLLVOnDisk("llv-failed", "tp0", "20Gi", 21*oneGiB),
+	)
+	c := newTestCache()
+	key := cache.StoragePoolKey{LVGName: "lvg1", ThinPoolName: "tp0"}
+
+	info, err := getAvailableSpace(ctx, cl, c, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(20)*oneGiB, info.AvailableSpace,
+		"available space must not be reduced by Failed LLVs that are already on disk")
+	assert.Equal(t, int64(50)*oneGiB, info.TotalSize)
+}
+
+func TestGetAvailableSpace_FailedLLVOnDisk_ManyFailed(t *testing.T) {
+	ctx := context.Background()
+	// Regression test simulating production scenario:
+	// Thin pool: AllocatedSize=80Gi, AvailableSpace=20Gi → totalCapacity=100Gi
+	// Created LLVs: 40Gi, Failed LLVs on disk: 40Gi, Pending LLV: 5Gi
+	// sumAll = 85Gi, sumOnDisk = 80Gi (Created + Failed with actualSize)
+	// unaccounted = 100 - 80 - 20 = 0
+	// llvBased = 100 - 85 - 0 = 15Gi (correctly subtracts only the Pending 5Gi)
+	// baseFree = min(15, 20) = 15Gi → available = 15Gi
+	cl := newFakeClient(
+		readyLVGWithThinPool("lvg1", 80*oneGiB, 20*oneGiB),
+		thinLLV("llv-created-1", "tp0", "20Gi", "Created"),
+		thinLLV("llv-created-2", "tp0", "20Gi", "Created"),
+		thinFailedLLVOnDisk("llv-failed-1", "tp0", "20Gi", 21*oneGiB),
+		thinFailedLLVOnDisk("llv-failed-2", "tp0", "20Gi", 21*oneGiB),
+		thinLLV("llv-pending", "tp0", "5Gi", "Pending"),
+	)
+	c := newTestCache()
+	key := cache.StoragePoolKey{LVGName: "lvg1", ThinPoolName: "tp0"}
+
+	info, err := getAvailableSpace(ctx, cl, c, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(15)*oneGiB, info.AvailableSpace,
+		"available space should only be reduced by the truly Pending LLV, not by Failed LLVs on disk")
 }
 
 func TestGetAvailableSpace_NotReady(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a chain of issues where thousands of LLVs end up in `Failed` phase, causing the
scheduler extender to report negative available space and block all volume scheduling.

Three root causes identified and fixed:

- **Scheduler extender double-counting Failed LLVs** — Failed LLVs that already exist on disk
  (`actualSize > 0`) were counted twice: once through reduced `reportedFree` and again through
  `sumAll - sumCreated`. With thousands of such LLVs, `availableSpace` went deeply negative.
  Fixed by treating on-disk Failed LLVs as already reflected in `reportedFree`.

- **False Failed status when actualSize > spec.size** — `validateLVMLogicalVolume` incorrectly
  marked LLVs as `Failed` ("Desired LV size is less than actual one") when the backing LV was
  slightly larger than `spec.size` (normal for DRBD metadata overhead + extent alignment).
  Removed the check; `reconcileLLVUpdateFunc` already handles this case correctly.

- **ExtentSize=0 causing "extent size must be positive, got 0"** — `hasLVMVolumeGroupDiff` did not
  compare `ExtentSize`, so LVGs created before the field was added never got it populated.
  Added `ExtentSize` to the diff check and a 4Mi fallback (LVM default) in the LLV controller
  as defense-in-depth.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
