### PR TITLE
[scheduler-extender] Skip rawfile-backed local PVCs

### DIFF
--- a/images/sds-common-scheduler-extender/pkg/consts/consts.go
+++ b/images/sds-common-scheduler-extender/pkg/consts/consts.go
@@ -23,6 +23,19 @@ const (
 	LvmTypeParamKey         = "local.csi.storage.deckhouse.io/lvm-type"
 	LVMVolumeGroupsParamKey = "local.csi.storage.deckhouse.io/lvm-volume-groups"
 
+	// LocalStorageTypeParamKey identifies the backing storage type of a
+	// LocalStorageClass-derived StorageClass. The LSC controller in
+	// sds-local-volume sets it to either "lvm" or "rawfile".
+	LocalStorageTypeParamKey = "local.csi.storage.deckhouse.io/type"
+
+	// LocalStorageTypeRawFile marks a StorageClass produced by a
+	// LocalStorageClass with `spec.rawFile` (loop-device-backed) configuration.
+	// Such StorageClasses MUST NOT be processed by the LVM-aware code paths of
+	// this extender: they have no `lvm-type` / `lvm-volume-groups` parameters
+	// and node placement is enforced by `allowedTopologies` on the StorageClass
+	// itself.
+	LocalStorageTypeRawFile = "rawfile"
+
 	Thick = "Thick"
 	Thin  = "Thin"
 )

--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
@@ -240,8 +240,11 @@ func filterNodes(
 	scUsedByPVCs map[string]*storagev1.StorageClass,
 	pvcRequests map[string]PVCRequest,
 ) (*ExtenderFilterResult, error) {
-	// Separate PVCs by provisioner
-	localPVCs := filterPVCsByProvisioner(managedPVCs, scUsedByPVCs, consts.SdsLocalVolumeProvisioner)
+	// Separate PVCs by provisioner. For local-volume PVCs we additionally
+	// require the StorageClass to be LVM-backed: rawfile-backed local PVCs
+	// have no LVM parameters and rely on `allowedTopologies` for placement,
+	// so the LVM-aware filter path MUST skip them entirely.
+	localPVCs := filterLocalLVMPVCs(managedPVCs, scUsedByPVCs)
 	replicatedPVCs := filterPVCsByProvisioner(managedPVCs, scUsedByPVCs, consts.SdsReplicatedVolumeProvisioner)
 
 	log.Debug(fmt.Sprintf("[filterNodes] local PVCs count: %d, replicated PVCs count: %d", len(localPVCs), len(replicatedPVCs)))
@@ -406,9 +409,15 @@ func createReservations(
 	for _, pvc := range managedPVCs {
 		sc := scUsedByPVCs[*pvc.Spec.StorageClassName]
 
-		// Only create reservations for local PVCs; replicated PVCs use a different mechanism
+		// Only create reservations for LVM-backed local PVCs; replicated PVCs
+		// use a different mechanism, and rawfile-backed local PVCs have no
+		// LVMVolumeGroups to reserve space in.
 		if sc.Provisioner != consts.SdsLocalVolumeProvisioner {
 			log.Debug(fmt.Sprintf("[createReservations] PVC %s uses provisioner %s, skipping", pvc.Name, sc.Provisioner))
+			continue
+		}
+		if isRawFileLocalSC(sc) {
+			log.Debug(fmt.Sprintf("[createReservations] PVC %s uses rawfile-backed StorageClass %s, skipping", pvc.Name, sc.Name))
 			continue
 		}
 

--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
@@ -251,8 +251,11 @@ func filterNodes(
 	scUsedByPVCs map[string]*storagev1.StorageClass,
 	pvcRequests map[string]PVCRequest,
 ) (*ExtenderFilterResult, error) {
-	// Separate PVCs by provisioner
-	localPVCs := filterPVCsByProvisioner(managedPVCs, scUsedByPVCs, consts.SdsLocalVolumeProvisioner)
+	// Separate PVCs by provisioner. For local-volume PVCs we additionally
+	// require the StorageClass to be LVM-backed: rawfile-backed local PVCs
+	// have no LVM parameters and rely on `allowedTopologies` for placement,
+	// so the LVM-aware filter path MUST skip them entirely.
+	localPVCs := filterLocalLVMPVCs(managedPVCs, scUsedByPVCs)
 	replicatedPVCs := filterPVCsByProvisioner(managedPVCs, scUsedByPVCs, consts.SdsReplicatedVolumeProvisioner)
 
 	log.Debug(fmt.Sprintf("[filterNodes] local PVCs count: %d, replicated PVCs count: %d", len(localPVCs), len(replicatedPVCs)))
@@ -417,9 +420,15 @@ func createReservations(
 	for _, pvc := range managedPVCs {
 		sc := scUsedByPVCs[*pvc.Spec.StorageClassName]
 
-		// Only create reservations for local PVCs; replicated PVCs use a different mechanism
+		// Only create reservations for LVM-backed local PVCs; replicated PVCs
+		// use a different mechanism, and rawfile-backed local PVCs have no
+		// LVMVolumeGroups to reserve space in.
 		if sc.Provisioner != consts.SdsLocalVolumeProvisioner {
 			log.Debug(fmt.Sprintf("[createReservations] PVC %s uses provisioner %s, skipping", pvc.Name, sc.Provisioner))
+			continue
+		}
+		if isRawFileLocalSC(sc) {
+			log.Debug(fmt.Sprintf("[createReservations] PVC %s uses rawfile-backed StorageClass %s, skipping", pvc.Name, sc.Name))
 			continue
 		}
 

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -508,7 +508,25 @@ func getNewControlPlane(ctx context.Context, cl client.Client, log logger.Logger
 	return &_false, nil
 }
 
+// isRawFileLocalSC reports whether the given StorageClass is produced by a
+// LocalStorageClass with `spec.rawFile` (loop-device-backed) configuration.
+//
+// Such StorageClasses share the local-volume provisioner with LVM-backed ones
+// but expose no LVM parameters and rely on `allowedTopologies` for node
+// placement, so they MUST be skipped by the LVM-aware code paths of this
+// extender.
+func isRawFileLocalSC(sc *storagev1.StorageClass) bool {
+	if sc == nil || sc.Provisioner != consts.SdsLocalVolumeProvisioner {
+		return false
+	}
+	return sc.Parameters[consts.LocalStorageTypeParamKey] == consts.LocalStorageTypeRawFile
+}
+
 // extractRequestedSize extracts the requested size from the PVC based on the PVC status phase and the StorageClass parameters.
+//
+// PVCs whose StorageClass is rawfile-backed (see isRawFileLocalSC) are silently
+// skipped: the extender has nothing useful to compute for them, and node
+// placement is enforced via `allowedTopologies` on the StorageClass.
 func extractRequestedSize(
 	ctx context.Context,
 	cl client.Client,
@@ -520,6 +538,11 @@ func extractRequestedSize(
 	for _, pvc := range pvcs {
 		sc := scs[*pvc.Spec.StorageClassName]
 		log.Debug(fmt.Sprintf("[extractRequestedSize] PVC %s/%s has status phase: %s", pvc.Namespace, pvc.Name, pvc.Status.Phase))
+
+		if isRawFileLocalSC(sc) {
+			log.Debug(fmt.Sprintf("[extractRequestedSize] PVC %s/%s uses rawfile-backed StorageClass %s, skipping LVM-aware extraction", pvc.Namespace, pvc.Name, sc.Name))
+			continue
+		}
 
 		var deviceType string
 		isReplicated := sc.Provisioner == consts.SdsReplicatedVolumeProvisioner

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -578,6 +578,20 @@ func getNewControlPlane(ctx context.Context, cl client.Client, log logger.Logger
 	return &_false, nil
 }
 
+// isRawFileLocalSC reports whether the given StorageClass is produced by a
+// LocalStorageClass with `spec.rawFile` (loop-device-backed) configuration.
+//
+// Such StorageClasses share the local-volume provisioner with LVM-backed ones
+// but expose no LVM parameters and rely on `allowedTopologies` for node
+// placement, so they MUST be skipped by the LVM-aware code paths of this
+// extender.
+func isRawFileLocalSC(sc *storagev1.StorageClass) bool {
+	if sc == nil || sc.Provisioner != consts.SdsLocalVolumeProvisioner {
+		return false
+	}
+	return sc.Parameters[consts.LocalStorageTypeParamKey] == consts.LocalStorageTypeRawFile
+}
+
 // extractRequestedSize extracts the requested size from the PVC based on the PVC
 // binding state (pvc.Spec.VolumeName) and the StorageClass parameters.
 //
@@ -588,6 +602,10 @@ func getNewControlPlane(ctx context.Context, cl client.Client, log logger.Logger
 // silently drops the PVC. Spec.VolumeName, on the other hand, is set in the same
 // transaction as the binding and matches what the upstream VolumeBinding plugin
 // uses to decide whether a PVC is bound.
+//
+// PVCs whose StorageClass is rawfile-backed (see isRawFileLocalSC) are silently
+// skipped: the extender has nothing useful to compute for them, and node
+// placement is enforced via `allowedTopologies` on the StorageClass.
 func extractRequestedSize(
 	ctx context.Context,
 	cl client.Client,
@@ -599,6 +617,11 @@ func extractRequestedSize(
 	for _, pvc := range pvcs {
 		sc := scs[*pvc.Spec.StorageClassName]
 		log.Debug(fmt.Sprintf("[extractRequestedSize] PVC %s/%s has status phase: %q, spec.volumeName: %q", pvc.Namespace, pvc.Name, pvc.Status.Phase, pvc.Spec.VolumeName))
+
+		if isRawFileLocalSC(sc) {
+			log.Debug(fmt.Sprintf("[extractRequestedSize] PVC %s/%s uses rawfile-backed StorageClass %s, skipping LVM-aware extraction", pvc.Namespace, pvc.Name, sc.Name))
+			continue
+		}
 
 		var deviceType string
 		isReplicated := sc.Provisioner == consts.SdsReplicatedVolumeProvisioner

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
@@ -515,3 +515,192 @@ func TestFilter_FailedExtractSize_RejectsAllNodes(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+// TestFilter_RawFileLocalSC_PassesAllNodes is a regression test for the bug
+// where any PVC bound to a StorageClass with provisioner `local.csi.storage.deckhouse.io`
+// but without `lvm-type` parameter caused the filter to fail with
+// "unable to extract request size: [...] unable to determine device type for PVC ...",
+// rejecting all candidate nodes.
+//
+// LocalStorageClass resources with `spec.rawFile` produce exactly such
+// StorageClasses (LVM parameters are absent on purpose). For those PVCs the
+// extender has nothing useful to compute -- placement is enforced by
+// `allowedTopologies` on the StorageClass. The filter MUST return all input
+// nodes unchanged.
+func TestFilter_RawFileLocalSC_PassesAllNodes(t *testing.T) {
+	scName := "rawfile-sc"
+	sc := testLocalRawFileSC(scName)
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	cl := newFakeClient(sc, pvc)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node1", "node2", "node3"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.NotNil(t, result.NodeNames)
+	assert.ElementsMatch(t, nodeNames, *result.NodeNames, "all input nodes must be returned unchanged")
+	assert.Empty(t, result.FailedNodes, "no nodes must be marked as failed for a rawfile-only Pod")
+}
+
+// TestFilter_MixedLocalLVMAndRawFile_LVMRulesApply verifies that mixing an
+// LVM-backed local PVC and a rawfile-backed local PVC on the same Pod does not
+// regress the LVM behavior: LVG matching still happens for the LVM PVC, and
+// the rawfile PVC is silently ignored.
+func TestFilter_MixedLocalLVMAndRawFile_LVMRulesApply(t *testing.T) {
+	rawFileSCName := "rawfile-sc"
+	rawFileSC := testLocalRawFileSC(rawFileSCName)
+	rawFilePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "raw-pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &rawFileSCName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+
+	lvmSCName := "lvm-sc"
+	lvmSC := testLocalSC(lvmSCName, "lvg1")
+	lvmPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "lvm-pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &lvmSCName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+
+	// node1 has the matching LVG, node2 does not -- so the LVM PVC must
+	// keep node1 and reject node2.
+	const hundredGiB = int64(100 * 1024 * 1024 * 1024)
+	cl := newFakeClient(rawFileSC, rawFilePVC, lvmSC, lvmPVC, readyLVGOnNode("lvg1", "node1", hundredGiB, hundredGiB))
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node1", "node2"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v-lvm", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "lvm-pvc"},
+					}},
+					{Name: "v-raw", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "raw-pvc"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.NotNil(t, result.NodeNames)
+	assert.ElementsMatch(t, []string{"node1"}, *result.NodeNames, "only the node with a matching LVG must pass the LVM filter")
+	if reason, ok := result.FailedNodes["node2"]; ok {
+		assert.Contains(t, reason, "[local]", "node2 must be rejected by the LVM-aware filter, not by rawfile handling")
+	}
+}
+
+// TestPrioritize_RawFileLocalSC_DoesNotError ensures the prioritize endpoint
+// also tolerates rawfile-backed local PVCs (used to return 500 with the same
+// "unable to extract request size" failure).
+func TestPrioritize_RawFileLocalSC_DoesNotError(t *testing.T) {
+	scName := "rawfile-sc"
+	sc := testLocalRawFileSC(scName)
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	cl := newFakeClient(sc, pvc)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node1", "node2"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/prioritize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.prioritize(w, req)
+
+	assert.NotEqual(t, http.StatusInternalServerError, w.Code, "prioritize must not return 500 for a rawfile-backed local SC")
+}

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
@@ -1188,3 +1188,192 @@ func TestFilter_LocalPVC_EmptyPhase_KeepsMatchingNode(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+// TestFilter_RawFileLocalSC_PassesAllNodes is a regression test for the bug
+// where any PVC bound to a StorageClass with provisioner `local.csi.storage.deckhouse.io`
+// but without `lvm-type` parameter caused the filter to fail with
+// "unable to extract request size: [...] unable to determine device type for PVC ...",
+// rejecting all candidate nodes.
+//
+// LocalStorageClass resources with `spec.rawFile` produce exactly such
+// StorageClasses (LVM parameters are absent on purpose). For those PVCs the
+// extender has nothing useful to compute -- placement is enforced by
+// `allowedTopologies` on the StorageClass. The filter MUST return all input
+// nodes unchanged.
+func TestFilter_RawFileLocalSC_PassesAllNodes(t *testing.T) {
+	scName := "rawfile-sc"
+	sc := testLocalRawFileSC(scName)
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	cl := newFakeClient(sc, pvc)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node1", "node2", "node3"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.NotNil(t, result.NodeNames)
+	assert.ElementsMatch(t, nodeNames, *result.NodeNames, "all input nodes must be returned unchanged")
+	assert.Empty(t, result.FailedNodes, "no nodes must be marked as failed for a rawfile-only Pod")
+}
+
+// TestFilter_MixedLocalLVMAndRawFile_LVMRulesApply verifies that mixing an
+// LVM-backed local PVC and a rawfile-backed local PVC on the same Pod does not
+// regress the LVM behavior: LVG matching still happens for the LVM PVC, and
+// the rawfile PVC is silently ignored.
+func TestFilter_MixedLocalLVMAndRawFile_LVMRulesApply(t *testing.T) {
+	rawFileSCName := "rawfile-sc"
+	rawFileSC := testLocalRawFileSC(rawFileSCName)
+	rawFilePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "raw-pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &rawFileSCName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+
+	lvmSCName := "lvm-sc"
+	lvmSC := testLocalSC(lvmSCName, "lvg1")
+	lvmPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "lvm-pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &lvmSCName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+
+	// node1 has the matching LVG, node2 does not -- so the LVM PVC must
+	// keep node1 and reject node2.
+	const hundredGiB = int64(100 * 1024 * 1024 * 1024)
+	cl := newFakeClient(rawFileSC, rawFilePVC, lvmSC, lvmPVC, readyLVGOnNode("lvg1", "node1", hundredGiB, hundredGiB))
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node1", "node2"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v-lvm", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "lvm-pvc"},
+					}},
+					{Name: "v-raw", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "raw-pvc"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.NotNil(t, result.NodeNames)
+	assert.ElementsMatch(t, []string{"node1"}, *result.NodeNames, "only the node with a matching LVG must pass the LVM filter")
+	if reason, ok := result.FailedNodes["node2"]; ok {
+		assert.Contains(t, reason, "[local]", "node2 must be rejected by the LVM-aware filter, not by rawfile handling")
+	}
+}
+
+// TestPrioritize_RawFileLocalSC_DoesNotError ensures the prioritize endpoint
+// also tolerates rawfile-backed local PVCs (used to return 500 with the same
+// "unable to extract request size" failure).
+func TestPrioritize_RawFileLocalSC_DoesNotError(t *testing.T) {
+	scName := "rawfile-sc"
+	sc := testLocalRawFileSC(scName)
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	cl := newFakeClient(sc, pvc)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node1", "node2"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/prioritize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.prioritize(w, req)
+
+	assert.NotEqual(t, http.StatusInternalServerError, w.Code, "prioritize must not return 500 for a rawfile-backed local SC")
+}

--- a/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
@@ -385,6 +385,20 @@ func testLocalThinSC(name, lvgName, thinPoolName string) *storagev1.StorageClass
 	}
 }
 
+// testLocalRawFileSC returns a StorageClass that mimics what the LSC controller
+// in sds-local-volume creates for a LocalStorageClass with `spec.rawFile` set:
+// same provisioner as LVM-backed local SCs, but with the `type=rawfile` marker
+// and no LVM parameters.
+func testLocalRawFileSC(name string) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: name},
+		Provisioner: consts.SdsLocalVolumeProvisioner,
+		Parameters: map[string]string{
+			consts.LocalStorageTypeParamKey: consts.LocalStorageTypeRawFile,
+		},
+	}
+}
+
 func testPendingPVC(name, namespace, scName string) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},

--- a/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
@@ -191,8 +191,11 @@ func scoreNodes(
 	replicaLocations map[string][]string,
 	divisor float64,
 ) ([]HostPriority, error) {
-	// Separate PVCs by provisioner
-	localPVCs := filterPVCsByProvisioner(managedPVCs, scUsedByPVCs, consts.SdsLocalVolumeProvisioner)
+	// Separate PVCs by provisioner. For local-volume PVCs we additionally
+	// require the StorageClass to be LVM-backed: rawfile-backed local PVCs
+	// have no LVM parameters and rely on `allowedTopologies` for placement,
+	// so the LVM-aware scoring path MUST skip them entirely.
+	localPVCs := filterLocalLVMPVCs(managedPVCs, scUsedByPVCs)
 	replicatedPVCs := filterPVCsByProvisioner(managedPVCs, scUsedByPVCs, consts.SdsReplicatedVolumeProvisioner)
 
 	log.Debug(fmt.Sprintf("[scoreNodes] local PVCs count: %d, replicated PVCs count: %d", len(localPVCs), len(replicatedPVCs)))
@@ -377,8 +380,12 @@ func narrowReservationsToFinalNodes(
 	for _, pvc := range managedPVCs {
 		sc := scUsedByPVCs[*pvc.Spec.StorageClassName]
 
-		// Only narrow local PVCs (replicated use a different mechanism)
+		// Only narrow LVM-backed local PVCs (replicated use a different
+		// mechanism, and rawfile-backed local PVCs have no reservation).
 		if sc.Provisioner != consts.SdsLocalVolumeProvisioner {
+			continue
+		}
+		if isRawFileLocalSC(sc) {
 			continue
 		}
 

--- a/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
@@ -195,8 +195,11 @@ func scoreNodes(
 	replicaLocations map[string][]string,
 	divisor float64,
 ) ([]HostPriority, error) {
-	// Separate PVCs by provisioner
-	localPVCs := filterPVCsByProvisioner(managedPVCs, scUsedByPVCs, consts.SdsLocalVolumeProvisioner)
+	// Separate PVCs by provisioner. For local-volume PVCs we additionally
+	// require the StorageClass to be LVM-backed: rawfile-backed local PVCs
+	// have no LVM parameters and rely on `allowedTopologies` for placement,
+	// so the LVM-aware scoring path MUST skip them entirely.
+	localPVCs := filterLocalLVMPVCs(managedPVCs, scUsedByPVCs)
 	replicatedPVCs := filterPVCsByProvisioner(managedPVCs, scUsedByPVCs, consts.SdsReplicatedVolumeProvisioner)
 
 	log.Debug(fmt.Sprintf("[scoreNodes] local PVCs count: %d, replicated PVCs count: %d", len(localPVCs), len(replicatedPVCs)))
@@ -386,8 +389,12 @@ func narrowReservationsToFinalNodes(
 	for _, pvc := range managedPVCs {
 		sc := scUsedByPVCs[*pvc.Spec.StorageClassName]
 
-		// Only narrow local PVCs (replicated use a different mechanism)
+		// Only narrow LVM-backed local PVCs (replicated use a different
+		// mechanism, and rawfile-backed local PVCs have no reservation).
 		if sc.Provisioner != consts.SdsLocalVolumeProvisioner {
+			continue
+		}
+		if isRawFileLocalSC(sc) {
 			continue
 		}
 

--- a/images/sds-common-scheduler-extender/pkg/scheduler/replicated.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/replicated.go
@@ -239,6 +239,35 @@ func filterPVCsByProvisioner(
 	return result
 }
 
+// filterLocalLVMPVCs returns the subset of PVCs whose StorageClass is the
+// local-volume provisioner AND is LVM-backed (i.e. NOT a rawfile-backed
+// LocalStorageClass). The LVM-aware filter/score/reservation paths only handle
+// LVM-backed local PVCs; rawfile-backed PVCs are passed through to the default
+// scheduler and constrained by `allowedTopologies` on their StorageClass.
+func filterLocalLVMPVCs(
+	pvcs map[string]*corev1.PersistentVolumeClaim,
+	scs map[string]*storagev1.StorageClass,
+) map[string]*corev1.PersistentVolumeClaim {
+	result := make(map[string]*corev1.PersistentVolumeClaim)
+	for name, pvc := range pvcs {
+		if pvc.Spec.StorageClassName == nil {
+			continue
+		}
+		sc, exists := scs[*pvc.Spec.StorageClassName]
+		if !exists {
+			continue
+		}
+		if sc.Provisioner != consts.SdsLocalVolumeProvisioner {
+			continue
+		}
+		if isRawFileLocalSC(sc) {
+			continue
+		}
+		result[name] = pvc
+	}
+	return result
+}
+
 func filterNodeForReplicatedPVCs(
 	ctx context.Context,
 	log logger.Logger,

--- a/images/sds-common-scheduler-extender/pkg/scheduler/replicated.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/replicated.go
@@ -243,6 +243,35 @@ func filterPVCsByProvisioner(
 	return result
 }
 
+// filterLocalLVMPVCs returns the subset of PVCs whose StorageClass is the
+// local-volume provisioner AND is LVM-backed (i.e. NOT a rawfile-backed
+// LocalStorageClass). The LVM-aware filter/score/reservation paths only handle
+// LVM-backed local PVCs; rawfile-backed PVCs are passed through to the default
+// scheduler and constrained by `allowedTopologies` on their StorageClass.
+func filterLocalLVMPVCs(
+	pvcs map[string]*corev1.PersistentVolumeClaim,
+	scs map[string]*storagev1.StorageClass,
+) map[string]*corev1.PersistentVolumeClaim {
+	result := make(map[string]*corev1.PersistentVolumeClaim)
+	for name, pvc := range pvcs {
+		if pvc.Spec.StorageClassName == nil {
+			continue
+		}
+		sc, exists := scs[*pvc.Spec.StorageClassName]
+		if !exists {
+			continue
+		}
+		if sc.Provisioner != consts.SdsLocalVolumeProvisioner {
+			continue
+		}
+		if isRawFileLocalSC(sc) {
+			continue
+		}
+		result[name] = pvc
+	}
+	return result
+}
+
 func filterNodeForReplicatedPVCs(
 	ctx context.Context,
 	log logger.Logger,


### PR DESCRIPTION
## Description

Teach `sds-common-scheduler-extender` to recognize and silently pass through PVCs whose StorageClass is a rawfile-backed `LocalStorageClass` (added by sds-local-volume [#157](https://github.com/deckhouse/sds-local-volume/pull/157)).

Detection uses the positive marker the LSC controller already sets on the generated StorageClass:

- `Provisioner == local.csi.storage.deckhouse.io`
- `Parameters["local.csi.storage.deckhouse.io/type"] == "rawfile"`

When matched, the extender:

- skips the PVC in `extractRequestedSize` (no LVM-aware size/device-type extraction);
- excludes it from the local-PVC set used by `filterNodes` / `scoreNodes` via a new `filterLocalLVMPVCs` helper;
- skips it in `createReservations` and `narrowReservationsToFinalNodes` (no LVMVolumeGroups to reserve space in).

LVM-backed local PVCs and replicated PVCs go through the existing code paths unchanged. The existing `TestFilter_FailedExtractSize_RejectsAllNodes` still passes — a local SC that is neither LVM (`lvm-type` set) nor rawfile (`type=rawfile` set) is still rejected as a misconfiguration.

This change does not influence ingress-controllers, control-plane components, Prometheus, or other critical cluster components — only the optional `sds-common-scheduler-extender` is affected.

## Why do we need it, and what problem does it solve?

PR [deckhouse/sds-local-volume#157](https://github.com/deckhouse/sds-local-volume/pull/157) adds rawfile (loop-device-backed) support to `LocalStorageClass`. The generated StorageClass shares the local-volume provisioner with LVM-backed ones, but exposes no `lvm-type` / `lvm-volume-groups` parameters.

Today's extender treats every SC with that provisioner as LVM-backed:

```go
deviceType = sc.Parameters[consts.LvmTypeParamKey]
if deviceType == "" {
    return nil, fmt.Errorf("[extractRequestedSize] unable to determine device type for PVC %s/%s", ...)
}
```

The error is then translated into a fail-all response by `filter`, so any Pod consuming a rawfile PVC stays Pending with:

```
0/N nodes are available: ... unable to extract request size:
[extractRequestedSize] unable to determine device type for PVC default/<pvc>.
```

This makes rawfile-backed `LocalStorageClass` unusable end-to-end: the controller in `sds-local-volume` already provisions the StorageClass correctly (including `allowedTopologies` for `rawFile.nodes`), but the scheduler extender blocks every Pod.

Node placement for rawfile PVCs does not need extender input — `allowedTopologies` on the StorageClass and `WaitForFirstConsumer` on the LSC are sufficient. The fix therefore short-circuits the LVM-only logic for these PVCs.

## What is the expected result?

After applying:

- A Pod consuming a PVC whose StorageClass was generated from a `LocalStorageClass` with `spec.rawFile` MUST be scheduled successfully (assuming `allowedTopologies` is satisfied), instead of failing with the message above.
- A Pod consuming a PVC from an LVM-backed `LocalStorageClass` MUST keep being filtered/scored exactly as before — LVG matching, free-space checks, and reservations stay intact (covered by existing tests).
- A Pod with a mix of LVM-backed and rawfile-backed local PVCs MUST be scheduled to the subset of nodes that satisfies the LVM PVC; the rawfile PVC contributes no constraints (covered by the new `TestFilter_MixedLocalLVMAndRawFile_LVMRulesApply`).
- A Pod with a misconfigured local SC (neither `lvm-type` nor `type=rawfile`) MUST keep being rejected with a clear failure reason on every node (existing `TestFilter_FailedExtractSize_RejectsAllNodes`).

How to verify in a cluster:

1. Apply a rawfile-backed `LocalStorageClass`:

    ```yaml
    apiVersion: storage.deckhouse.io/v1alpha1
    kind: LocalStorageClass
    metadata:
      name: rawfile-storage-class
    spec:
      rawFile:
        sparse: false
      reclaimPolicy: Delete
      volumeBindingMode: WaitForFirstConsumer
      fsType: ext4
    ```

2. Create a PVC + Pod using this StorageClass.
3. Before this fix the Pod stays Pending with the `unable to extract request size` event. After this fix the Pod is scheduled normally.
4. Verify that existing LVM-backed Pods continue to be scheduled with capacity-aware behavior (free-space rejection, reservations).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.