### PR TITLE
fix(scheduler-extender): tolerate PVCs whose StorageClass does not exist

### DIFF
--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
@@ -111,7 +111,11 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 	// actionable scheduling decision to make for them, so we skip these PVCs
 	// instead of failing the whole pod-scheduling request.
 	if dropped := dropPVCsWithMissingSC(managedPVCs, scUsedByPVCs); len(dropped) > 0 {
-		servingLog.Warning(fmt.Sprintf("dropping PVCs without an existing StorageClass from scheduling decision: %v", dropped))
+		allKeys, pendingKeys := formatDroppedPVCsForLog(dropped)
+		servingLog.Warning(fmt.Sprintf("dropping PVCs without an existing StorageClass from scheduling decision: %v", allKeys))
+		if len(pendingKeys) > 0 {
+			servingLog.Warning(fmt.Sprintf("Pending PVCs reference a missing StorageClass and will never be dynamically provisioned (the Pod will likely get stuck in ContainerCreating with FailedMount): %v", pendingKeys))
+		}
 	}
 	if len(managedPVCs) == 0 {
 		servingLog.Debug("After filtering out PVCs with missing StorageClass, no managed PVCs left. Return the same nodes")

--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
@@ -103,17 +103,23 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 		writeFailAllNodesResponse(w, servingLog, nodeNames, fmt.Sprintf("unable to get StorageClasses: %s", err))
 		return
 	}
-	for pvcName, pvc := range managedPVCs {
-		if pvc.Spec.StorageClassName == nil {
-			servingLog.Error(fmt.Errorf("PVC %s has no StorageClassName", pvcName), "unable to get StorageClass from PVC")
-			writeFailAllNodesResponse(w, servingLog, nodeNames, fmt.Sprintf("PVC %s has no StorageClassName", pvcName))
-			return
+
+	// Drop managed PVCs whose StorageClass is missing or unset. Such PVCs are
+	// valid in Kubernetes (e.g. statically provisioned PVs, PVs that survived
+	// the deletion of their StorageClass) and the upstream kube-scheduler does
+	// not require the SC object for already-bound PVCs. The extender has no
+	// actionable scheduling decision to make for them, so we skip these PVCs
+	// instead of failing the whole pod-scheduling request.
+	if dropped := dropPVCsWithMissingSC(managedPVCs, scUsedByPVCs); len(dropped) > 0 {
+		servingLog.Warning(fmt.Sprintf("dropping PVCs without an existing StorageClass from scheduling decision: %v", dropped))
+	}
+	if len(managedPVCs) == 0 {
+		servingLog.Debug("After filtering out PVCs with missing StorageClass, no managed PVCs left. Return the same nodes")
+		if err := writeNodeNamesResponse(w, servingLog, nodeNames); err != nil {
+			servingLog.Error(err, "unable to write node names response")
+			http.Error(w, "internal server error", http.StatusInternalServerError)
 		}
-		if _, found := scUsedByPVCs[*pvc.Spec.StorageClassName]; !found {
-			servingLog.Error(fmt.Errorf("StorageClass %s not found for PVC %s", *pvc.Spec.StorageClassName, pvcName), "unable to get StorageClass from PVC")
-			writeFailAllNodesResponse(w, servingLog, nodeNames, fmt.Sprintf("StorageClass %s not found for PVC %s", *pvc.Spec.StorageClassName, pvcName))
-			return
-		}
+		return
 	}
 
 	servingLog.Debug("starts to extract PVC requested sizes")

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert/yaml"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -379,7 +380,7 @@ func discoverProvisionerForPVC(
 			if discoveredProvisioner != "" {
 				return discoveredProvisioner, nil
 			}
-		case client.IgnoreNotFound(err) == nil:
+		case apierrors.IsNotFound(err):
 			log.Debug(fmt.Sprintf("[discoverProvisionerForPVC] StorageClass %s not found, falling back to PV-based provisioner discovery", *pvc.Spec.StorageClassName))
 		default:
 			return "", fmt.Errorf("[discoverProvisionerForPVC] error getting StorageClass %s: %v", *pvc.Spec.StorageClassName, err)
@@ -496,7 +497,7 @@ func getStorageClassesUsedByPVCs(ctx context.Context, cl client.Client, pvcs map
 	for scName := range uniqueSCNames {
 		sc := &storagev1.StorageClass{}
 		if err := cl.Get(ctx, client.ObjectKey{Name: scName}, sc); err != nil {
-			if client.IgnoreNotFound(err) == nil {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			return nil, fmt.Errorf("unable to get StorageClass %s: %w", scName, err)
@@ -509,8 +510,9 @@ func getStorageClassesUsedByPVCs(ctx context.Context, cl client.Client, pvcs map
 
 // dropPVCsWithMissingSC removes from managedPVCs all PVCs whose StorageClass is
 // not present in scs (either StorageClassName is empty/nil or the SC object does
-// not exist in the cluster). It returns the list of dropped PVC names so the
-// caller can log them.
+// not exist in the cluster). It returns the list of dropped PVCs so the caller
+// can log them and emit additional diagnostics (e.g. for Pending PVCs whose
+// volume can never be provisioned without an existing StorageClass).
 //
 // Removing such PVCs (instead of failing the whole pod-scheduling request) is the
 // behavior consistent with the upstream kube-scheduler VolumeBinding plugin:
@@ -519,20 +521,36 @@ func getStorageClassesUsedByPVCs(ctx context.Context, cl client.Client, pvcs map
 func dropPVCsWithMissingSC(
 	managedPVCs map[string]*corev1.PersistentVolumeClaim,
 	scs map[string]*storagev1.StorageClass,
-) []string {
-	var dropped []string
+) []*corev1.PersistentVolumeClaim {
+	var dropped []*corev1.PersistentVolumeClaim
 	for pvcName, pvc := range managedPVCs {
 		if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName == "" {
-			dropped = append(dropped, pvcName)
+			dropped = append(dropped, pvc)
 			delete(managedPVCs, pvcName)
 			continue
 		}
 		if _, ok := scs[*pvc.Spec.StorageClassName]; !ok {
-			dropped = append(dropped, pvcName)
+			dropped = append(dropped, pvc)
 			delete(managedPVCs, pvcName)
 		}
 	}
 	return dropped
+}
+
+// formatDroppedPVCsForLog returns a "namespace/name" list and a separate list of
+// Pending PVCs that reference a missing StorageClass — those will never be
+// dynamically provisioned and the resulting Pod will get stuck in
+// ContainerCreating with FailedMount, so the operator deserves a louder warning
+// than the generic "dropped from scheduling decision" message.
+func formatDroppedPVCsForLog(dropped []*corev1.PersistentVolumeClaim) (allKeys []string, pendingKeys []string) {
+	for _, pvc := range dropped {
+		key := pvc.Namespace + "/" + pvc.Name
+		allKeys = append(allKeys, key)
+		if pvc.Status.Phase == corev1.ClaimPending {
+			pendingKeys = append(pendingKeys, key)
+		}
+	}
+	return allKeys, pendingKeys
 }
 
 // getNewControlPlane checks whether the sds-replicated-volume module uses the new control plane

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -360,17 +360,29 @@ func discoverProvisionerForPVC(
 		return discoveredProvisioner, nil
 	}
 
-	// Get provisioner from StorageClass
+	// Get provisioner from StorageClass.
+	//
+	// Tolerate a missing StorageClass: in Kubernetes, storageClassName is a
+	// matching label between PV and PVC, not a hard reference, so PVs can
+	// legitimately reference a non-existent SC (statically provisioned PVs,
+	// PVs that survived their SC being deleted, SC migrations, etc.). In
+	// such cases we fall through to PV-based provisioner discovery instead
+	// of failing the whole scheduling request.
 	if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
 		log.Trace(fmt.Sprintf("[discoverProvisionerForPVC] can't find provisioner in pvc annotations, check in storageClass with name: %s", *pvc.Spec.StorageClassName))
 		storageClass := &storagev1.StorageClass{}
-		if err := cl.Get(ctx, client.ObjectKey{Name: *pvc.Spec.StorageClassName}, storageClass); err != nil {
+		err := cl.Get(ctx, client.ObjectKey{Name: *pvc.Spec.StorageClassName}, storageClass)
+		switch {
+		case err == nil:
+			discoveredProvisioner = storageClass.Provisioner
+			log.Trace(fmt.Sprintf("[discoverProvisionerForPVC] discover provisioner %s in storageClass: %+v", discoveredProvisioner, storageClass))
+			if discoveredProvisioner != "" {
+				return discoveredProvisioner, nil
+			}
+		case client.IgnoreNotFound(err) == nil:
+			log.Debug(fmt.Sprintf("[discoverProvisionerForPVC] StorageClass %s not found, falling back to PV-based provisioner discovery", *pvc.Spec.StorageClassName))
+		default:
 			return "", fmt.Errorf("[discoverProvisionerForPVC] error getting StorageClass %s: %v", *pvc.Spec.StorageClassName, err)
-		}
-		discoveredProvisioner = storageClass.Provisioner
-		log.Trace(fmt.Sprintf("[discoverProvisionerForPVC] discover provisioner %s in storageClass: %+v", discoveredProvisioner, storageClass))
-		if discoveredProvisioner != "" {
-			return discoveredProvisioner, nil
 		}
 	}
 
@@ -459,11 +471,23 @@ func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Log
 }
 
 // getStorageClassesUsedByPVCs fetches only the StorageClasses referenced by PVCs.
+//
+// It is intentionally tolerant towards PVCs without a StorageClassName and towards
+// references to non-existent StorageClass objects: in both cases the corresponding
+// entry is just absent from the returned map. Such PVCs represent statically
+// provisioned PersistentVolumes (or PVCs that survived their StorageClass being
+// removed/renamed) — both are valid scenarios per the Kubernetes API contract,
+// where storageClassName is a matching label rather than a hard reference to a
+// StorageClass object (see https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class).
+//
+// Callers should drop PVCs whose StorageClass is missing from the returned map
+// (e.g. via dropPVCsWithMissingSC) instead of failing the whole scheduling
+// request.
 func getStorageClassesUsedByPVCs(ctx context.Context, cl client.Client, pvcs map[string]*corev1.PersistentVolumeClaim) (map[string]*storagev1.StorageClass, error) {
 	uniqueSCNames := make(map[string]struct{}, len(pvcs))
 	for _, pvc := range pvcs {
-		if pvc.Spec.StorageClassName == nil {
-			return nil, fmt.Errorf("no StorageClass specified for PVC %s", pvc.Name)
+		if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName == "" {
+			continue
 		}
 		uniqueSCNames[*pvc.Spec.StorageClassName] = struct{}{}
 	}
@@ -481,6 +505,34 @@ func getStorageClassesUsedByPVCs(ctx context.Context, cl client.Client, pvcs map
 	}
 
 	return result, nil
+}
+
+// dropPVCsWithMissingSC removes from managedPVCs all PVCs whose StorageClass is
+// not present in scs (either StorageClassName is empty/nil or the SC object does
+// not exist in the cluster). It returns the list of dropped PVC names so the
+// caller can log them.
+//
+// Removing such PVCs (instead of failing the whole pod-scheduling request) is the
+// behavior consistent with the upstream kube-scheduler VolumeBinding plugin:
+// for bound PVCs it relies on the PV's nodeAffinity and never consults the
+// StorageClass, so a PV referencing a missing StorageClass schedules normally.
+func dropPVCsWithMissingSC(
+	managedPVCs map[string]*corev1.PersistentVolumeClaim,
+	scs map[string]*storagev1.StorageClass,
+) []string {
+	var dropped []string
+	for pvcName, pvc := range managedPVCs {
+		if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName == "" {
+			dropped = append(dropped, pvcName)
+			delete(managedPVCs, pvcName)
+			continue
+		}
+		if _, ok := scs[*pvc.Spec.StorageClassName]; !ok {
+			dropped = append(dropped, pvcName)
+			delete(managedPVCs, pvcName)
+		}
+	}
+	return dropped
 }
 
 // getNewControlPlane checks whether the sds-replicated-volume module uses the new control plane

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
@@ -395,7 +395,19 @@ func TestTwoPVCsSameStorageClass_Prioritize(t *testing.T) {
 	}
 }
 
-func TestFilter_MissingSC_RejectsAllNodes(t *testing.T) {
+// TestFilter_MissingSC_PassesAllNodes asserts the regression fix: when the only
+// managed PVC references a StorageClass that does not exist in the cluster
+// (typical for statically provisioned PVs, including hostPath-backed PVs and
+// PVs that survived their StorageClass being deleted), the extender must NOT
+// fail-all-nodes. Instead, it must drop the PVC from its scheduling decision
+// and return the input node list unchanged so that the upstream kube-scheduler
+// (which does not require the SC object for bound PVCs either) can schedule
+// the pod normally.
+//
+// See: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class
+// "A PV of a particular class can only be bound to PVCs requesting that class."
+// (storageClassName is a matching label, not a hard reference to a SC object).
+func TestFilter_MissingSC_PassesAllNodes(t *testing.T) {
 	scName := "non-existent-sc"
 	provisioner := consts.SdsLocalVolumeProvisioner
 
@@ -441,17 +453,235 @@ func TestFilter_MissingSC_RejectsAllNodes(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.filter(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code, "filter must return 200 so the scheduler does not ignore the response")
+	assert.Equal(t, http.StatusOK, w.Code, "filter must return 200")
 
 	var result ExtenderFilterResult
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
-	assert.Empty(t, *result.NodeNames, "filtered node list must be empty")
-	assert.Len(t, result.FailedNodes, 2, "all input nodes must be in FailedNodes")
-	for _, nodeName := range nodeNames {
-		reason, ok := result.FailedNodes[nodeName]
-		assert.True(t, ok, "node %s must be in FailedNodes", nodeName)
-		assert.Contains(t, reason, "StorageClass", "reason must mention StorageClass")
+	require.NotNil(t, result.NodeNames, "node list must be present in the response")
+	assert.ElementsMatch(t, nodeNames, *result.NodeNames, "all input nodes must be returned unchanged")
+	assert.Empty(t, result.FailedNodes, "no nodes must be reported as failed")
+}
+
+// TestPrioritize_MissingSC_PassesAllNodes mirrors TestFilter_MissingSC_PassesAllNodes
+// for the prioritize endpoint: a missing StorageClass must not cause the
+// extender to fail the request; instead, it should return all input nodes with
+// a neutral score so kube-scheduler can pick one.
+func TestPrioritize_MissingSC_PassesAllNodes(t *testing.T) {
+	scName := "non-existent-sc"
+	provisioner := consts.SdsLocalVolumeProvisioner
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"volume.beta.kubernetes.io/storage-provisioner": provisioner,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+		},
 	}
+
+	cl := newFakeClient(pvc)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{provisioner}
+
+	nodeNames := []string{"node1", "node2"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+
+	body, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/prioritize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.prioritize(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "prioritize must return 200")
+
+	var scores []HostPriority
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &scores))
+	gotNodes := make([]string, 0, len(scores))
+	for _, hp := range scores {
+		gotNodes = append(gotNodes, hp.Host)
+		assert.Equal(t, 0, hp.Score, "score for node %s must be 0 when there are no managed PVCs to score", hp.Host)
+	}
+	assert.ElementsMatch(t, nodeNames, gotNodes, "all input nodes must be scored")
+}
+
+// TestFilter_BoundStaticPV_NoSC verifies the realistic regression scenario:
+// the pod uses a managed PVC that is already bound to a statically provisioned
+// PV (via PVC annotation -> PV.Spec.CSI.Driver discovery); the storageClassName
+// references a StorageClass object that no longer exists in the cluster
+// (deleted, never created, or used as a static-binding marker).
+//
+// Expected: the extender returns the input nodes unchanged and lets upstream
+// kube-scheduler pick one based on the PV's nodeAffinity.
+func TestFilter_BoundStaticPV_NoSC(t *testing.T) {
+	scName := "manual"
+	provisioner := consts.SdsLocalVolumeProvisioner
+	pvName := "pv-static-1"
+
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: pvName},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       provisioner,
+					VolumeHandle: "vh-1",
+				},
+			},
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			StorageClassName: scName,
+		},
+	}
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			VolumeName:       pvName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+
+	cl := newFakeClient(pv, pvc)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{provisioner}
+
+	nodeNames := []string{"node1", "node2"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.NotNil(t, result.NodeNames)
+	assert.ElementsMatch(t, nodeNames, *result.NodeNames, "all input nodes must be returned for a statically bound PVC with no SC")
+	assert.Empty(t, result.FailedNodes)
+}
+
+// TestFilter_MixedManagedPVCs_OneMissingSC verifies that a missing SC for one
+// managed PVC must NOT prevent processing of other managed PVCs in the same
+// pod. The pod has two managed PVCs: pvc-bad (SC missing) is dropped, and
+// pvc-good (SC present, with a usable LVG) is processed normally.
+func TestFilter_MixedManagedPVCs_OneMissingSC(t *testing.T) {
+	scGood := "sc-good"
+	scBad := "sc-missing"
+	provisioner := consts.SdsLocalVolumeProvisioner
+
+	scGoodObj := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scGood},
+		Provisioner: provisioner,
+		Parameters: map[string]string{
+			consts.LvmTypeParamKey:         consts.Thick,
+			consts.LVMVolumeGroupsParamKey: "- name: lvg1\n",
+		},
+	}
+	pvcGood := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-good", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scGood,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+	pvcBad := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-bad",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"volume.beta.kubernetes.io/storage-provisioner": provisioner,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scBad,
+		},
+	}
+	hundredGiB := int64(100 * 1024 * 1024 * 1024)
+	lvg := readyLVGOnNode("lvg1", "node1", hundredGiB, hundredGiB)
+
+	cl := newFakeClient(scGoodObj, pvcGood, pvcBad, lvg)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{provisioner}
+
+	nodeNames := []string{"node1", "node2"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-good"},
+					}},
+					{Name: "v2", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-bad"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "filter must return 200")
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.NotNil(t, result.NodeNames)
+	// node1 hosts a usable LVG matching pvc-good's SC; node2 has no LVG and
+	// must be filtered out by the local-PVC checks. The missing-SC PVC must
+	// not cause node1 to be rejected.
+	assert.Contains(t, *result.NodeNames, "node1", "node1 with a matching LVG must remain")
+	assert.NotContains(t, *result.NodeNames, "node2", "node2 without any LVG must be filtered out by the local PVC")
 }
 
 func TestFilter_FailedExtractSize_RejectsAllNodes(t *testing.T) {

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
@@ -682,6 +682,207 @@ func TestFilter_MixedManagedPVCs_OneMissingSC(t *testing.T) {
 	// not cause node1 to be rejected.
 	assert.Contains(t, *result.NodeNames, "node1", "node1 with a matching LVG must remain")
 	assert.NotContains(t, *result.NodeNames, "node2", "node2 without any LVG must be filtered out by the local PVC")
+	// node2's failure reason must be the missing LVG, not the missing SC of the
+	// sibling PVC — otherwise dropPVCsWithMissingSC would have leaked into the
+	// per-node failure reasons.
+	if reason, ok := result.FailedNodes["node2"]; ok {
+		assert.NotContains(t, reason, "sc-missing", "node2 reason must not mention the dropped PVC's StorageClass")
+		assert.NotContains(t, reason, "pvc-bad", "node2 reason must not mention the dropped PVC")
+	}
+}
+
+// TestPrioritize_MixedManagedPVCs_OneMissingSC mirrors the filter-side test for
+// the prioritize endpoint: a PVC referencing a missing StorageClass must be
+// dropped from the scoring decision, but sibling PVCs whose StorageClass exists
+// must still produce sensible per-node scores.
+func TestPrioritize_MixedManagedPVCs_OneMissingSC(t *testing.T) {
+	scGood := "sc-good"
+	scBad := "sc-missing"
+	provisioner := consts.SdsLocalVolumeProvisioner
+
+	scGoodObj := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scGood},
+		Provisioner: provisioner,
+		Parameters: map[string]string{
+			consts.LvmTypeParamKey:         consts.Thick,
+			consts.LVMVolumeGroupsParamKey: "- name: lvg1\n",
+		},
+	}
+	pvcGood := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-good", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scGood,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+	pvcBad := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-bad",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"volume.beta.kubernetes.io/storage-provisioner": provisioner,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scBad,
+		},
+	}
+	hundredGiB := int64(100 * 1024 * 1024 * 1024)
+	lvg := readyLVGOnNode("lvg1", "node1", hundredGiB, hundredGiB)
+
+	cl := newFakeClient(scGoodObj, pvcGood, pvcBad, lvg)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{provisioner}
+
+	nodeNames := []string{"node1", "node2"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-good"},
+					}},
+					{Name: "v2", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-bad"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/prioritize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.prioritize(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "prioritize must return 200")
+
+	var scores []HostPriority
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &scores))
+	gotNodes := make([]string, 0, len(scores))
+	for _, hp := range scores {
+		gotNodes = append(gotNodes, hp.Host)
+	}
+	// Both nodes must be scored: prioritize never removes nodes (filter does),
+	// it only attaches priorities. The presence of pvc-bad with a missing SC
+	// must not abort the request.
+	assert.ElementsMatch(t, nodeNames, gotNodes, "prioritize must return a score for every input node")
+}
+
+// TestDropPVCsWithMissingSC exercises the helper directly with the four cases
+// it has to handle: (a) PVC with nil StorageClassName; (b) PVC with empty
+// StorageClassName; (c) PVC referencing a non-existent SC; (d) PVC whose SC
+// exists. Only (d) must remain in the input map. The pointer identity of the
+// dropped entries must match the inputs (the helper returns the original PVC
+// objects, not copies, so callers can inspect their phase, namespace, etc.).
+func TestDropPVCsWithMissingSC(t *testing.T) {
+	scExisting := "sc-existing"
+	scMissing := "sc-missing"
+	emptySC := ""
+
+	pvcNilSC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-nil-sc", Namespace: "ns1"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: nil},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+	pvcEmptySC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-empty-sc", Namespace: "ns1"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &emptySC},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+	pvcMissingSC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-missing-sc", Namespace: "ns1"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &scMissing},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+	pvcGood := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-good", Namespace: "ns1"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &scExisting},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+
+	managed := map[string]*corev1.PersistentVolumeClaim{
+		"pvc-nil-sc":     pvcNilSC,
+		"pvc-empty-sc":   pvcEmptySC,
+		"pvc-missing-sc": pvcMissingSC,
+		"pvc-good":       pvcGood,
+	}
+	scs := map[string]*storagev1.StorageClass{
+		scExisting: {ObjectMeta: metav1.ObjectMeta{Name: scExisting}},
+	}
+
+	dropped := dropPVCsWithMissingSC(managed, scs)
+
+	require.Len(t, managed, 1, "only the PVC with an existing SC must remain in the input map")
+	assert.Same(t, pvcGood, managed["pvc-good"], "pvc-good must remain (by pointer identity)")
+
+	require.Len(t, dropped, 3, "exactly three PVCs must be dropped")
+	droppedNames := make([]string, 0, len(dropped))
+	for _, p := range dropped {
+		droppedNames = append(droppedNames, p.Name)
+	}
+	assert.ElementsMatch(t,
+		[]string{"pvc-nil-sc", "pvc-empty-sc", "pvc-missing-sc"},
+		droppedNames,
+		"dropped set must contain nil-SC, empty-SC and missing-SC PVCs",
+	)
+
+	// The helper must hand back the original PVC objects (not copies) so the
+	// caller can read namespace/phase for richer diagnostics.
+	for _, p := range dropped {
+		assert.Equal(t, "ns1", p.Namespace, "namespace must be preserved on dropped PVCs")
+	}
+
+	allKeys, pendingKeys := formatDroppedPVCsForLog(dropped)
+	assert.ElementsMatch(t,
+		[]string{"ns1/pvc-nil-sc", "ns1/pvc-empty-sc", "ns1/pvc-missing-sc"},
+		allKeys,
+		"formatDroppedPVCsForLog must produce namespace/name keys for every dropped PVC",
+	)
+	assert.ElementsMatch(t,
+		[]string{"ns1/pvc-nil-sc", "ns1/pvc-missing-sc"},
+		pendingKeys,
+		"only Pending PVCs (here: nil-SC and missing-SC) must appear in the pending-keys subset",
+	)
+}
+
+// TestDropPVCsWithMissingSC_NoOp asserts that when every managed PVC already
+// has an existing StorageClass the helper is a no-op: nothing is removed and
+// the returned slice is empty.
+func TestDropPVCsWithMissingSC_NoOp(t *testing.T) {
+	scA := "sc-a"
+	scB := "sc-b"
+
+	pvcA := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-a", Namespace: "ns1"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &scA},
+	}
+	pvcB := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-b", Namespace: "ns1"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &scB},
+	}
+
+	managed := map[string]*corev1.PersistentVolumeClaim{
+		"pvc-a": pvcA,
+		"pvc-b": pvcB,
+	}
+	scs := map[string]*storagev1.StorageClass{
+		scA: {ObjectMeta: metav1.ObjectMeta{Name: scA}},
+		scB: {ObjectMeta: metav1.ObjectMeta{Name: scB}},
+	}
+
+	dropped := dropPVCsWithMissingSC(managed, scs)
+	assert.Empty(t, dropped, "no PVCs must be dropped when every SC exists")
+	assert.Len(t, managed, 2, "input map must be unchanged")
 }
 
 func TestFilter_FailedExtractSize_RejectsAllNodes(t *testing.T) {

--- a/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
@@ -97,7 +97,11 @@ func (s *scheduler) prioritize(w http.ResponseWriter, r *http.Request) {
 	// object for bound PVCs, and refusing to score for the whole pod when one
 	// PVC's SC is gone would break statically provisioned PVs and SC migrations.
 	if dropped := dropPVCsWithMissingSC(managedPVCs, scUsedByPVCs); len(dropped) > 0 {
-		servingLog.Warning(fmt.Sprintf("dropping PVCs without an existing StorageClass from prioritize decision: %v", dropped))
+		allKeys, pendingKeys := formatDroppedPVCsForLog(dropped)
+		servingLog.Warning(fmt.Sprintf("dropping PVCs without an existing StorageClass from prioritize decision: %v", allKeys))
+		if len(pendingKeys) > 0 {
+			servingLog.Warning(fmt.Sprintf("Pending PVCs reference a missing StorageClass and will never be dynamically provisioned (the Pod will likely get stuck in ContainerCreating with FailedMount): %v", pendingKeys))
+		}
 	}
 	if len(managedPVCs) == 0 {
 		servingLog.Debug("After filtering out PVCs with missing StorageClass, no managed PVCs left. Return the same nodes with 0 score")

--- a/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
@@ -91,17 +91,21 @@ func (s *scheduler) prioritize(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
-	for pvcName, pvc := range managedPVCs {
-		if pvc.Spec.StorageClassName == nil {
-			servingLog.Error(fmt.Errorf("PVC %s has no StorageClassName", pvcName), "unable to get StorageClass from PVC")
+
+	// Drop managed PVCs whose StorageClass is missing or unset. See filter.go
+	// for the rationale: the upstream kube-scheduler does not require the SC
+	// object for bound PVCs, and refusing to score for the whole pod when one
+	// PVC's SC is gone would break statically provisioned PVs and SC migrations.
+	if dropped := dropPVCsWithMissingSC(managedPVCs, scUsedByPVCs); len(dropped) > 0 {
+		servingLog.Warning(fmt.Sprintf("dropping PVCs without an existing StorageClass from prioritize decision: %v", dropped))
+	}
+	if len(managedPVCs) == 0 {
+		servingLog.Debug("After filtering out PVCs with missing StorageClass, no managed PVCs left. Return the same nodes with 0 score")
+		if err := writeNodeScoresResponse(w, servingLog, nodeNames, 0); err != nil {
+			servingLog.Error(err, "unable to write node scores response")
 			http.Error(w, "internal server error", http.StatusInternalServerError)
-			return
 		}
-		if _, found := scUsedByPVCs[*pvc.Spec.StorageClassName]; !found {
-			servingLog.Error(fmt.Errorf("StorageClass %s not found for PVC %s", *pvc.Spec.StorageClassName, pvcName), "unable to get StorageClass from PVC")
-			http.Error(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
+		return
 	}
 
 	servingLog.Debug("starts to extract PVC requested sizes")


### PR DESCRIPTION
## Description

Fix a regression in `sds-common-scheduler-extender` where the extender refused to schedule the entire pod (returning `FailedNodes` for every input node, or HTTP 500 in the prioritize endpoint) whenever a managed PVC referenced a `StorageClass` that did not exist in the cluster (or had `storageClassName` unset).

The extender now drops such PVCs from its scheduling decision instead of failing the whole request:

- `discoverProvisionerForPVC` now treats a `NotFound` `StorageClass` as a fall-through to PV-based provisioner discovery rather than a hard error.
- `getStorageClassesUsedByPVCs` is uniformly tolerant: PVCs with `nil`/empty `StorageClassName` and references to non-existent SC objects are simply absent from the returned map.
- A new helper `dropPVCsWithMissingSC` removes such PVCs from the managed set; both `filter.go` and `prioritize.go` use it. If no managed PVCs remain after the drop, the extender returns the input nodes (or a neutral score) so kube-scheduler can proceed normally.

This change does not affect critical cluster components (no restarts of ingress-controller/control-plane/Prometheus). Only the `sds-common-scheduler-extender` Deployment is affected.

## Why do we need it, and what problem does it solve?

We were rejecting pod scheduling for combinations that the Kubernetes API explicitly considers valid:

- **Statically provisioned PVs** (e.g. `hostPath`/`local` PVs created by an admin, manually preallocated LVM PVs, imported legacy volumes) — the canonical Kubernetes tutorial uses `storageClassName: manual` with no `StorageClass` named `manual` in the cluster.
- **PVs that survived the deletion of their StorageClass** — `reclaimPolicy: Retain` plus PV reuse, SC migrations, SC renames.
- Scenarios where the extender's [`discoverProvisionerForPVC`](images/sds-common-scheduler-extender/pkg/scheduler/func.go) discovers the provisioner via PV annotations or `pv.Spec.CSI.Driver` (already supported) but the SC object it would have looked up next does not exist.

The Kubernetes documentation is explicit:

> *A PV of a particular class can only be bound to PVCs requesting that class. A PV with no `storageClassName` has no class and can only be bound to PVCs that request no particular class.*
> — https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class

`storageClassName` is a matching label between PV and PVC, not a hard reference to a `StorageClass` object. The upstream `kube-scheduler` `VolumeBinding` plugin reflects this: for **bound** PVCs it only checks the PV's `nodeAffinity` and never consults the `StorageClass` (see [pkg/scheduler/framework/plugins/volumebinding/volume_binding.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go)). Our extender being stricter than upstream broke pods that the rest of Kubernetes considers schedulable.

**User-visible impact of the bug:** pods stuck `Pending` with `FailedScheduling` events naming the extender, even though the PV is bound and `kube-scheduler` would otherwise schedule them.

## What is the expected result?

After applying:

- A pod whose **only** managed PVC references a non-existent `StorageClass` is scheduled normally (the extender returns the input node list unchanged, score 0).
- A pod with **multiple** managed PVCs where one references a non-existent `StorageClass` is scheduled based on the remaining managed PVCs; the missing-SC PVC is dropped from the decision and only logged as a warning.
- A pod whose managed PVC is bound to a statically provisioned PV (with `pv.Spec.CSI.Driver` matching a target provisioner) and whose `storageClassName` references a non-existent SC is scheduled normally.
- The previous valid behavior is unchanged: PVCs whose SC exists are filtered/scored exactly as before; non-managed PVCs continue to be ignored; capacity checks for managed PVCs with an existing SC continue to fail nodes that lack capacity.

How to verify manually in a cluster:

1. Create a `PersistentVolume` with `spec.csi.driver: local.csi.storage.deckhouse.io` (or any provisioner listed in `TARGET_PROVISIONERS`), `storageClassName: manual-static`, and matching `nodeAffinity`.
2. Create a `PersistentVolumeClaim` with `storageClassName: manual-static` and `volumeName` equal to the PV name. Do **not** create a `StorageClass` named `manual-static`.
3. Schedule a pod consuming that PVC. Before this change the extender would log `StorageClass manual-static not found for PVC ...` and the pod would stay `Pending`. After the change the pod is scheduled to the node selected by the PV's `nodeAffinity`.
4. Check the extender logs — instead of an `Error`, you'll see one `Warning`: `dropping PVCs without an existing StorageClass from scheduling decision: [default/<pvc>]` (PVCs are reported in `namespace/name` form).

## Review follow-ups (commit `0b3acfe`)

Addressing the self-review on top of the original `7fb2107`:

- **Louder diagnostics for Pending PVCs.** A `Pending` PVC with a missing `StorageClass` will never be dynamically provisioned, so the Pod scheduled by the relaxed extender will get stuck in `ContainerCreating` with `FailedMount`. The extender now emits an additional `Warning` for that subset:
  > `Pending PVCs reference a missing StorageClass and will never be dynamically provisioned (the Pod will likely get stuck in ContainerCreating with FailedMount): [default/<pvc>]`

  This points the operator at the real root cause rather than at downstream `FailedMount` events. Bound PVCs (the canonical static-PV case) keep the single, milder warning.
- **`dropPVCsWithMissingSC` returns `[]*corev1.PersistentVolumeClaim`** instead of bare names, so callers can read `Namespace`/`Phase` for richer logging without re-walking the input map. A new helper `formatDroppedPVCsForLog` produces the `namespace/name` keys and the Pending subset; both `filter.go` and `prioritize.go` use it.
- **`apierrors.IsNotFound(err)`** instead of the inverted `client.IgnoreNotFound(err) == nil` idiom in `discoverProvisionerForPVC` and `getStorageClassesUsedByPVCs` (readability only).
- **Test coverage:**
  - `TestPrioritize_MixedManagedPVCs_OneMissingSC` — mirror of the filter-side mixed-PVC test for the `/prioritize` endpoint, so a regression that breaks scoring (but keeps filter intact) is caught.
  - `TestDropPVCsWithMissingSC` — direct unit test for the helper covering nil `StorageClassName`, empty `StorageClassName`, missing SC object, and the existing-SC happy case; also asserts that `formatDroppedPVCsForLog` produces `namespace/name` keys and a correct Pending subset.
  - `TestDropPVCsWithMissingSC_NoOp` — when every managed PVC has an existing SC the helper is a no-op and the input map is left untouched.
  - `TestFilter_MixedManagedPVCs_OneMissingSC` extended: assert that the per-node failure reason for the LVG-less node does **not** mention the dropped PVC or its missing SC, so a regression that leaks the missing-SC PVC into per-node failure reasons is caught.

No on-the-wire behavior change vs. `7fb2107` — only logging and tests.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

> Note: documentation does not require changes — the existing docs do not promise that a `StorageClass` must exist for an arbitrary `storageClassName` reference (and the Kubernetes API explicitly does not require this). The fix simply aligns the extender with the Kubernetes contract.
