### PR TITLE
[agent] Add sysfs readers and udev property parsers for netlink-based device discovery

### DIFF
--- a/images/agent/internal/udev/properties.go
+++ b/images/agent/internal/udev/properties.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"strconv"
+	"strings"
+)
+
+type UdevProperties struct {
+	DevName  string
+	DevType  string
+	Major    int
+	Minor    int
+	Serial   string
+	Model    string
+	WWN      string
+	FSType   string
+	PartUUID string
+	DMName   string
+	DMUUID   string
+	MDLevel  string
+}
+
+func ParseUdevProperties(env map[string]string) UdevProperties {
+	major, _ := strconv.Atoi(env["MAJOR"])
+	minor, _ := strconv.Atoi(env["MINOR"])
+
+	devName := ensureDevPrefix(env["DEVNAME"])
+
+	return UdevProperties{
+		DevName:  devName,
+		DevType:  env["DEVTYPE"],
+		Major:    major,
+		Minor:    minor,
+		Serial:   serialFromUdevEnv(env),
+		Model:    modelFromUdevEnv(env),
+		WWN:      wwnFromUdevEnv(env),
+		FSType:   env["ID_FS_TYPE"],
+		PartUUID: env["ID_PART_ENTRY_UUID"],
+		DMName:   env["DM_NAME"],
+		DMUUID:   env["DM_UUID"],
+		MDLevel:  env["MD_LEVEL"],
+	}
+}
+
+// ResolveDeviceType returns the lsblk-style TYPE (util-linux misc-utils/lsblk.c get_type()).
+// Order: partition, device-mapper, loop, md, sr prefix, fallback "disk".
+func ResolveDeviceType(props UdevProperties, devName string) string {
+	bare := SysfsDevName(devName)
+	if bare == "" {
+		bare = SysfsDevName(props.DevName)
+	}
+
+	if props.DevType == "partition" {
+		return "part"
+	}
+	if props.DevType == "" && bare != "" && isPartition(bare) {
+		return "part"
+	}
+
+	if strings.HasPrefix(bare, "dm-") {
+		return dmTypeFromDMUUID(props.DMUUID)
+	}
+
+	if strings.HasPrefix(bare, "loop") {
+		return "loop"
+	}
+
+	if strings.HasPrefix(bare, "md") {
+		if lvl := strings.TrimSpace(props.MDLevel); lvl != "" {
+			return strings.ToLower(lvl)
+		}
+		return "md"
+	}
+
+	if strings.HasPrefix(bare, "sr") {
+		return "rom"
+	}
+	return "disk"
+}
+
+// dmTypeFromDMUUID derives TYPE from dm uuid prefix (substring before first '-', lowercased).
+// kpartx uses a "part*" prefix trimmed to "part" (lsblk get_type).
+func dmTypeFromDMUUID(dmUUID string) string {
+	if dmUUID == "" {
+		return "dm"
+	}
+	prefix := dmUUID
+	if i := strings.Index(dmUUID, "-"); i >= 0 {
+		prefix = dmUUID[:i]
+	}
+	if prefix == "" {
+		return "dm"
+	}
+	if len(prefix) >= 4 && strings.EqualFold(prefix[:4], "part") {
+		prefix = "part"
+	}
+	return strings.ToLower(prefix)
+}
+
+func ResolveDeviceName(props UdevProperties) string {
+	if props.DMName != "" {
+		return "/dev/mapper/" + props.DMName
+	}
+	return ensureDevPrefix(props.DevName)
+}
+
+func ResolveKernelName(devName string) string {
+	return ensureDevPrefix(devName)
+}
+
+// ResolveParentDevice returns PkName: sysfs parent for partitions (first);
+// for dm-* / md* the first slave. Partition-first avoids md0p1 -> wrong path.
+func ResolveParentDevice(devName string) string {
+	devName = SysfsDevName(devName)
+	if isPartition(devName) {
+		if parent := parentFromSysfs(devName); parent != "" {
+			return "/dev/" + parent
+		}
+	}
+	if strings.HasPrefix(devName, "dm-") || strings.HasPrefix(devName, "md") {
+		slaves, err := ReadSysfsSlaves(devName)
+		if err == nil && len(slaves) > 0 {
+			return "/dev/" + slaves[0]
+		}
+	}
+	return ""
+}
+
+// serialFromUdevEnv follows the lsblk get_properties_by_udev() priority chain:
+// SCSI_IDENT_SERIAL -> ID_SCSI_SERIAL -> ID_SERIAL_SHORT -> ID_SERIAL.
+func serialFromUdevEnv(env map[string]string) string {
+	for _, key := range []string{"SCSI_IDENT_SERIAL", "ID_SCSI_SERIAL", "ID_SERIAL_SHORT", "ID_SERIAL"} {
+		if v := env[key]; v != "" {
+			return normalizeWhitespace(v)
+		}
+	}
+	return ""
+}
+
+// modelFromUdevEnv follows lsblk: ID_MODEL_ENC (unhexmangle + normalize) or ID_MODEL.
+func modelFromUdevEnv(env map[string]string) string {
+	if enc := env["ID_MODEL_ENC"]; enc != "" {
+		return normalizeWhitespace(unhexmangle(enc))
+	}
+	return normalizeWhitespace(env["ID_MODEL"])
+}
+
+// wwnFromUdevEnv follows lsblk: ID_WWN_WITH_EXTENSION takes priority over ID_WWN.
+func wwnFromUdevEnv(env map[string]string) string {
+	if v := env["ID_WWN_WITH_EXTENSION"]; v != "" {
+		return v
+	}
+	return env["ID_WWN"]
+}
+
+// normalizeWhitespace collapses whitespace runs and trims edges,
+// matching util-linux normalize_whitespace() used by lsblk after reading udev properties.
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func hexVal(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	default:
+		return -1
+	}
+}
+
+// unhexmangle decodes udev \xHH escape sequences,
+// matching unhexmangle_to_buffer() in util-linux lib/mangle.c.
+func unhexmangle(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if i+3 < len(s) && s[i] == '\\' && s[i+1] == 'x' &&
+			hexVal(s[i+2]) >= 0 && hexVal(s[i+3]) >= 0 {
+			b.WriteByte(byte(hexVal(s[i+2])<<4 | hexVal(s[i+3])))
+			i += 4
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+func ensureDevPrefix(devName string) string {
+	if devName == "" || strings.HasPrefix(devName, "/dev/") {
+		return devName
+	}
+	return "/dev/" + devName
+}
+
+// DeviceKey returns "major:minor".
+func DeviceKey(major, minor int) string {
+	return strconv.Itoa(major) + ":" + strconv.Itoa(minor)
+}

--- a/images/agent/internal/udev/properties_test.go
+++ b/images/agent/internal/udev/properties_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ================== ParseUdevProperties ==================
+
+func TestParseUdevProperties_FullEnv(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":            "sda",
+		"DEVTYPE":            "disk",
+		"MAJOR":              "8",
+		"MINOR":              "0",
+		"ID_SERIAL_SHORT":    "WD-ABC123",
+		"ID_SERIAL":          "WDC_WD10EZEX_WD-ABC123",
+		"ID_MODEL":           "WDC_WD10EZEX",
+		"ID_WWN":             "0x50014ee2b5e7c5a0",
+		"ID_FS_TYPE":         "ext4",
+		"ID_PART_ENTRY_UUID": "abcd-1234",
+		"DM_NAME":            "",
+		"DM_UUID":            "",
+		"MD_LEVEL":           "",
+	}
+	props := ParseUdevProperties(env)
+
+	assert.Equal(t, "/dev/sda", props.DevName)
+	assert.Equal(t, "disk", props.DevType)
+	assert.Equal(t, 8, props.Major)
+	assert.Equal(t, 0, props.Minor)
+	assert.Equal(t, "WD-ABC123", props.Serial, "ID_SERIAL_SHORT takes priority")
+	assert.Equal(t, "WDC_WD10EZEX", props.Model)
+	assert.Equal(t, "0x50014ee2b5e7c5a0", props.WWN)
+	assert.Equal(t, "ext4", props.FSType)
+	assert.Equal(t, "abcd-1234", props.PartUUID)
+}
+
+func TestParseUdevProperties_SerialFallback(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":   "/dev/sda",
+		"MAJOR":     "8",
+		"MINOR":     "0",
+		"ID_SERIAL": "WDC_WD10EZEX_WD-ABC123",
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "WDC_WD10EZEX_WD-ABC123", props.Serial, "Falls back to ID_SERIAL")
+}
+
+func TestParseUdevProperties_SerialScsiChainAndNormalize(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":           "/dev/sda",
+		"MAJOR":             "8",
+		"MINOR":             "0",
+		"SCSI_IDENT_SERIAL": "  SG3  ID  ",
+		"ID_SCSI_SERIAL":    "scsi",
+		"ID_SERIAL_SHORT":   "short",
+		"ID_SERIAL":         "long",
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "SG3 ID", props.Serial)
+}
+
+func TestParseUdevProperties_WwnPrefersExtension(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":               "/dev/sda",
+		"MAJOR":                 "8",
+		"MINOR":                 "0",
+		"ID_WWN":                "0x5000",
+		"ID_WWN_WITH_EXTENSION": "0x5000deadbeef",
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "0x5000deadbeef", props.WWN)
+}
+
+func TestParseUdevProperties_ModelFromEnc(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":      "/dev/sda",
+		"MAJOR":        "8",
+		"MINOR":        "0",
+		"ID_MODEL":     "IGNORED_WHEN_ENC",
+		"ID_MODEL_ENC": `Vendor\x20Disk\x20Name`,
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "Vendor Disk Name", props.Model)
+}
+
+func TestParseUdevProperties_DevNamePrefixAdded(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME": "sda",
+		"MAJOR":   "8",
+		"MINOR":   "0",
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "/dev/sda", props.DevName, "Adds /dev/ prefix when missing")
+}
+
+func TestParseUdevProperties_DevNameAlreadyPrefixed(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME": "/dev/nvme0n1",
+		"MAJOR":   "259",
+		"MINOR":   "0",
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, "/dev/nvme0n1", props.DevName)
+}
+
+func TestParseUdevProperties_EmptyEnv(t *testing.T) {
+	props := ParseUdevProperties(map[string]string{})
+	assert.Equal(t, "", props.DevName)
+	assert.Equal(t, 0, props.Major)
+	assert.Equal(t, 0, props.Minor)
+	assert.Equal(t, "", props.Serial)
+}
+
+func TestParseUdevProperties_InvalidMajorMinor(t *testing.T) {
+	env := map[string]string{
+		"MAJOR": "abc",
+		"MINOR": "xyz",
+	}
+	props := ParseUdevProperties(env)
+	assert.Equal(t, 0, props.Major)
+	assert.Equal(t, 0, props.Minor)
+}
+
+// ================== ResolveDeviceType ==================
+
+func TestResolveDeviceType(t *testing.T) {
+	tests := []struct {
+		name     string
+		props    UdevProperties
+		devName  string
+		expected string
+	}{
+		{"partition before loop name", UdevProperties{DevType: "partition"}, "/dev/loop0p1", "part"},
+		{"loop device", UdevProperties{DevType: "disk"}, "/dev/loop0", "loop"},
+		{"LVM volume", UdevProperties{DMUUID: "LVM-abc123"}, "/dev/dm-0", "lvm"},
+		{"multipath lower", UdevProperties{DMUUID: "mpath-xyz"}, "/dev/dm-1", "mpath"},
+		{"multipath upper prefix", UdevProperties{DMUUID: "MPATH-xyz"}, "/dev/dm-1", "mpath"},
+		{"crypt dm", UdevProperties{DMUUID: "CRYPT-LUKS2-deadbeef"}, "/dev/dm-2", "crypt"},
+		{"dm no uuid", UdevProperties{}, "/dev/dm-9", "dm"},
+		{"dm kpartx part prefix", UdevProperties{DMUUID: "part7-00002-abcdef"}, "/dev/dm-3", "part"},
+		{"MD RAID1", UdevProperties{MDLevel: "raid1"}, "/dev/md0", "raid1"},
+		{"MD RAID5", UdevProperties{MDLevel: "raid5"}, "/dev/md1", "raid5"},
+		{"MD level lowercased", UdevProperties{MDLevel: "RAID10"}, "/dev/md2", "raid10"},
+		{"MD no level", UdevProperties{DevType: "disk"}, "/dev/md3", "md"},
+		{"partition", UdevProperties{DevType: "partition"}, "/dev/sda1", "part"},
+		{"plain disk no sysfs", UdevProperties{DevType: "disk"}, "/dev/sda", "disk"},
+		{"nvme disk no sysfs", UdevProperties{DevType: "disk"}, "/dev/nvme0n1", "disk"},
+		{"CD-ROM sr0 no sysfs", UdevProperties{DevType: "disk"}, "/dev/sr0", "rom"},
+		{"CD-ROM sr1 no sysfs", UdevProperties{}, "/dev/sr1", "rom"},
+		{"empty props", UdevProperties{}, "/dev/sda", "disk"},
+		{"dm uuid starts with dash", UdevProperties{DMUUID: "-something"}, "/dev/dm-5", "dm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ResolveDeviceType(tt.props, tt.devName))
+		})
+	}
+}
+
+func TestResolveDeviceType_PartitionFallbackWhenDevTypeMissing(t *testing.T) {
+	root := withFakeSysfs(t)
+	createPartitionSymlink(t, root, "sda", "sda1")
+
+	assert.Equal(t, "part", ResolveDeviceType(UdevProperties{}, "/dev/sda1"))
+}
+
+// ================== ResolveDeviceName ==================
+
+func TestResolveDeviceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		props    UdevProperties
+		expected string
+	}{
+		{"DM device", UdevProperties{DMName: "vg0-lv0", DevName: "/dev/dm-0"}, "/dev/mapper/vg0-lv0"},
+		{"regular with prefix", UdevProperties{DevName: "/dev/sda"}, "/dev/sda"},
+		{"regular without prefix", UdevProperties{DevName: "sda"}, "/dev/sda"},
+		{"empty", UdevProperties{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ResolveDeviceName(tt.props))
+		})
+	}
+}
+
+// ================== ResolveKernelName ==================
+
+func TestResolveKernelName(t *testing.T) {
+	assert.Equal(t, "/dev/sda", ResolveKernelName("sda"))
+	assert.Equal(t, "/dev/sda", ResolveKernelName("/dev/sda"))
+	assert.Equal(t, "/dev/nvme0n1", ResolveKernelName("nvme0n1"))
+}
+
+// ================== normalizeWhitespace ==================
+
+func TestNormalizeWhitespace(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"a", "a"},
+		{"  a", "a"},
+		{"a  b", "a b"},
+		{"a \t b", "a b"},
+		{"a b ", "a b"},
+		{"  a  b  ", "a b"},
+		{"   ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeWhitespace(tt.in))
+		})
+	}
+}
+
+// ================== unhexmangle ==================
+
+func TestUnhexmangle(t *testing.T) {
+	assert.Equal(t, "ST330006 50NS", unhexmangle(`ST330006\x2050NS`))
+	assert.Equal(t, "Vendor Disk Name", unhexmangle(`Vendor\x20Disk\x20Name`))
+	assert.Equal(t, "no escapes", unhexmangle("no escapes"))
+	assert.Equal(t, "", unhexmangle(""))
+	assert.Equal(t, `\xZZ`, unhexmangle(`\xZZ`), "invalid hex digits left as-is")
+	assert.Equal(t, `\x4`, unhexmangle(`\x4`), "incomplete sequence left as-is")
+}
+
+// ================== ensureDevPrefix ==================
+
+func TestEnsureDevPrefix(t *testing.T) {
+	assert.Equal(t, "", ensureDevPrefix(""))
+	assert.Equal(t, "/dev/sda", ensureDevPrefix("sda"))
+	assert.Equal(t, "/dev/sda", ensureDevPrefix("/dev/sda"))
+	assert.Equal(t, "/dev/nvme0n1", ensureDevPrefix("nvme0n1"))
+}
+
+// ================== DeviceKey ==================
+
+func TestDeviceKey(t *testing.T) {
+	assert.Equal(t, "8:0", DeviceKey(8, 0))
+	assert.Equal(t, "259:1", DeviceKey(259, 1))
+}

--- a/images/agent/internal/udev/sysfs.go
+++ b/images/agent/internal/udev/sysfs.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+var (
+	sysClassBlockPath = "/sys/class/block"
+	sysBlockPath      = "/sys/block"
+)
+
+const sectorSize = 512
+
+func ReadSysfsSize(devName string) (int64, error) {
+	devName = SysfsDevName(devName)
+	data, err := os.ReadFile(filepath.Join(sysClassBlockPath, devName, "size"))
+	if err != nil {
+		return 0, fmt.Errorf("reading size for %s: %w", devName, err)
+	}
+	sectors, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing size for %s: %w", devName, err)
+	}
+	return sectors * sectorSize, nil
+}
+
+func ReadSysfsRotational(devName string) (bool, error) {
+	devName = SysfsDevName(devName)
+	devName = resolveParentForPartition(devName)
+	data, err := os.ReadFile(filepath.Join(sysClassBlockPath, devName, "queue", "rotational"))
+	if err != nil {
+		return false, fmt.Errorf("reading rotational for %s: %w", devName, err)
+	}
+	return strings.TrimSpace(string(data)) == "1", nil
+}
+
+// ReadSysfsHotplug mirrors util-linux sysfs_blkdev_is_hotpluggable() (lib/sysfs.c):
+// walk the device path upward, checking /removable at each level; "1" -> hotpluggable,
+// "0" -> fixed. The kernel writes "1" or "0" into the removable attribute.
+func ReadSysfsHotplug(devName string) (bool, error) {
+	devName = SysfsDevName(devName)
+	symlinkPath := filepath.Join(sysClassBlockPath, devName)
+	resolved, err := filepath.EvalSymlinks(symlinkPath)
+	if err != nil {
+		return false, fmt.Errorf("resolving symlink for %s: %w", devName, err)
+	}
+
+	dir := resolved
+	for dir != "/" && dir != "." {
+		removableFile := filepath.Join(dir, "removable")
+		data, err := os.ReadFile(removableFile)
+		if err == nil {
+			content := strings.TrimSpace(string(data))
+			if content == "1" {
+				return true, nil
+			}
+			if content == "0" {
+				return false, nil
+			}
+		}
+		dir = filepath.Dir(dir)
+	}
+
+	return false, nil
+}
+
+func ReadSysfsSlaves(devName string) ([]string, error) {
+	devName = SysfsDevName(devName)
+	dir := filepath.Join(sysBlockPath, devName, "slaves")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading slaves for %s: %w", devName, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names, nil
+}
+
+func isPartition(devName string) bool {
+	devName = SysfsDevName(devName)
+	partitionFile := filepath.Join(sysClassBlockPath, devName, "partition")
+	_, err := os.Stat(partitionFile)
+	return err == nil
+}
+
+// parentFromSysfs returns the parent block name from /sys/class/block/<part> symlink.
+func parentFromSysfs(devName string) string {
+	devName = SysfsDevName(devName)
+	link, err := os.Readlink(filepath.Join(sysClassBlockPath, devName))
+	if err != nil {
+		return ""
+	}
+	parent := filepath.Base(filepath.Dir(link))
+	if parent == "." || parent == "/" || parent == "block" {
+		return ""
+	}
+	return parent
+}
+
+func SysfsDevName(devPath string) string {
+	return strings.TrimPrefix(devPath, "/dev/")
+}
+
+// resolveParentForPartition returns the parent disk for partitions so
+// rotational/removable read the backing device; else devName unchanged.
+func resolveParentForPartition(devName string) string {
+	devName = SysfsDevName(devName)
+	if !isPartition(devName) {
+		return devName
+	}
+	if parent := parentFromSysfs(devName); parent != "" {
+		return parent
+	}
+	return devName
+}

--- a/images/agent/internal/udev/sysfs_test.go
+++ b/images/agent/internal/udev/sysfs_test.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withFakeSysfs(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	origSysClassBlock := sysClassBlockPath
+	origSysBlock := sysBlockPath
+	sysClassBlockPath = filepath.Join(root, "sys", "class", "block")
+	sysBlockPath = filepath.Join(root, "sys", "block")
+	t.Cleanup(func() {
+		sysClassBlockPath = origSysClassBlock
+		sysBlockPath = origSysBlock
+	})
+	return root
+}
+
+func writeFakeSysfsFile(t *testing.T, devName, fileName, content string) {
+	t.Helper()
+	dir := filepath.Join(sysClassBlockPath, devName, filepath.Dir(fileName))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sysClassBlockPath, devName, fileName), []byte(content), 0o644))
+}
+
+func writeFakeSysBlockFile(t *testing.T, devName, relPath, content string) {
+	t.Helper()
+	full := filepath.Join(sysBlockPath, devName, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+}
+
+// createPartitionSymlink creates a fake sysfs partition entry:
+// /sys/class/block/<part> -> ../../devices/.../block/<parent>/<part>
+// with a "partition" file inside the target directory.
+func createPartitionSymlink(t *testing.T, root, parent, part string) {
+	t.Helper()
+	targetDir := filepath.Join(root, "devices", "fake", "block", parent, part)
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "partition"), []byte("1"), 0o644))
+	require.NoError(t, os.MkdirAll(sysClassBlockPath, 0o755))
+	require.NoError(t, os.Symlink(targetDir, filepath.Join(sysClassBlockPath, part)))
+}
+
+// ================== SysfsDevName ==================
+
+func TestSysfsDevName(t *testing.T) {
+	assert.Equal(t, "sda", SysfsDevName("/dev/sda"))
+	assert.Equal(t, "nvme0n1", SysfsDevName("/dev/nvme0n1"))
+	assert.Equal(t, "sda", SysfsDevName("sda"))
+}
+
+// ================== ReadSysfsSize ==================
+
+func TestReadSysfsSize(t *testing.T) {
+	withFakeSysfs(t)
+	writeFakeSysfsFile(t, "sda", "size", "2097152\n")
+
+	size, err := ReadSysfsSize("sda")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2097152*512), size)
+}
+
+func TestReadSysfsSize_WithDevPrefix(t *testing.T) {
+	withFakeSysfs(t)
+	writeFakeSysfsFile(t, "sda", "size", "8\n")
+
+	size, err := ReadSysfsSize("/dev/sda")
+	require.NoError(t, err)
+	assert.Equal(t, int64(8*512), size)
+}
+
+func TestReadSysfsSize_NotExist(t *testing.T) {
+	withFakeSysfs(t)
+
+	_, err := ReadSysfsSize("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestReadSysfsSize_ParseError(t *testing.T) {
+	withFakeSysfs(t)
+	writeFakeSysfsFile(t, "sda", "size", "not_a_number\n")
+
+	_, err := ReadSysfsSize("sda")
+	assert.Error(t, err)
+}
+
+// ================== ReadSysfsRotational ==================
+
+func TestReadSysfsRotational_HDD(t *testing.T) {
+	withFakeSysfs(t)
+	writeFakeSysfsFile(t, "sda", "queue/rotational", "1\n")
+
+	rota, err := ReadSysfsRotational("sda")
+	require.NoError(t, err)
+	assert.True(t, rota)
+}
+
+func TestReadSysfsRotational_SSD(t *testing.T) {
+	withFakeSysfs(t)
+	writeFakeSysfsFile(t, "nvme0n1", "queue/rotational", "0\n")
+
+	rota, err := ReadSysfsRotational("nvme0n1")
+	require.NoError(t, err)
+	assert.False(t, rota)
+}
+
+func TestReadSysfsRotational_Partition_ReadsParent(t *testing.T) {
+	root := withFakeSysfs(t)
+	createPartitionSymlink(t, root, "sda", "sda1")
+	writeFakeSysfsFile(t, "sda", "queue/rotational", "1\n")
+
+	rota, err := ReadSysfsRotational("sda1")
+	require.NoError(t, err)
+	assert.True(t, rota, "partition should read rotational from parent")
+}
+
+func TestReadSysfsRotational_WithDevPrefix(t *testing.T) {
+	withFakeSysfs(t)
+	writeFakeSysfsFile(t, "sda", "queue/rotational", "0\n")
+
+	rota, err := ReadSysfsRotational("/dev/sda")
+	require.NoError(t, err)
+	assert.False(t, rota)
+}
+
+// ================== ReadSysfsHotplug ==================
+
+func TestReadSysfsHotplug_USBDisk(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	devicesPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:14.0", "usb1", "1-1", "1-1:1.0", "host0", "target0:0:0", "0:0:0:0", "block", "sdb")
+	usbPortPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:14.0", "usb1", "1-1")
+
+	require.NoError(t, os.MkdirAll(devicesPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(usbPortPath, "removable"), []byte("1\n"), 0o644))
+
+	require.NoError(t, os.MkdirAll(sysClassBlockPath, 0o755))
+	require.NoError(t, os.Symlink(devicesPath, filepath.Join(sysClassBlockPath, "sdb")))
+
+	hotplug, err := ReadSysfsHotplug("sdb")
+	require.NoError(t, err)
+	assert.True(t, hotplug, "USB disk should be hotpluggable")
+}
+
+func TestReadSysfsHotplug_WithDevPrefix(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	devicesPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:14.0", "usb1", "1-1", "1-1:1.0", "host0", "target0:0:0", "0:0:0:0", "block", "sdb")
+	usbPortPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:14.0", "usb1", "1-1")
+
+	require.NoError(t, os.MkdirAll(devicesPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(usbPortPath, "removable"), []byte("1\n"), 0o644))
+
+	require.NoError(t, os.MkdirAll(sysClassBlockPath, 0o755))
+	require.NoError(t, os.Symlink(devicesPath, filepath.Join(sysClassBlockPath, "sdb")))
+
+	hotplug, err := ReadSysfsHotplug("/dev/sdb")
+	require.NoError(t, err)
+	assert.True(t, hotplug)
+}
+
+func TestReadSysfsHotplug_SATADisk(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	devicesPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:1f.2", "ata1", "host0", "target0:0:0", "0:0:0:0", "block", "sda")
+	pciPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:1f.2")
+
+	require.NoError(t, os.MkdirAll(devicesPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pciPath, "removable"), []byte("0\n"), 0o644))
+
+	require.NoError(t, os.MkdirAll(sysClassBlockPath, 0o755))
+	require.NoError(t, os.Symlink(devicesPath, filepath.Join(sysClassBlockPath, "sda")))
+
+	hotplug, err := ReadSysfsHotplug("sda")
+	require.NoError(t, err)
+	assert.False(t, hotplug, "SATA disk should not be hotpluggable")
+}
+
+func TestReadSysfsHotplug_NoRemovableFile(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	devicesPath := filepath.Join(root, "devices", "virtual", "block", "dm-0")
+	require.NoError(t, os.MkdirAll(devicesPath, 0o755))
+
+	require.NoError(t, os.MkdirAll(sysClassBlockPath, 0o755))
+	require.NoError(t, os.Symlink(devicesPath, filepath.Join(sysClassBlockPath, "dm-0")))
+
+	hotplug, err := ReadSysfsHotplug("dm-0")
+	require.NoError(t, err)
+	assert.False(t, hotplug, "virtual device with no removable file should not be hotpluggable")
+}
+
+func TestReadSysfsHotplug_NotSymlink(t *testing.T) {
+	withFakeSysfs(t)
+
+	devDir := filepath.Join(sysClassBlockPath, "sda")
+	require.NoError(t, os.MkdirAll(devDir, 0o755))
+
+	hotplug, err := ReadSysfsHotplug("sda")
+	require.NoError(t, err)
+	assert.False(t, hotplug, "plain directory with no removable ancestors")
+}
+
+func TestReadSysfsHotplug_PartitionOnFixedDisk(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	devicesPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:1f.2", "ata1", "host0", "target0:0:0", "0:0:0:0", "block", "sda")
+	pciPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:1f.2")
+
+	require.NoError(t, os.MkdirAll(devicesPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pciPath, "removable"), []byte("0\n"), 0o644))
+
+	require.NoError(t, os.MkdirAll(sysClassBlockPath, 0o755))
+	require.NoError(t, os.Symlink(devicesPath, filepath.Join(sysClassBlockPath, "sda")))
+
+	sda1DevicesPath := filepath.Join(devicesPath, "sda1")
+	require.NoError(t, os.MkdirAll(sda1DevicesPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sda1DevicesPath, "partition"), []byte("1"), 0o644))
+	require.NoError(t, os.Symlink(sda1DevicesPath, filepath.Join(sysClassBlockPath, "sda1")))
+
+	hotplug, err := ReadSysfsHotplug("sda1")
+	require.NoError(t, err)
+	assert.False(t, hotplug, "partition on fixed SATA disk should not be hotpluggable")
+}
+
+func TestReadSysfsHotplug_Partition_ReadsParent(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	devicesPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:14.0", "usb1", "1-1", "1-1:1.0", "host0", "target0:0:0", "0:0:0:0", "block", "sdb")
+	usbPortPath := filepath.Join(root, "devices", "pci0000:00", "0000:00:14.0", "usb1", "1-1")
+
+	require.NoError(t, os.MkdirAll(devicesPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(usbPortPath, "removable"), []byte("1\n"), 0o644))
+
+	require.NoError(t, os.MkdirAll(sysClassBlockPath, 0o755))
+	require.NoError(t, os.Symlink(devicesPath, filepath.Join(sysClassBlockPath, "sdb")))
+
+	sdb1DevicesPath := filepath.Join(devicesPath, "sdb1")
+	require.NoError(t, os.MkdirAll(sdb1DevicesPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sdb1DevicesPath, "partition"), []byte("1"), 0o644))
+	require.NoError(t, os.Symlink(sdb1DevicesPath, filepath.Join(sysClassBlockPath, "sdb1")))
+
+	hotplug, err := ReadSysfsHotplug("sdb1")
+	require.NoError(t, err)
+	assert.True(t, hotplug, "partition on USB disk should be hotpluggable")
+}
+
+// ================== ReadSysfsSlaves ==================
+
+func TestReadSysfsSlaves(t *testing.T) {
+	withFakeSysfs(t)
+
+	slavesDir := filepath.Join(sysBlockPath, "dm-0", "slaves")
+	require.NoError(t, os.MkdirAll(slavesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(slavesDir, "sda"), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(slavesDir, "sdb"), nil, 0o644))
+
+	slaves, err := ReadSysfsSlaves("dm-0")
+	require.NoError(t, err)
+	assert.Len(t, slaves, 2)
+	assert.Contains(t, slaves, "sda")
+	assert.Contains(t, slaves, "sdb")
+}
+
+func TestReadSysfsSlaves_WithDevPrefix(t *testing.T) {
+	withFakeSysfs(t)
+
+	slavesDir := filepath.Join(sysBlockPath, "dm-0", "slaves")
+	require.NoError(t, os.MkdirAll(slavesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(slavesDir, "sda"), nil, 0o644))
+
+	slaves, err := ReadSysfsSlaves("/dev/dm-0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sda"}, slaves)
+}
+
+func TestReadSysfsSlaves_NoDir(t *testing.T) {
+	withFakeSysfs(t)
+
+	slaves, err := ReadSysfsSlaves("sda")
+	require.NoError(t, err)
+	assert.Nil(t, slaves)
+}
+
+// ================== parentFromSysfs ==================
+
+func TestParentFromSysfs(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	tests := []struct {
+		name     string
+		parent   string
+		part     string
+		expected string
+	}{
+		{"sda1 -> sda", "sda", "sda1", "sda"},
+		{"sda2 -> sda", "sda", "sda2", "sda"},
+		{"nvme0n1p1 -> nvme0n1", "nvme0n1", "nvme0n1p1", "nvme0n1"},
+		{"nvme0n1p12 -> nvme0n1", "nvme0n1", "nvme0n1p12", "nvme0n1"},
+		{"mmcblk0p1 -> mmcblk0", "mmcblk0", "mmcblk0p1", "mmcblk0"},
+		{"mmcblk0p2 -> mmcblk0", "mmcblk0", "mmcblk0p2", "mmcblk0"},
+		{"nbd0p1 -> nbd0", "nbd0", "nbd0p1", "nbd0"},
+		{"vda1 -> vda", "vda", "vda1", "vda"},
+		{"xvda1 -> xvda", "xvda", "xvda1", "xvda"},
+		{"loop0p1 -> loop0", "loop0", "loop0p1", "loop0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			createPartitionSymlink(t, root, tt.parent, tt.part)
+			assert.Equal(t, tt.expected, parentFromSysfs(tt.part))
+		})
+	}
+}
+
+func TestParentFromSysfs_NotSymlink(t *testing.T) {
+	withFakeSysfs(t)
+
+	devDir := filepath.Join(sysClassBlockPath, "sda")
+	require.NoError(t, os.MkdirAll(devDir, 0o755))
+
+	assert.Equal(t, "", parentFromSysfs("sda"))
+}
+
+func TestParentFromSysfs_Nonexistent(t *testing.T) {
+	withFakeSysfs(t)
+	assert.Equal(t, "", parentFromSysfs("nonexistent"))
+}
+
+// ================== ResolveParentDevice ==================
+
+func TestResolveParentDevice_Partitions(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	createPartitionSymlink(t, root, "sda", "sda1")
+	createPartitionSymlink(t, root, "nvme0n1", "nvme0n1p1")
+	createPartitionSymlink(t, root, "mmcblk0", "mmcblk0p1")
+	createPartitionSymlink(t, root, "nbd0", "nbd0p1")
+
+	assert.Equal(t, "/dev/sda", ResolveParentDevice("sda1"))
+	assert.Equal(t, "/dev/nvme0n1", ResolveParentDevice("nvme0n1p1"))
+	assert.Equal(t, "/dev/mmcblk0", ResolveParentDevice("mmcblk0p1"))
+	assert.Equal(t, "/dev/nbd0", ResolveParentDevice("nbd0p1"))
+	assert.Equal(t, "/dev/sda", ResolveParentDevice("/dev/sda1"))
+	assert.Equal(t, "", ResolveParentDevice("sda"))
+}
+
+func TestResolveParentDevice_MDPartition(t *testing.T) {
+	root := withFakeSysfs(t)
+
+	createPartitionSymlink(t, root, "md0", "md0p1")
+
+	assert.Equal(t, "/dev/md0", ResolveParentDevice("md0p1"))
+}
+
+func TestResolveParentDevice_MDArray(t *testing.T) {
+	withFakeSysfs(t)
+
+	slavesDir := filepath.Join(sysBlockPath, "md0", "slaves")
+	require.NoError(t, os.MkdirAll(slavesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(slavesDir, "sda1"), nil, 0o644))
+
+	assert.Equal(t, "/dev/sda1", ResolveParentDevice("md0"))
+}
+
+func TestResolveParentDevice_WholeDeviceWithDigits(t *testing.T) {
+	withFakeSysfs(t)
+
+	for _, dev := range []string{"loop0", "loop1", "nbd0", "sr0"} {
+		devDir := filepath.Join(sysClassBlockPath, dev)
+		require.NoError(t, os.MkdirAll(devDir, 0o755))
+	}
+
+	assert.Equal(t, "", ResolveParentDevice("loop0"))
+	assert.Equal(t, "", ResolveParentDevice("loop1"))
+	assert.Equal(t, "", ResolveParentDevice("nbd0"))
+	assert.Equal(t, "", ResolveParentDevice("sr0"))
+}
+
+func TestResolveParentDevice_DM_WithSlaves(t *testing.T) {
+	withFakeSysfs(t)
+
+	slavesDir := filepath.Join(sysBlockPath, "dm-0", "slaves")
+	require.NoError(t, os.MkdirAll(slavesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(slavesDir, "sda"), nil, 0o644))
+
+	assert.Equal(t, "/dev/sda", ResolveParentDevice("dm-0"))
+	assert.Equal(t, "/dev/sda", ResolveParentDevice("/dev/dm-0"))
+}
+
+func TestResolveParentDevice_DM_NoSlaves(t *testing.T) {
+	withFakeSysfs(t)
+	assert.Equal(t, "", ResolveParentDevice("dm-0"))
+}


### PR DESCRIPTION
## Summary

First step in replacing lsblk with netlink-based block device discovery.

Adds a new package `images/agent/internal/udev/` with stateless pure functions
that reproduce lsblk's device attribute reading logic:

- **sysfs.go** — read size, rotational, hotplug, slaves, parent/child from sysfs
- **properties.go** — parse udev env maps (serial/model/WWN with lsblk-compatible
  priority chains), resolve device types and names, string helpers (unhexmangle,
  normalizeWhitespace)

Does not modify any existing code. No external dependencies beyond stdlib.