### PR TITLE
feat(agent): add mountinfo parser for mount-point detection

### DIFF
--- a/images/agent/internal/utils/mountinfo.go
+++ b/images/agent/internal/utils/mountinfo.go
@@ -23,6 +23,13 @@ import (
 	"strings"
 )
 
+// ProcHostMountInfo is the mountinfo of PID 1 (the host's init process).
+// The agent runs with hostPID: true (see templates/agent/daemonset.yaml), so PID 1
+// in the pod's PID namespace is the host's init. /proc/1/mountinfo therefore
+// exposes the host's mount namespace (see proc_pid_mountinfo(5)).
+// This is equivalent to `nsenter -t 1 -m -- cat /proc/self/mountinfo` (the same
+// PID 1 reference used by all LVM commands, see nsentrerExpendedArgs) but avoids
+// spawning a separate process.
 const ProcHostMountInfo = "/proc/1/mountinfo"
 
 // ParseMountInfo parses a mountinfo file (see proc(5)) into a map of "major:minor" → mount-point path.
@@ -33,8 +40,6 @@ const ProcHostMountInfo = "/proc/1/mountinfo"
 //
 // When a device appears multiple times (e.g. bind mounts), the last mount point wins,
 // matching lsblk MOUNTPOINT semantics ("usually the last mounted instance").
-// For the current use case (determining whether a device is mounted at all)
-// the specific path does not matter — any non-empty value is sufficient.
 //
 // Mount-point paths are decoded from kernel octal escapes (\NNN) so the returned
 // strings match real filesystem paths (parity with lsblk output).

--- a/images/agent/internal/utils/mountinfo.go
+++ b/images/agent/internal/utils/mountinfo.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const ProcHostMountInfo = "/proc/1/mountinfo"
+
+// ParseMountInfo parses a mountinfo file (see proc(5)) into a map of "major:minor" → mount-point path.
+//
+// mountinfo format (see proc(5), one line per mount):
+//
+//	mount_id parent_id major:minor root mount_point mount_options optional_fields - fs_type source super_options
+//
+// When a device appears multiple times (e.g. bind mounts), the last mount point wins,
+// matching lsblk MOUNTPOINT semantics ("usually the last mounted instance").
+// For the current use case (determining whether a device is mounted at all)
+// the specific path does not matter — any non-empty value is sufficient.
+//
+// Mount-point paths are decoded from kernel octal escapes (\NNN) so the returned
+// strings match real filesystem paths (parity with lsblk output).
+func ParseMountInfo(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("[ParseMountInfo] opening mountinfo: %w", err)
+	}
+	defer f.Close()
+
+	result := make(map[string]string, 64)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 5 {
+			continue
+		}
+
+		devID := fields[2]
+		if !strings.Contains(devID, ":") {
+			continue
+		}
+
+		mountPoint := decodeMountInfoOctal(fields[4])
+
+		result[devID] = mountPoint
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("[ParseMountInfo] scanning mountinfo: %w", err)
+	}
+	return result, nil
+}
+
+// decodeMountInfoOctal decodes octal escape sequences (\NNN) used by the kernel
+// in /proc/*/mountinfo paths (see mangle_path in fs/seq_file.c).
+// Currently the kernel escapes space (\040), tab (\011), newline (\012),
+// and backslash (\134), but this decoder handles any valid 3-digit octal sequence.
+func decodeMountInfoOctal(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+3 < len(s) {
+			o1, o2, o3 := s[i+1]-'0', s[i+2]-'0', s[i+3]-'0'
+			if o1 <= 7 && o2 <= 7 && o3 <= 7 {
+				b.WriteByte(o1*64 + o2*8 + o3)
+				i += 3
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/images/agent/internal/utils/mountinfo_test.go
+++ b/images/agent/internal/utils/mountinfo_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withFakeMountInfo(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	fakePath := filepath.Join(dir, "mountinfo")
+	require.NoError(t, os.WriteFile(fakePath, []byte(content), 0o644))
+	return fakePath
+}
+
+func TestParseMountInfo_MultipleEntries(t *testing.T) {
+	content := `22 1 8:1 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
+23 22 8:2 / /boot rw,nosuid,nodev shared:2 - ext4 /dev/sda2 rw
+24 22 0:20 / /proc rw,nosuid,nodev,noexec,relatime shared:5 - proc proc rw
+25 22 259:0 / /data rw,relatime shared:10 - xfs /dev/nvme0n1 rw
+`
+	path := withFakeMountInfo(t, content)
+
+	mounts, err := ParseMountInfo(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/", mounts["8:1"])
+	assert.Equal(t, "/boot", mounts["8:2"])
+	assert.Equal(t, "/proc", mounts["0:20"])
+	assert.Equal(t, "/data", mounts["259:0"])
+	assert.Len(t, mounts, 4)
+}
+
+func TestParseMountInfo_DuplicateDevID_LastWins(t *testing.T) {
+	content := `22 1 8:1 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
+30 22 8:1 / /mnt/copy rw,relatime shared:1 - ext4 /dev/sda1 rw
+`
+	path := withFakeMountInfo(t, content)
+
+	mounts, err := ParseMountInfo(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/mnt/copy", mounts["8:1"], "last mount point should win")
+	assert.Len(t, mounts, 1)
+}
+
+func TestParseMountInfo_EmptyFile(t *testing.T) {
+	path := withFakeMountInfo(t, "")
+
+	mounts, err := ParseMountInfo(path)
+	require.NoError(t, err)
+	assert.Empty(t, mounts)
+}
+
+func TestParseMountInfo_FileNotExist(t *testing.T) {
+	path := "/nonexistent/path/mountinfo"
+	_, err := ParseMountInfo(path)
+	assert.Error(t, err)
+}
+
+func TestParseMountInfo_ShortLines_Skipped(t *testing.T) {
+	content := `22 1 8:1 /
+25 22 259:0 / /data rw,relatime shared:10 - xfs /dev/nvme0n1 rw
+`
+	path := withFakeMountInfo(t, content)
+
+	mounts, err := ParseMountInfo(path)
+	require.NoError(t, err)
+	assert.Len(t, mounts, 1)
+	assert.Equal(t, "/data", mounts["259:0"])
+}
+
+func TestParseMountInfo_KernelDocExample(t *testing.T) {
+	content := `36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+100 35 8:1 / /boot rw,noatime - ext4 /dev/sda1 rw,data=ordered
+`
+	path := withFakeMountInfo(t, content)
+
+	mounts, err := ParseMountInfo(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/mnt2", mounts["98:0"])
+	assert.Equal(t, "/boot", mounts["8:1"])
+}
+
+func TestParseMountInfo_OctalEscapeSpace(t *testing.T) {
+	content := "30 1 8:1 / /mnt/my\\040data rw,relatime shared:1 - ext4 /dev/sda1 rw\n"
+	path := withFakeMountInfo(t, content)
+
+	mounts, err := ParseMountInfo(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/mnt/my data", mounts["8:1"])
+}
+
+func TestParseMountInfo_OctalEscapeMultiple(t *testing.T) {
+	content := "30 1 8:1 / /mnt/a\\040b\\011c\\134d rw,relatime shared:1 - ext4 /dev/sda1 rw\n"
+	path := withFakeMountInfo(t, content)
+
+	mounts, err := ParseMountInfo(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/mnt/a b\tc\\d", mounts["8:1"])
+}
+
+func TestParseMountInfo_MalformedDevID_Skipped(t *testing.T) {
+	content := `22 1 badfield / / rw,relatime shared:1 - ext4 /dev/sda1 rw
+25 22 259:0 / /data rw,relatime shared:10 - xfs /dev/nvme0n1 rw
+`
+	path := withFakeMountInfo(t, content)
+
+	mounts, err := ParseMountInfo(path)
+	require.NoError(t, err)
+
+	assert.Len(t, mounts, 1)
+	assert.Equal(t, "/data", mounts["259:0"])
+}
+
+func TestDecodeMountInfoOctal_NoEscapes(t *testing.T) {
+	assert.Equal(t, "/mnt/data", decodeMountInfoOctal("/mnt/data"))
+}
+
+func TestDecodeMountInfoOctal_AllKernelEscapes(t *testing.T) {
+	assert.Equal(t, " ", decodeMountInfoOctal(`\040`))
+	assert.Equal(t, "\t", decodeMountInfoOctal(`\011`))
+	assert.Equal(t, "\n", decodeMountInfoOctal(`\012`))
+	assert.Equal(t, `\`, decodeMountInfoOctal(`\134`))
+}
+
+func TestDecodeMountInfoOctal_TrailingBackslash(t *testing.T) {
+	assert.Equal(t, `path\`, decodeMountInfoOctal(`path\`))
+	assert.Equal(t, `path\ab`, decodeMountInfoOctal(`path\ab`))
+}


### PR DESCRIPTION
## Summary

Adds a parser for Linux mountinfo format as a future replacement for the lsblk `MOUNTPOINT` column when determining whether a block device is mounted.

Currently the agent calls `lsblk -J ... MOUNTPOINT ...` on every scan cycle. This parser reads the same data directly from the kernel (`/proc/1/mountinfo`) without spawning an external process, targeting integration with the netlink event pipeline.

### Why `/proc/1/mountinfo`

The agent's DaemonSet is deployed with [`hostPID: true`](https://github.com/deckhouse/sds-node-configurator/blob/0ef81bae5ae737533dbe79a97832d0600306a213/templates/agent/daemonset.yaml#L76), so PID 1 inside the pod is the host's init process. `/proc/pid/mountinfo` shows mounts in that process's mount namespace ([proc_pid_mountinfo(5)](https://man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html)), meaning `/proc/1/mountinfo` exposes the host's mount table — the one we need to determine if a block device is mounted on the node.

This is the same PID 1 reference already used by all LVM commands via [`nsenter -t 1 -m`](https://github.com/deckhouse/sds-node-configurator/blob/0ef81bae5ae737533dbe79a97832d0600306a213/images/agent/internal/utils/commands.go#L757), but reading the file directly avoids spawning a separate process.

## What's included

- `ParseMountInfo(path)` — parses any mountinfo-formatted file into `map[major:minor]mountPoint`
- Octal escape decoding (`\040`->space, `\011`->tab, `\012`->newline, `\134`->backslash) for path parity with lsblk
- Last-wins semantics for duplicate devices (bind mounts), matching lsblk MOUNTPOINT behavior ("usually the last mounted instance")
- `major:minor` format validation
- Key is `major:minor` — the canonical kernel device identifier, directly available from netlink `MAJOR`/`MINOR` env vars, no ambiguity with symlinks/device-mapper paths
- Comprehensive tests: multiple entries, duplicate dev ID (last wins), empty file, missing file, short/malformed lines, kernel doc example, all octal escapes, trailing backslash

## Follow-up

The parser will be integrated into the netlink event processing pipeline to populate `Device.MountPoint` without calling lsblk.