### PR TITLE
udev: remove unused sysfs readers, shorten package comments

### DIFF
--- a/images/agent/internal/udev/device.go
+++ b/images/agent/internal/udev/device.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-// Filesystem paths are vars so tests can override them with tmpdir.
+// Package-level paths; tests may override.
 var (
 	sysClassBlockPath = "/sys/class/block"
 	sysBlockPath      = "/sys/block"
@@ -34,7 +34,7 @@ var (
 
 const sectorSize = 512
 
-// UdevProperties contains typed fields extracted from a udev env map.
+// UdevProperties holds selected keys from a merged udev uevent/database map.
 type UdevProperties struct {
 	DevName  string
 	DevType  string
@@ -49,8 +49,6 @@ type UdevProperties struct {
 	DMUUID   string
 	MDLevel  string
 }
-
-// ================== sysfs readers ==================
 
 func ReadSysfsSize(devName string) (int64, error) {
 	data, err := os.ReadFile(filepath.Join(sysClassBlockPath, devName, "size"))
@@ -82,14 +80,8 @@ func ReadSysfsRemovable(devName string) (bool, error) {
 	return strings.TrimSpace(string(data)) == "1", nil
 }
 
-// ReadSysfsHotplug checks whether a block device is hotpluggable by walking
-// the sysfs device ancestor chain and looking for a "removable" attribute
-// containing "removable" (vs "fixed"). This mirrors lsblk's HOTPLUG column
-// (sysfs_blkdev_is_hotpluggable in util-linux), which is different from the
-// block device's own "removable" attribute (RM column).
-//
-// A USB hard drive has removable=0 at the block device level but a parent
-// directory (the USB port) is marked "removable", so HOTPLUG=true.
+// ReadSysfsHotplug reports hot-plug by walking sysfs ancestors for
+// removable=removable vs fixed (not the block device RM sysfs file alone).
 func ReadSysfsHotplug(devName string) (bool, error) {
 	devName = resolveParentForPartition(devName)
 
@@ -134,9 +126,8 @@ func ReadSysfsSlaves(devName string) ([]string, error) {
 	return names, nil
 }
 
-// resolveParentForPartition returns the parent disk name for partitions
-// so that rotational/removable can be read from the parent.
-// For non-partitions returns devName unchanged.
+// resolveParentForPartition returns the parent disk for partitions so
+// rotational/removable read the backing device; else devName unchanged.
 func resolveParentForPartition(devName string) string {
 	if !isPartition(devName) {
 		return devName
@@ -146,8 +137,6 @@ func resolveParentForPartition(devName string) string {
 	}
 	return devName
 }
-
-// ================== udev DB ==================
 
 func ReadUdevDB(major, minor int) (map[string]string, error) {
 	path := fmt.Sprintf("%s/b%d:%d", runUdevDataPath, major, minor)
@@ -171,9 +160,7 @@ func ReadUdevDB(major, minor int) (map[string]string, error) {
 	return props, nil
 }
 
-// MergeEnvWithUdevDB enriches the env map from a crawler/netlink event
-// with additional properties from /run/udev/data/bMAJOR:MINOR.
-// Existing env keys take precedence over udev DB keys.
+// MergeEnvWithUdevDB adds /run/udev/data/b<major>:<minor>; event keys win.
 func MergeEnvWithUdevDB(env map[string]string) map[string]string {
 	majorStr, hasMajor := env["MAJOR"]
 	minorStr, hasMinor := env["MINOR"]
@@ -198,8 +185,6 @@ func MergeEnvWithUdevDB(env map[string]string) map[string]string {
 	}
 	return merged
 }
-
-// ================== mapping ==================
 
 func ParseUdevProperties(env map[string]string) UdevProperties {
 	major, _ := strconv.Atoi(env["MAJOR"])
@@ -275,10 +260,8 @@ func ResolveKernelName(devName string) string {
 	return "/dev/" + devName
 }
 
-// ResolveParentDevice determines the parent kernel device name (PkName).
-// For partitions: the parent disk. For DM/MD: the first slave device.
-// Partition check comes first so that MD partitions (md0p1) resolve to
-// their parent array (md0) rather than attempting a slaves lookup.
+// ResolveParentDevice returns PkName: sysfs parent for partitions (first);
+// for dm-* / md* the first slave. Partition-first avoids md0p1 -> wrong path.
 func ResolveParentDevice(devName string) string {
 	if isPartition(devName) {
 		if parent := parentFromSysfs(devName); parent != "" {
@@ -294,20 +277,13 @@ func ResolveParentDevice(devName string) string {
 	return ""
 }
 
-// isPartition checks if the device has a "partition" file in sysfs,
-// which is the authoritative way to distinguish partitions from
-// whole devices whose names happen to end with digits (loop0, nbd0, sr0).
 func isPartition(devName string) bool {
 	partitionFile := filepath.Join(sysClassBlockPath, devName, "partition")
 	_, err := os.Stat(partitionFile)
 	return err == nil
 }
 
-// parentFromSysfs reads the sysfs symlink for a partition device to determine
-// its parent disk. In sysfs, /sys/class/block/<partition> is a symlink like
-// ../../devices/.../block/<parent_disk>/<partition>, so the parent directory
-// name in the symlink target is the parent disk name. This works for all
-// naming schemes: sda1->sda, nvme0n1p1->nvme0n1, mmcblk0p1->mmcblk0, nbd0p1->nbd0.
+// parentFromSysfs returns the parent block name from /sys/class/block/<part> symlink.
 func parentFromSysfs(devName string) string {
 	link, err := os.Readlink(filepath.Join(sysClassBlockPath, devName))
 	if err != nil {
@@ -324,24 +300,7 @@ func SysfsDevName(devPath string) string {
 	return strings.TrimPrefix(devPath, "/dev/")
 }
 
-func readSysfsFile(devName, fileName string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(sysClassBlockPath, devName, fileName))
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
-
-// DeviceKey builds a "major:minor" key from separate values.
+// DeviceKey returns "major:minor".
 func DeviceKey(major, minor int) string {
 	return strconv.Itoa(major) + ":" + strconv.Itoa(minor)
-}
-
-// ReadDevMajorMinor reads the dev file from sysfs and returns "major:minor".
-func ReadDevMajorMinor(devName string) (string, error) {
-	data, err := readSysfsFile(devName, "dev")
-	if err != nil {
-		return "", fmt.Errorf("reading dev for %s: %w", devName, err)
-	}
-	return strings.TrimSpace(data), nil
 }

--- a/images/agent/internal/udev/mountinfo.go
+++ b/images/agent/internal/udev/mountinfo.go
@@ -23,13 +23,8 @@ import (
 	"strings"
 )
 
-// ParseMountInfo reads /proc/1/mountinfo (the host init process) and returns a map
-// of "major:minor" -> mount point. We read PID 1's mountinfo because the agent runs
-// in a container with hostPID: true, and /proc/self/mountinfo would only show the
-// container's mount namespace (overlayfs, tmpfs), not the actual host block device mounts.
-// See https://www.kernel.org/doc/Documentation/filesystems/proc.txt (section 3.5)
-// Format: 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
-// Fields: [0]=mount_id [1]=parent_id [2]=major:minor [3]=root [4]=mount_point ...
+// ParseMountInfo parses mountinfo (default PID 1 under hostPID) into major:minor -> mount point;
+// first mount per device wins.
 func ParseMountInfo() (map[string]string, error) {
 	f, err := os.Open(procSelfMountInfo)
 	if err != nil {

--- a/images/agent/internal/udev/scanner.go
+++ b/images/agent/internal/udev/scanner.go
@@ -29,8 +29,7 @@ import (
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal/logger"
 )
 
-// DeviceMap is an in-memory store of block device udev properties,
-// keyed by "major:minor". Updated incrementally by netlink events.
+// DeviceMap stores merged udev env per "major:minor"; netlink updates incrementally.
 type DeviceMap struct {
 	mu      sync.RWMutex
 	devices map[string]map[string]string // key = "major:minor", value = merged env map
@@ -52,7 +51,7 @@ func devKey(env map[string]string) (string, error) {
 	return major + ":" + minor, nil
 }
 
-// HandleEvent processes a netlink UEvent and updates the device map.
+// HandleEvent applies a netlink uevent to the map.
 func (dm *DeviceMap) HandleEvent(event *netlink.UEvent) {
 	env := MergeEnvWithUdevDB(event.Env)
 
@@ -73,10 +72,7 @@ func (dm *DeviceMap) HandleEvent(event *netlink.UEvent) {
 	}
 }
 
-// FillFromCrawler replaces the entire device map with devices from crawler results.
-// For each device, it merges udev DB properties on top of the uevent env.
-// This is safe to call multiple times (e.g. after netlink reconnect) --
-// old entries not present in the new crawl are removed.
+// FillFromCrawler replaces the map from a full crawl (MergeEnvWithUdevDB per device).
 func (dm *DeviceMap) FillFromCrawler(devices []crawler.Device) {
 	newDevices := make(map[string]map[string]string, len(devices))
 	for _, dev := range devices {
@@ -94,10 +90,7 @@ func (dm *DeviceMap) FillFromCrawler(devices []crawler.Device) {
 	dm.devices = newDevices
 }
 
-// Snapshot converts the current device map into a slice of internal.Device,
-// reading additional properties from sysfs. Mount-point enrichment is handled
-// separately by the caller (scanner) to decouple mount info failures from
-// device discovery.
+// Snapshot builds internal.Device from the map plus sysfs; mount paths are filled elsewhere.
 func (dm *DeviceMap) Snapshot() ([]internal.Device, []string) {
 	dm.mu.RLock()
 	envsCopy := make(map[string]map[string]string, len(dm.devices))
@@ -166,7 +159,7 @@ func (dm *DeviceMap) Snapshot() ([]internal.Device, []string) {
 	return result, errs
 }
 
-// Len returns the number of tracked devices.
+// Len returns the number of devices in the map.
 func (dm *DeviceMap) Len() int {
 	dm.mu.RLock()
 	defer dm.mu.RUnlock()


### PR DESCRIPTION
Stacked on [#209](https://github.com/deckhouse/sds-node-configurator/pull/209).

## Changes
- Remove unused `ReadDevMajorMinor` and `readSysfsFile` from `images/agent/internal/udev` (major:minor already comes from udev env).
- Shorten package comments in `device.go`, `scanner.go`, `mountinfo.go`.

## Verification
- `GOOS=linux GOARCH=amd64 go test -c ./internal/udev/...` from `images/agent` (darwin cannot build netlink-dependent tests without Linux target).