### PR TITLE
[agent] Add udev property parsers and DeviceMap event store

### DIFF
--- a/images/agent/internal/udev/devicemap.go
+++ b/images/agent/internal/udev/devicemap.go
@@ -17,21 +17,24 @@ limitations under the License.
 package udev
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 )
+
+var ErrUnknownAction = errors.New("unknown action")
 
 // DeviceMap is a thread-safe in-memory store of block device properties
 // keyed by "major:minor". It is populated by netlink events (HandleEvent)
 // and provides a consistent snapshot via All().
 type DeviceMap struct {
 	mu      sync.RWMutex
-	devices map[string]UdevProperties
+	devices map[string]Properties
 }
 
 func NewDeviceMap() *DeviceMap {
 	return &DeviceMap{
-		devices: make(map[string]UdevProperties),
+		devices: make(map[string]Properties),
 	}
 }
 
@@ -39,7 +42,7 @@ func NewDeviceMap() *DeviceMap {
 // directly from the kernel (add, change, remove, bind, unbind, move, online,
 // offline). The env map is the raw udev environment from the event.
 func (dm *DeviceMap) HandleEvent(action string, env map[string]string) error {
-	props, err := ParseUdevProperties(env)
+	props, err := ParseProperties(env)
 	if err != nil {
 		return fmt.Errorf("handle event (action=%s, DEVNAME=%s): %w", action, env["DEVNAME"], err)
 	}
@@ -55,7 +58,7 @@ func (dm *DeviceMap) HandleEvent(action string, env map[string]string) error {
 	case "remove", "unbind", "offline":
 		delete(dm.devices, key)
 	default:
-		return fmt.Errorf("unknown action %q for device %s", action, key)
+		return fmt.Errorf("%w %q for device %s", ErrUnknownAction, action, key)
 	}
 
 	return nil
@@ -63,11 +66,11 @@ func (dm *DeviceMap) HandleEvent(action string, env map[string]string) error {
 
 // All returns a shallow copy of the device map. Callers may modify the
 // returned map without affecting the DeviceMap.
-func (dm *DeviceMap) All() map[string]UdevProperties {
+func (dm *DeviceMap) All() map[string]Properties {
 	dm.mu.RLock()
 	defer dm.mu.RUnlock()
 
-	cp := make(map[string]UdevProperties, len(dm.devices))
+	cp := make(map[string]Properties, len(dm.devices))
 	for k, v := range dm.devices {
 		cp[k] = v
 	}

--- a/images/agent/internal/udev/devicemap.go
+++ b/images/agent/internal/udev/devicemap.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"fmt"
+	"sync"
+)
+
+// DeviceMap is a thread-safe in-memory store of block device properties
+// keyed by "major:minor". It is populated by netlink events (HandleEvent)
+// and provides a consistent snapshot via All().
+type DeviceMap struct {
+	mu      sync.RWMutex
+	devices map[string]UdevProperties
+}
+
+func NewDeviceMap() *DeviceMap {
+	return &DeviceMap{
+		devices: make(map[string]UdevProperties),
+	}
+}
+
+// HandleEvent processes a single netlink uevent. The action string comes
+// directly from the kernel (add, change, remove, bind, unbind, move, online,
+// offline). The env map is the raw udev environment from the event.
+func (dm *DeviceMap) HandleEvent(action string, env map[string]string) error {
+	props, err := ParseUdevProperties(env)
+	if err != nil {
+		return fmt.Errorf("handle event (action=%s, DEVNAME=%s): %w", action, env["DEVNAME"], err)
+	}
+
+	key := DeviceKey(props.Major, props.Minor)
+
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	switch action {
+	case "add", "change", "bind", "move", "online":
+		dm.devices[key] = props
+	case "remove", "unbind", "offline":
+		delete(dm.devices, key)
+	default:
+		return fmt.Errorf("unknown action %q for device %s", action, key)
+	}
+
+	return nil
+}
+
+// All returns a shallow copy of the device map. Callers may modify the
+// returned map without affecting the DeviceMap.
+func (dm *DeviceMap) All() map[string]UdevProperties {
+	dm.mu.RLock()
+	defer dm.mu.RUnlock()
+
+	cp := make(map[string]UdevProperties, len(dm.devices))
+	for k, v := range dm.devices {
+		cp[k] = v
+	}
+	return cp
+}
+
+// Len returns the number of devices currently tracked.
+func (dm *DeviceMap) Len() int {
+	dm.mu.RLock()
+	defer dm.mu.RUnlock()
+	return len(dm.devices)
+}

--- a/images/agent/internal/udev/devicemap.go
+++ b/images/agent/internal/udev/devicemap.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 )
 
+// ErrUnknownAction is returned by HandleEvent when the uevent action
+// is not one of the recognized kernel actions.
 var ErrUnknownAction = errors.New("unknown action")
 
 // DeviceMap is a thread-safe in-memory store of block device properties
@@ -32,6 +34,7 @@ type DeviceMap struct {
 	devices map[string]Properties
 }
 
+// NewDeviceMap returns an empty, ready-to-use DeviceMap.
 func NewDeviceMap() *DeviceMap {
 	return &DeviceMap{
 		devices: make(map[string]Properties),
@@ -41,6 +44,13 @@ func NewDeviceMap() *DeviceMap {
 // HandleEvent processes a single netlink uevent. The action string comes
 // directly from the kernel (add, change, remove, bind, unbind, move, online,
 // offline). The env map is the raw udev environment from the event.
+//
+// Add-like actions (add, change, bind, move, online) insert or overwrite the
+// device entry. Remove-like actions (remove, unbind, offline) delete it.
+// This is intentional: we listen on the UdevEvent multicast group, so every
+// event carries a fully enriched property set, and a device in the offline or
+// unbound state is unavailable for I/O — there is no value in keeping it in
+// the map.
 func (dm *DeviceMap) HandleEvent(action string, env map[string]string) error {
 	props, err := ParseProperties(env)
 	if err != nil {
@@ -49,16 +59,17 @@ func (dm *DeviceMap) HandleEvent(action string, env map[string]string) error {
 
 	key := DeviceKey(props.Major, props.Minor)
 
-	dm.mu.Lock()
-	defer dm.mu.Unlock()
-
 	switch action {
 	case "add", "change", "bind", "move", "online":
+		dm.mu.Lock()
 		dm.devices[key] = props
+		dm.mu.Unlock()
 	case "remove", "unbind", "offline":
+		dm.mu.Lock()
 		delete(dm.devices, key)
+		dm.mu.Unlock()
 	default:
-		return fmt.Errorf("%w %q for device %s", ErrUnknownAction, action, key)
+		return fmt.Errorf("handle event: %w %q for device %s", ErrUnknownAction, action, key)
 	}
 
 	return nil

--- a/images/agent/internal/udev/devicemap_test.go
+++ b/images/agent/internal/udev/devicemap_test.go
@@ -214,3 +214,47 @@ func TestDeviceMap_ConcurrentAccess(t *testing.T) {
 	}
 	assert.Equal(t, 100, dm.Len())
 }
+
+func TestDeviceMap_ConcurrentReadWrite(t *testing.T) {
+	dm := NewDeviceMap()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(minor int) {
+			defer wg.Done()
+			env := makeEnv("8", fmt.Sprintf("%d", minor), fmt.Sprintf("sd%d", minor))
+			_ = dm.HandleEvent("add", env)
+		}(i)
+	}
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = dm.All()
+			_ = dm.Len()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestDeviceMap_ConcurrentAddRemoveSameKey(t *testing.T) {
+	dm := NewDeviceMap()
+	env := makeEnv("8", "0", "sda")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				_ = dm.HandleEvent("add", env)
+			} else {
+				_ = dm.HandleEvent("remove", env)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.True(t, dm.Len() <= 1, "at most one entry for the key")
+}

--- a/images/agent/internal/udev/devicemap_test.go
+++ b/images/agent/internal/udev/devicemap_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package udev
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -117,7 +118,7 @@ func TestHandleEvent_UnknownAction_ReturnsError(t *testing.T) {
 	dm := NewDeviceMap()
 	err := dm.HandleEvent("explode", makeEnv("8", "0", "sda"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown action")
+	assert.True(t, errors.Is(err, ErrUnknownAction))
 	assert.Equal(t, 0, dm.Len())
 }
 
@@ -196,16 +197,20 @@ func TestAll_EmptyMap(t *testing.T) {
 func TestDeviceMap_ConcurrentAccess(t *testing.T) {
 	dm := NewDeviceMap()
 
+	errs := make([]error, 100)
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func(minor int) {
 			defer wg.Done()
 			env := makeEnv("8", fmt.Sprintf("%d", minor), fmt.Sprintf("sd%d", minor))
-			_ = dm.HandleEvent("add", env)
+			errs[minor] = dm.HandleEvent("add", env)
 		}(i)
 	}
 	wg.Wait()
 
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d returned error", i)
+	}
 	assert.Equal(t, 100, dm.Len())
 }

--- a/images/agent/internal/udev/devicemap_test.go
+++ b/images/agent/internal/udev/devicemap_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeEnv(major, minor, devname string) map[string]string {
+	return map[string]string{
+		"MAJOR":   major,
+		"MINOR":   minor,
+		"DEVNAME": devname,
+	}
+}
+
+// ================== HandleEvent — add/change/remove ==================
+
+func TestHandleEvent_Add(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("add", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 1, dm.Len())
+}
+
+func TestHandleEvent_Change_Updates(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("add", makeEnv("8", "0", "sda")))
+
+	env := makeEnv("8", "0", "sda")
+	env["ID_FS_TYPE"] = "ext4"
+	require.NoError(t, dm.HandleEvent("change", env))
+
+	assert.Equal(t, 1, dm.Len())
+	all := dm.All()
+	assert.Equal(t, "ext4", all["8:0"].FSType)
+}
+
+func TestHandleEvent_Remove(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("add", makeEnv("8", "0", "sda")))
+	require.NoError(t, dm.HandleEvent("remove", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 0, dm.Len())
+}
+
+// ================== HandleEvent — bind/unbind/move/online/offline ==================
+
+func TestHandleEvent_Bind(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("bind", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 1, dm.Len())
+}
+
+func TestHandleEvent_Unbind(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("add", makeEnv("8", "0", "sda")))
+	require.NoError(t, dm.HandleEvent("unbind", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 0, dm.Len())
+}
+
+func TestHandleEvent_Move(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("move", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 1, dm.Len())
+}
+
+func TestHandleEvent_Online(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("online", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 1, dm.Len())
+}
+
+func TestHandleEvent_Offline(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("add", makeEnv("8", "0", "sda")))
+	require.NoError(t, dm.HandleEvent("offline", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 0, dm.Len())
+}
+
+// ================== HandleEvent — error cases ==================
+
+func TestHandleEvent_NoMajorMinor_ReturnsError(t *testing.T) {
+	dm := NewDeviceMap()
+	err := dm.HandleEvent("add", map[string]string{"DEVNAME": "sda"})
+	require.Error(t, err)
+	assert.Equal(t, 0, dm.Len())
+}
+
+func TestHandleEvent_InvalidMajorMinor_ReturnsError(t *testing.T) {
+	dm := NewDeviceMap()
+	err := dm.HandleEvent("add", map[string]string{
+		"MAJOR": "abc", "MINOR": "xyz", "DEVNAME": "sda",
+	})
+	require.Error(t, err)
+	assert.Equal(t, 0, dm.Len())
+}
+
+func TestHandleEvent_UnknownAction_ReturnsError(t *testing.T) {
+	dm := NewDeviceMap()
+	err := dm.HandleEvent("explode", makeEnv("8", "0", "sda"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown action")
+	assert.Equal(t, 0, dm.Len())
+}
+
+// ================== HandleEvent — parsing ==================
+
+func TestHandleEvent_ParsesProperties(t *testing.T) {
+	dm := NewDeviceMap()
+	env := map[string]string{
+		"MAJOR": "8", "MINOR": "0", "DEVNAME": "sda",
+		"DEVTYPE": "disk", "ID_MODEL": "TestDisk",
+		"ID_SERIAL_SHORT": "SN123", "ID_WWN": "0x5000",
+	}
+	require.NoError(t, dm.HandleEvent("add", env))
+
+	all := dm.All()
+	props := all["8:0"]
+	assert.Equal(t, "/dev/sda", props.DevName)
+	assert.Equal(t, "disk", props.DevType)
+	assert.Equal(t, 8, props.Major)
+	assert.Equal(t, 0, props.Minor)
+	assert.Equal(t, "SN123", props.Serial)
+	assert.Equal(t, "TestDisk", props.Model)
+	assert.Equal(t, "0x5000", props.WWN)
+}
+
+func TestHandleEvent_UsesDeviceKeyFromParsedMajorMinor(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("add", makeEnv("259", "1", "nvme0n1")))
+
+	all := dm.All()
+	_, ok := all["259:1"]
+	assert.True(t, ok, "key must use parsed major:minor")
+}
+
+// ================== HandleEvent — sequence ==================
+
+func TestHandleEvent_Sequence(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("add", makeEnv("8", "0", "sda")))
+	require.NoError(t, dm.HandleEvent("add", makeEnv("8", "1", "sda1")))
+	assert.Equal(t, 2, dm.Len())
+
+	require.NoError(t, dm.HandleEvent("remove", makeEnv("8", "1", "sda1")))
+	assert.Equal(t, 1, dm.Len())
+
+	require.NoError(t, dm.HandleEvent("remove", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 0, dm.Len())
+}
+
+func TestHandleEvent_RemoveNonexistent_NoError(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("remove", makeEnv("8", "0", "sda")))
+	assert.Equal(t, 0, dm.Len())
+}
+
+// ================== All — copy safety ==================
+
+func TestAll_ReturnsCopy(t *testing.T) {
+	dm := NewDeviceMap()
+	require.NoError(t, dm.HandleEvent("add", makeEnv("8", "0", "sda")))
+
+	all := dm.All()
+	delete(all, "8:0")
+	assert.Equal(t, 1, dm.Len(), "deleting from copy must not affect the map")
+}
+
+func TestAll_EmptyMap(t *testing.T) {
+	dm := NewDeviceMap()
+	all := dm.All()
+	assert.NotNil(t, all)
+	assert.Empty(t, all)
+}
+
+// ================== Concurrency ==================
+
+func TestDeviceMap_ConcurrentAccess(t *testing.T) {
+	dm := NewDeviceMap()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(minor int) {
+			defer wg.Done()
+			env := makeEnv("8", fmt.Sprintf("%d", minor), fmt.Sprintf("sd%d", minor))
+			_ = dm.HandleEvent("add", env)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, 100, dm.Len())
+}

--- a/images/agent/internal/udev/properties.go
+++ b/images/agent/internal/udev/properties.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 )
 
+// Properties is the parsed, normalized subset of a udev environment that
+// matches lsblk's field-resolution rules for block device metadata.
 type Properties struct {
 	DevName  string
 	DevType  string
@@ -37,13 +39,16 @@ type Properties struct {
 	MDLevel  string
 }
 
+// ParseProperties parses a raw udev environment map into Properties.
+// MAJOR and MINOR are required and must be non-negative integers;
+// any parse error yields a zero Properties and a wrapped error.
 func ParseProperties(env map[string]string) (Properties, error) {
-	major, err := strconv.Atoi(env["MAJOR"])
+	major, err := strconv.ParseUint(env["MAJOR"], 10, 32)
 	if err != nil {
 		return Properties{}, fmt.Errorf("parse MAJOR: %w", err)
 	}
 
-	minor, err := strconv.Atoi(env["MINOR"])
+	minor, err := strconv.ParseUint(env["MINOR"], 10, 32)
 	if err != nil {
 		return Properties{}, fmt.Errorf("parse MINOR: %w", err)
 	}
@@ -51,8 +56,8 @@ func ParseProperties(env map[string]string) (Properties, error) {
 	return Properties{
 		DevName:  ensureDevPrefix(env["DEVNAME"]),
 		DevType:  env["DEVTYPE"],
-		Major:    major,
-		Minor:    minor,
+		Major:    int(major),
+		Minor:    int(minor),
 		Serial:   serialFromUdevEnv(env),
 		Model:    modelFromUdevEnv(env),
 		WWN:      wwnFromUdevEnv(env),
@@ -92,22 +97,9 @@ func wwnFromUdevEnv(env map[string]string) string {
 }
 
 // normalizeWhitespace collapses whitespace runs and trims edges,
-// matching util-linux normalize_whitespace() used by lsblk after reading udev properties.
+// approximating util-linux normalize_whitespace() for ASCII inputs.
 func normalizeWhitespace(s string) string {
 	return strings.Join(strings.Fields(s), " ")
-}
-
-func hexVal(c byte) int {
-	switch {
-	case c >= '0' && c <= '9':
-		return int(c - '0')
-	case c >= 'a' && c <= 'f':
-		return int(c-'a') + 10
-	case c >= 'A' && c <= 'F':
-		return int(c-'A') + 10
-	default:
-		return -1
-	}
 }
 
 // unhexmangle decodes udev \xHH escape sequences,
@@ -116,11 +108,12 @@ func unhexmangle(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	for i := 0; i < len(s); {
-		if i+3 < len(s) && s[i] == '\\' && s[i+1] == 'x' &&
-			hexVal(s[i+2]) >= 0 && hexVal(s[i+3]) >= 0 {
-			b.WriteByte(byte(hexVal(s[i+2])<<4 | hexVal(s[i+3])))
-			i += 4
-			continue
+		if i+3 < len(s) && s[i] == '\\' && s[i+1] == 'x' {
+			if v, err := strconv.ParseUint(s[i+2:i+4], 16, 8); err == nil {
+				b.WriteByte(byte(v))
+				i += 4
+				continue
+			}
 		}
 		b.WriteByte(s[i])
 		i++

--- a/images/agent/internal/udev/properties.go
+++ b/images/agent/internal/udev/properties.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type UdevProperties struct {
+	DevName  string
+	DevType  string
+	Major    int
+	Minor    int
+	Serial   string
+	Model    string
+	WWN      string
+	FSType   string
+	PartUUID string
+	DMName   string
+	DMUUID   string
+	MDLevel  string
+}
+
+func ParseUdevProperties(env map[string]string) (UdevProperties, error) {
+	major, err := strconv.Atoi(env["MAJOR"])
+	if err != nil {
+		return UdevProperties{}, fmt.Errorf("parse MAJOR: %w", err)
+	}
+
+	minor, err := strconv.Atoi(env["MINOR"])
+	if err != nil {
+		return UdevProperties{}, fmt.Errorf("parse MINOR: %w", err)
+	}
+
+	return UdevProperties{
+		DevName:  ensureDevPrefix(env["DEVNAME"]),
+		DevType:  env["DEVTYPE"],
+		Major:    major,
+		Minor:    minor,
+		Serial:   serialFromUdevEnv(env),
+		Model:    modelFromUdevEnv(env),
+		WWN:      wwnFromUdevEnv(env),
+		FSType:   env["ID_FS_TYPE"],
+		PartUUID: env["ID_PART_ENTRY_UUID"],
+		DMName:   env["DM_NAME"],
+		DMUUID:   env["DM_UUID"],
+		MDLevel:  env["MD_LEVEL"],
+	}, nil
+}
+
+// serialFromUdevEnv follows the lsblk get_properties_by_udev() priority chain:
+// SCSI_IDENT_SERIAL -> ID_SCSI_SERIAL -> ID_SERIAL_SHORT -> ID_SERIAL.
+func serialFromUdevEnv(env map[string]string) string {
+	for _, key := range []string{"SCSI_IDENT_SERIAL", "ID_SCSI_SERIAL", "ID_SERIAL_SHORT", "ID_SERIAL"} {
+		if v := env[key]; v != "" {
+			return normalizeWhitespace(v)
+		}
+	}
+	return ""
+}
+
+// modelFromUdevEnv follows lsblk: ID_MODEL_ENC (unhexmangle + normalize) or ID_MODEL.
+func modelFromUdevEnv(env map[string]string) string {
+	if enc := env["ID_MODEL_ENC"]; enc != "" {
+		return normalizeWhitespace(unhexmangle(enc))
+	}
+	return normalizeWhitespace(env["ID_MODEL"])
+}
+
+// wwnFromUdevEnv follows lsblk: ID_WWN_WITH_EXTENSION takes priority over ID_WWN.
+func wwnFromUdevEnv(env map[string]string) string {
+	if v := env["ID_WWN_WITH_EXTENSION"]; v != "" {
+		return v
+	}
+	return env["ID_WWN"]
+}
+
+// normalizeWhitespace collapses whitespace runs and trims edges,
+// matching util-linux normalize_whitespace() used by lsblk after reading udev properties.
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func hexVal(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	default:
+		return -1
+	}
+}
+
+// unhexmangle decodes udev \xHH escape sequences,
+// matching unhexmangle_to_buffer() in util-linux lib/mangle.c.
+func unhexmangle(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if i+3 < len(s) && s[i] == '\\' && s[i+1] == 'x' &&
+			hexVal(s[i+2]) >= 0 && hexVal(s[i+3]) >= 0 {
+			b.WriteByte(byte(hexVal(s[i+2])<<4 | hexVal(s[i+3])))
+			i += 4
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+func ensureDevPrefix(devName string) string {
+	if devName == "" || strings.HasPrefix(devName, "/dev/") {
+		return devName
+	}
+	return "/dev/" + devName
+}
+
+// DeviceKey returns "major:minor".
+func DeviceKey(major, minor int) string {
+	return strconv.Itoa(major) + ":" + strconv.Itoa(minor)
+}

--- a/images/agent/internal/udev/properties.go
+++ b/images/agent/internal/udev/properties.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 )
 
-type UdevProperties struct {
+type Properties struct {
 	DevName  string
 	DevType  string
 	Major    int
@@ -37,18 +37,18 @@ type UdevProperties struct {
 	MDLevel  string
 }
 
-func ParseUdevProperties(env map[string]string) (UdevProperties, error) {
+func ParseProperties(env map[string]string) (Properties, error) {
 	major, err := strconv.Atoi(env["MAJOR"])
 	if err != nil {
-		return UdevProperties{}, fmt.Errorf("parse MAJOR: %w", err)
+		return Properties{}, fmt.Errorf("parse MAJOR: %w", err)
 	}
 
 	minor, err := strconv.Atoi(env["MINOR"])
 	if err != nil {
-		return UdevProperties{}, fmt.Errorf("parse MINOR: %w", err)
+		return Properties{}, fmt.Errorf("parse MINOR: %w", err)
 	}
 
-	return UdevProperties{
+	return Properties{
 		DevName:  ensureDevPrefix(env["DEVNAME"]),
 		DevType:  env["DEVTYPE"],
 		Major:    major,

--- a/images/agent/internal/udev/properties_test.go
+++ b/images/agent/internal/udev/properties_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ================== ParseUdevProperties ==================
+// ================== ParseProperties ==================
 
-func TestParseUdevProperties_FullEnv(t *testing.T) {
+func TestParseProperties_FullEnv(t *testing.T) {
 	env := map[string]string{
 		"DEVNAME":            "sda",
 		"DEVTYPE":            "disk",
@@ -41,7 +41,7 @@ func TestParseUdevProperties_FullEnv(t *testing.T) {
 		"DM_UUID":            "",
 		"MD_LEVEL":           "",
 	}
-	props, err := ParseUdevProperties(env)
+	props, err := ParseProperties(env)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/dev/sda", props.DevName)
@@ -55,19 +55,19 @@ func TestParseUdevProperties_FullEnv(t *testing.T) {
 	assert.Equal(t, "abcd-1234", props.PartUUID)
 }
 
-func TestParseUdevProperties_SerialFallback(t *testing.T) {
+func TestParseProperties_SerialFallback(t *testing.T) {
 	env := map[string]string{
 		"DEVNAME":   "/dev/sda",
 		"MAJOR":     "8",
 		"MINOR":     "0",
 		"ID_SERIAL": "WDC_WD10EZEX_WD-ABC123",
 	}
-	props, err := ParseUdevProperties(env)
+	props, err := ParseProperties(env)
 	require.NoError(t, err)
 	assert.Equal(t, "WDC_WD10EZEX_WD-ABC123", props.Serial, "Falls back to ID_SERIAL")
 }
 
-func TestParseUdevProperties_SerialScsiChainAndNormalize(t *testing.T) {
+func TestParseProperties_SerialScsiChainAndNormalize(t *testing.T) {
 	env := map[string]string{
 		"DEVNAME":           "/dev/sda",
 		"MAJOR":             "8",
@@ -77,12 +77,12 @@ func TestParseUdevProperties_SerialScsiChainAndNormalize(t *testing.T) {
 		"ID_SERIAL_SHORT":   "short",
 		"ID_SERIAL":         "long",
 	}
-	props, err := ParseUdevProperties(env)
+	props, err := ParseProperties(env)
 	require.NoError(t, err)
 	assert.Equal(t, "SG3 ID", props.Serial)
 }
 
-func TestParseUdevProperties_WwnPrefersExtension(t *testing.T) {
+func TestParseProperties_WwnPrefersExtension(t *testing.T) {
 	env := map[string]string{
 		"DEVNAME":               "/dev/sda",
 		"MAJOR":                 "8",
@@ -90,12 +90,12 @@ func TestParseUdevProperties_WwnPrefersExtension(t *testing.T) {
 		"ID_WWN":                "0x5000",
 		"ID_WWN_WITH_EXTENSION": "0x5000deadbeef",
 	}
-	props, err := ParseUdevProperties(env)
+	props, err := ParseProperties(env)
 	require.NoError(t, err)
 	assert.Equal(t, "0x5000deadbeef", props.WWN)
 }
 
-func TestParseUdevProperties_ModelFromEnc(t *testing.T) {
+func TestParseProperties_ModelFromEnc(t *testing.T) {
 	env := map[string]string{
 		"DEVNAME":      "/dev/sda",
 		"MAJOR":        "8",
@@ -103,60 +103,60 @@ func TestParseUdevProperties_ModelFromEnc(t *testing.T) {
 		"ID_MODEL":     "IGNORED_WHEN_ENC",
 		"ID_MODEL_ENC": `Vendor\x20Disk\x20Name`,
 	}
-	props, err := ParseUdevProperties(env)
+	props, err := ParseProperties(env)
 	require.NoError(t, err)
 	assert.Equal(t, "Vendor Disk Name", props.Model)
 }
 
-func TestParseUdevProperties_DevNamePrefixAdded(t *testing.T) {
+func TestParseProperties_DevNamePrefixAdded(t *testing.T) {
 	env := map[string]string{
 		"DEVNAME": "sda",
 		"MAJOR":   "8",
 		"MINOR":   "0",
 	}
-	props, err := ParseUdevProperties(env)
+	props, err := ParseProperties(env)
 	require.NoError(t, err)
 	assert.Equal(t, "/dev/sda", props.DevName, "Adds /dev/ prefix when missing")
 }
 
-func TestParseUdevProperties_DevNameAlreadyPrefixed(t *testing.T) {
+func TestParseProperties_DevNameAlreadyPrefixed(t *testing.T) {
 	env := map[string]string{
 		"DEVNAME": "/dev/nvme0n1",
 		"MAJOR":   "259",
 		"MINOR":   "0",
 	}
-	props, err := ParseUdevProperties(env)
+	props, err := ParseProperties(env)
 	require.NoError(t, err)
 	assert.Equal(t, "/dev/nvme0n1", props.DevName)
 }
 
-func TestParseUdevProperties_MissingMajor(t *testing.T) {
-	_, err := ParseUdevProperties(map[string]string{"DEVNAME": "/dev/sda"})
+func TestParseProperties_MissingMajor(t *testing.T) {
+	_, err := ParseProperties(map[string]string{"DEVNAME": "/dev/sda"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "MAJOR")
 }
 
-func TestParseUdevProperties_MissingMinor(t *testing.T) {
-	_, err := ParseUdevProperties(map[string]string{"MAJOR": "8"})
+func TestParseProperties_MissingMinor(t *testing.T) {
+	_, err := ParseProperties(map[string]string{"MAJOR": "8"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "MINOR")
 }
 
-func TestParseUdevProperties_InvalidMajor(t *testing.T) {
-	props, err := ParseUdevProperties(map[string]string{
+func TestParseProperties_InvalidMajor(t *testing.T) {
+	props, err := ParseProperties(map[string]string{
 		"MAJOR": "abc", "MINOR": "0",
 	})
 	require.Error(t, err)
-	assert.Equal(t, UdevProperties{}, props)
+	assert.Equal(t, Properties{}, props)
 	assert.Contains(t, err.Error(), "MAJOR")
 }
 
-func TestParseUdevProperties_InvalidMinor(t *testing.T) {
-	props, err := ParseUdevProperties(map[string]string{
+func TestParseProperties_InvalidMinor(t *testing.T) {
+	props, err := ParseProperties(map[string]string{
 		"MAJOR": "8", "MINOR": "xyz",
 	})
 	require.Error(t, err)
-	assert.Equal(t, UdevProperties{}, props)
+	assert.Equal(t, Properties{}, props)
 	assert.Contains(t, err.Error(), "MINOR")
 }
 

--- a/images/agent/internal/udev/properties_test.go
+++ b/images/agent/internal/udev/properties_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ================== ParseUdevProperties ==================
+
+func TestParseUdevProperties_FullEnv(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":            "sda",
+		"DEVTYPE":            "disk",
+		"MAJOR":              "8",
+		"MINOR":              "0",
+		"ID_SERIAL_SHORT":    "WD-ABC123",
+		"ID_SERIAL":          "WDC_WD10EZEX_WD-ABC123",
+		"ID_MODEL":           "WDC_WD10EZEX",
+		"ID_WWN":             "0x50014ee2b5e7c5a0",
+		"ID_FS_TYPE":         "ext4",
+		"ID_PART_ENTRY_UUID": "abcd-1234",
+		"DM_NAME":            "",
+		"DM_UUID":            "",
+		"MD_LEVEL":           "",
+	}
+	props, err := ParseUdevProperties(env)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/dev/sda", props.DevName)
+	assert.Equal(t, "disk", props.DevType)
+	assert.Equal(t, 8, props.Major)
+	assert.Equal(t, 0, props.Minor)
+	assert.Equal(t, "WD-ABC123", props.Serial, "ID_SERIAL_SHORT takes priority")
+	assert.Equal(t, "WDC_WD10EZEX", props.Model)
+	assert.Equal(t, "0x50014ee2b5e7c5a0", props.WWN)
+	assert.Equal(t, "ext4", props.FSType)
+	assert.Equal(t, "abcd-1234", props.PartUUID)
+}
+
+func TestParseUdevProperties_SerialFallback(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":   "/dev/sda",
+		"MAJOR":     "8",
+		"MINOR":     "0",
+		"ID_SERIAL": "WDC_WD10EZEX_WD-ABC123",
+	}
+	props, err := ParseUdevProperties(env)
+	require.NoError(t, err)
+	assert.Equal(t, "WDC_WD10EZEX_WD-ABC123", props.Serial, "Falls back to ID_SERIAL")
+}
+
+func TestParseUdevProperties_SerialScsiChainAndNormalize(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":           "/dev/sda",
+		"MAJOR":             "8",
+		"MINOR":             "0",
+		"SCSI_IDENT_SERIAL": "  SG3  ID  ",
+		"ID_SCSI_SERIAL":    "scsi",
+		"ID_SERIAL_SHORT":   "short",
+		"ID_SERIAL":         "long",
+	}
+	props, err := ParseUdevProperties(env)
+	require.NoError(t, err)
+	assert.Equal(t, "SG3 ID", props.Serial)
+}
+
+func TestParseUdevProperties_WwnPrefersExtension(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":               "/dev/sda",
+		"MAJOR":                 "8",
+		"MINOR":                 "0",
+		"ID_WWN":                "0x5000",
+		"ID_WWN_WITH_EXTENSION": "0x5000deadbeef",
+	}
+	props, err := ParseUdevProperties(env)
+	require.NoError(t, err)
+	assert.Equal(t, "0x5000deadbeef", props.WWN)
+}
+
+func TestParseUdevProperties_ModelFromEnc(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME":      "/dev/sda",
+		"MAJOR":        "8",
+		"MINOR":        "0",
+		"ID_MODEL":     "IGNORED_WHEN_ENC",
+		"ID_MODEL_ENC": `Vendor\x20Disk\x20Name`,
+	}
+	props, err := ParseUdevProperties(env)
+	require.NoError(t, err)
+	assert.Equal(t, "Vendor Disk Name", props.Model)
+}
+
+func TestParseUdevProperties_DevNamePrefixAdded(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME": "sda",
+		"MAJOR":   "8",
+		"MINOR":   "0",
+	}
+	props, err := ParseUdevProperties(env)
+	require.NoError(t, err)
+	assert.Equal(t, "/dev/sda", props.DevName, "Adds /dev/ prefix when missing")
+}
+
+func TestParseUdevProperties_DevNameAlreadyPrefixed(t *testing.T) {
+	env := map[string]string{
+		"DEVNAME": "/dev/nvme0n1",
+		"MAJOR":   "259",
+		"MINOR":   "0",
+	}
+	props, err := ParseUdevProperties(env)
+	require.NoError(t, err)
+	assert.Equal(t, "/dev/nvme0n1", props.DevName)
+}
+
+func TestParseUdevProperties_MissingMajor(t *testing.T) {
+	_, err := ParseUdevProperties(map[string]string{"DEVNAME": "/dev/sda"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MAJOR")
+}
+
+func TestParseUdevProperties_MissingMinor(t *testing.T) {
+	_, err := ParseUdevProperties(map[string]string{"MAJOR": "8"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MINOR")
+}
+
+func TestParseUdevProperties_InvalidMajor(t *testing.T) {
+	props, err := ParseUdevProperties(map[string]string{
+		"MAJOR": "abc", "MINOR": "0",
+	})
+	require.Error(t, err)
+	assert.Equal(t, UdevProperties{}, props)
+	assert.Contains(t, err.Error(), "MAJOR")
+}
+
+func TestParseUdevProperties_InvalidMinor(t *testing.T) {
+	props, err := ParseUdevProperties(map[string]string{
+		"MAJOR": "8", "MINOR": "xyz",
+	})
+	require.Error(t, err)
+	assert.Equal(t, UdevProperties{}, props)
+	assert.Contains(t, err.Error(), "MINOR")
+}
+
+// ================== normalizeWhitespace ==================
+
+func TestNormalizeWhitespace(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"a", "a"},
+		{"  a", "a"},
+		{"a  b", "a b"},
+		{"a \t b", "a b"},
+		{"a b ", "a b"},
+		{"  a  b  ", "a b"},
+		{"   ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeWhitespace(tt.in))
+		})
+	}
+}
+
+// ================== unhexmangle ==================
+
+func TestUnhexmangle(t *testing.T) {
+	assert.Equal(t, "ST330006 50NS", unhexmangle(`ST330006\x2050NS`))
+	assert.Equal(t, "Vendor Disk Name", unhexmangle(`Vendor\x20Disk\x20Name`))
+	assert.Equal(t, "no escapes", unhexmangle("no escapes"))
+	assert.Equal(t, "", unhexmangle(""))
+	assert.Equal(t, `\xZZ`, unhexmangle(`\xZZ`), "invalid hex digits left as-is")
+	assert.Equal(t, `\x4`, unhexmangle(`\x4`), "incomplete sequence left as-is")
+}
+
+// ================== ensureDevPrefix ==================
+
+func TestEnsureDevPrefix(t *testing.T) {
+	assert.Equal(t, "", ensureDevPrefix(""))
+	assert.Equal(t, "/dev/sda", ensureDevPrefix("sda"))
+	assert.Equal(t, "/dev/sda", ensureDevPrefix("/dev/sda"))
+	assert.Equal(t, "/dev/nvme0n1", ensureDevPrefix("nvme0n1"))
+}
+
+// ================== DeviceKey ==================
+
+func TestDeviceKey(t *testing.T) {
+	assert.Equal(t, "8:0", DeviceKey(8, 0))
+	assert.Equal(t, "259:1", DeviceKey(259, 1))
+}


### PR DESCRIPTION
## Summary

This is PR 1 of 3 in the effort to replace `lsblk` exec-based block device
discovery with an in-process netlink/udev/sysfs approach.

This PR introduces the foundational data layer (`internal/udev` package):

- **`Properties`** — typed struct for parsed udev environment, matching
  lsblk's field-resolution priority chains (serial, model, wwn).
- **`ParseProperties`** — parses raw `map[string]string` from netlink events
  into `Properties`. Returns error on invalid/missing MAJOR/MINOR, never
  returns partial data.
- **`DeviceMap`** — thread-safe concurrent store (`map[string]Properties`,
  keyed by `"major:minor"`). `HandleEvent` processes kernel uevents
  (add/change/remove/bind/unbind) and returns errors to the caller.
- **`ErrUnknownAction`** — sentinel error for programmatic handling of
  unexpected uevent actions.

## How this will be used

1. **PR 2** will add `FillFromCrawler` to `DeviceMap` for initial device
   population from sysfs crawler + udev DB enrichment.
2. **PR 3** will add sysfs readers, `BuildDevice` (Properties → internal.Device),
   `Snapshot`, and integrate everything into `scanner.Run` — replacing the
   current `lsblk` exec path.

## What is NOT in this PR

- No sysfs I/O (reading size, rotational, hotplug, slaves)
- No `BuildDevice` / `Snapshot` / scanner integration
- No changes to existing code — this is purely additive

## Test plan

- 33 unit tests covering property parsing, error handling, DeviceMap
  lifecycle (add/change/remove/bind/unbind/move/online/offline),
  concurrent access, and copy safety