### PR TITLE
fix(agent): align udev model/serial/wwn with lsblk for stable BD iden…

### DIFF
--- a/images/agent/internal/udev/device.go
+++ b/images/agent/internal/udev/device.go
@@ -191,11 +191,8 @@ func ParseUdevProperties(env map[string]string) UdevProperties {
 	major, _ := strconv.Atoi(env["MAJOR"])
 	minor, _ := strconv.Atoi(env["MINOR"])
 
-	serial := env["ID_SERIAL_SHORT"]
-	if serial == "" {
-		serial = env["ID_SERIAL"]
-	}
-
+	// Model / serial / WWN follow lsblk get_properties_by_udev() (misc-utils/lsblk-properties.c)
+	// so BlockDevice identity matches `lsblk -J` on main (pre-netlink) for the same hardware.
 	devName := env["DEVNAME"]
 	if devName != "" && !strings.HasPrefix(devName, "/dev/") {
 		devName = "/dev/" + devName
@@ -206,9 +203,9 @@ func ParseUdevProperties(env map[string]string) UdevProperties {
 		DevType:  env["DEVTYPE"],
 		Major:    major,
 		Minor:    minor,
-		Serial:   serial,
-		Model:    env["ID_MODEL"],
-		WWN:      env["ID_WWN"],
+		Serial:   serialFromUdevEnv(env),
+		Model:    modelFromUdevEnv(env),
+		WWN:      wwnFromUdevEnv(env),
 		FSType:   env["ID_FS_TYPE"],
 		PartUUID: env["ID_PART_ENTRY_UUID"],
 		DMName:   env["DM_NAME"],

--- a/images/agent/internal/udev/device_test.go
+++ b/images/agent/internal/udev/device_test.go
@@ -114,6 +114,44 @@ func TestParseUdevProperties_SerialFallback(t *testing.T) {
 	assert.Equal(t, "WDC_WD10EZEX_WD-ABC123", props.Serial, "Falls back to ID_SERIAL")
 }
 
+func TestParseUdevProperties_SerialScsiChainAndNormalize(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":            "/dev/sda",
+		"MAJOR":              "8",
+		"MINOR":              "0",
+		"SCSI_IDENT_SERIAL":  "  SG3  ID  ",
+		"ID_SCSI_SERIAL":     "scsi",
+		"ID_SERIAL_SHORT":    "short",
+		"ID_SERIAL":          "long",
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "SG3 ID", props.Serial)
+}
+
+func TestParseUdevProperties_WwnPrefersExtension(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":               "/dev/sda",
+		"MAJOR":                 "8",
+		"MINOR":                 "0",
+		"ID_WWN":                "0x5000",
+		"ID_WWN_WITH_EXTENSION": "0x5000deadbeef",
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "0x5000deadbeef", props.WWN)
+}
+
+func TestParseUdevProperties_ModelFromEnc(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":      "/dev/sda",
+		"MAJOR":        "8",
+		"MINOR":        "0",
+		"ID_MODEL":     "IGNORED_WHEN_ENC",
+		"ID_MODEL_ENC": `Vendor\x20Disk\x20Name`,
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "Vendor Disk Name", props.Model)
+}
+
 func TestParseUdevProperties_DevNamePrefixAdded(t *testing.T) {
 	env := map[string]string{
 		"DEVNAME": "sda",

--- a/images/agent/internal/udev/lsblk_strings.go
+++ b/images/agent/internal/udev/lsblk_strings.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+// normalizeWhitespace collapses runs of ASCII whitespace and trims leading /
+// trailing space, matching util-linux __normalize_whitespace() / normalize_whitespace()
+// in include/strutils.h (used by lsblk after udev properties).
+func normalizeWhitespace(src []byte) []byte {
+	sz := len(src)
+	if sz == 0 {
+		return nil
+	}
+	dst := make([]byte, sz+1)
+	var i, x int
+	nsp := 0
+	intext := 0
+	for i < sz && x < len(dst)-1 {
+		b := src[i]
+		isSpace := b == ' ' || b == '\t' || b == '\n' || b == '\v' || b == '\f' || b == '\r'
+		if isSpace {
+			nsp++
+		} else {
+			nsp = 0
+			intext = 1
+		}
+		if nsp > 1 || (nsp > 0 && intext == 0) {
+			i++
+			continue
+		}
+		dst[x] = src[i]
+		x++
+		i++
+	}
+	if nsp > 0 && x > 0 {
+		x--
+	}
+	return dst[:x]
+}
+
+func fromHex(c byte) byte {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0'
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10
+	default:
+		return 0
+	}
+}
+
+func isXdigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+// unhexmangle decodes udev \\xHH sequences in place of the four-byte escape,
+// matching unhexmangle_to_buffer() in util-linux lib/mangle.c (unhexmangle_string).
+func unhexmangle(src []byte) []byte {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]byte, 0, len(src))
+	i := 0
+	for i < len(src) {
+		if i+3 < len(src) && src[i] == '\\' && src[i+1] == 'x' &&
+			isXdigit(src[i+2]) && isXdigit(src[i+3]) {
+			dst = append(dst, fromHex(src[i+2])<<4|fromHex(src[i+3]))
+			i += 4
+		} else {
+			dst = append(dst, src[i])
+			i++
+		}
+	}
+	return dst
+}
+
+// normalizeUdevSerialOrModel applies lsblk's normalize_whitespace to a property string.
+func normalizeUdevSerialOrModel(s string) string {
+	if s == "" {
+		return ""
+	}
+	out := normalizeWhitespace([]byte(s))
+	return string(out)
+}
+
+// modelFromUdevEnv matches lsblk get_properties_by_udev: ID_MODEL_ENC (unhexmangle + normalize)
+// or ID_MODEL + normalize.
+func modelFromUdevEnv(env map[string]string) string {
+	if enc := env["ID_MODEL_ENC"]; enc != "" {
+		return string(normalizeWhitespace(unhexmangle([]byte(enc))))
+	}
+	if m := env["ID_MODEL"]; m != "" {
+		return normalizeUdevSerialOrModel(m)
+	}
+	return ""
+}
+
+// serialFromUdevEnv matches lsblk: SCSI_IDENT_SERIAL → ID_SCSI_SERIAL → ID_SERIAL_SHORT → ID_SERIAL,
+// then normalize_whitespace.
+func serialFromUdevEnv(env map[string]string) string {
+	var raw string
+	switch {
+	case env["SCSI_IDENT_SERIAL"] != "":
+		raw = env["SCSI_IDENT_SERIAL"]
+	case env["ID_SCSI_SERIAL"] != "":
+		raw = env["ID_SCSI_SERIAL"]
+	case env["ID_SERIAL_SHORT"] != "":
+		raw = env["ID_SERIAL_SHORT"]
+	default:
+		raw = env["ID_SERIAL"]
+	}
+	return normalizeUdevSerialOrModel(raw)
+}
+
+// wwnFromUdevEnv matches lsblk: ID_WWN_WITH_EXTENSION, else ID_WWN (no normalization).
+func wwnFromUdevEnv(env map[string]string) string {
+	if env["ID_WWN_WITH_EXTENSION"] != "" {
+		return env["ID_WWN_WITH_EXTENSION"]
+	}
+	return env["ID_WWN"]
+}

--- a/images/agent/internal/udev/lsblk_strings_test.go
+++ b/images/agent/internal/udev/lsblk_strings_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeWhitespace(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"a", "a"},
+		{"  a", "a"},
+		{"a  b", "a b"},
+		{"a \t b", "a b"},
+		{"a b ", "a b"},
+		{"  a  b  ", "a b"},
+		{"   ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			var got string
+			if tt.in != "" {
+				got = string(normalizeWhitespace([]byte(tt.in)))
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUnhexmangle(t *testing.T) {
+	assert.Equal(t, "ST330006 50NS", string(unhexmangle([]byte(`ST330006\x2050NS`))))
+	assert.Equal(t, `no\xhex`, string(unhexmangle([]byte(`no\xhex`))))
+	assert.Equal(t, "A", string(unhexmangle([]byte(`\x41`))))
+}
+
+func TestSerialFromUdevEnv_Chain(t *testing.T) {
+	base := map[string]string{
+		"ID_SERIAL_SHORT": "short",
+		"ID_SERIAL":       "long",
+	}
+	assert.Equal(t, "short", serialFromUdevEnv(base))
+
+	env := map[string]string{
+		"ID_SCSI_SERIAL":  "scsi",
+		"ID_SERIAL_SHORT": "short",
+	}
+	assert.Equal(t, "scsi", serialFromUdevEnv(env))
+
+	env2 := map[string]string{
+		"SCSI_IDENT_SERIAL": "sg",
+		"ID_SCSI_SERIAL":    "scsi",
+	}
+	assert.Equal(t, "sg", serialFromUdevEnv(env2))
+}
+
+func TestWwnFromUdevEnv_PrefersExtension(t *testing.T) {
+	env := map[string]string{
+		"ID_WWN":                  "0x5000",
+		"ID_WWN_WITH_EXTENSION":   "0x5000abc",
+	}
+	assert.Equal(t, "0x5000abc", wwnFromUdevEnv(env))
+}
+
+func TestModelFromUdevEnv_EncVersusPlain(t *testing.T) {
+	env := map[string]string{
+		"ID_MODEL":     "Plain",
+		"ID_MODEL_ENC": `Foo\x20Bar`,
+	}
+	assert.Equal(t, "Foo Bar", modelFromUdevEnv(env))
+
+	env2 := map[string]string{
+		"ID_MODEL": "  two  spaces  ",
+	}
+	assert.Equal(t, "two spaces", modelFromUdevEnv(env2))
+}


### PR DESCRIPTION
…tity

ParseUdevProperties now mirrors util-linux get_properties_by_udev (lsblk-properties.c): WWN extension first, SCSI serial chain, ID_MODEL_ENC unhexmangle + whitespace normalization matching strutils.h. This keeps dev-<sha1> consistent with main which sourced these fields from lsblk -J.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
