### PR TITLE
feat(e2e): add env-based config loader with validation

### DIFF
--- a/e2e/cfg/config.go
+++ b/e2e/cfg/config.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cfg
+
+import (
+	"github.com/caarlos0/env/v11"
+)
+
+type Config struct {
+	TestCluster    TestCluster `envPrefix:"TEST_CLUSTER_"`
+	SSH            SSH         `envPrefix:"SSH_"`
+	KubeConfigPath string      `env:"KUBE_CONFIG_PATH,required"`
+	DKPLicenceKey  string      `env:"DKP_LICENSE_KEY"`
+	LogLevel       string      `env:"LOG_LEVEL" envDefault:"info"`
+}
+
+type TestCluster struct {
+	CreateMode   CreateMode `env:"CREATE_MODE,required"`
+	Namespace    string     `env:"NAMESPACE" envDefault:"e2e-test-cluster"`
+	StorageClass string     `env:"STORAGE_CLASS,required"`
+	Cleanup      bool       `env:"CLEANUP" envDefault:"false"`
+}
+
+type SSH struct {
+	User       string `env:"USER,required"`
+	Host       string `env:"HOST,required"`
+	JumpHost   string `env:"JUMP_HOST"`
+	JumpUser   string `env:"JUMP_USER"`
+	PrivateKey string `env:"PRIVATE_KEY,required"`
+}
+
+var cfg Config
+
+func New() (*Config, error) {
+	if err := env.Parse(&cfg); err != nil {
+		return nil, err
+	}
+
+	vErr := validate()
+	if vErr != nil {
+		return nil, vErr
+	}
+
+	return &cfg, nil
+}
+
+func Load() *Config {
+	return &cfg
+}

--- a/e2e/cfg/config_test.go
+++ b/e2e/cfg/config_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cfg
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewModeCreateNew(t *testing.T) {
+	err := os.Setenv("TEST_CLUSTER_CREATE_MODE", ModeCreateNew)
+	assert.NoError(t, err, "Failed to set env TEST_CLUSTER_CREATE_MODE")
+
+	err = os.Setenv("TEST_CLUSTER_STORAGE_CLASS", "linstor-r1")
+	assert.NoError(t, err, "Failed to set env TEST_CLUSTER_STORAGE_CLASS")
+
+	err = os.Setenv("SSH_USER", "test")
+	assert.NoError(t, err, "Failed to set env SSH_USER")
+
+	err = os.Setenv("SSH_HOST", "localhost")
+	assert.NoError(t, err, "Failed to set env SSH_HOST")
+
+	err = os.Setenv("SSH_PRIVATE_KEY", "test-key")
+	assert.NoError(t, err, "Failed to set env SSH_PRIVATE_KEY")
+
+	err = os.Setenv("KUBE_CONFIG_PATH", "/path/to/kubeconfig")
+	assert.NoError(t, err, "Failed to set env KUBE_CONFIG_PATH")
+
+	err = os.Setenv("DKP_LICENSE_KEY", "test-key")
+	assert.NoError(t, err, "Failed to set env DKP_LICENSE_KEY")
+
+	got, err := New()
+	assert.NoError(t, err)
+	assert.Equal(t, &Config{
+		TestCluster: TestCluster{
+			CreateMode:   ModeCreateNew,
+			Namespace:    "e2e-test-cluster",
+			StorageClass: "linstor-r1",
+			Cleanup:      false,
+		},
+		SSH: SSH{
+			User:       "test",
+			Host:       "localhost",
+			PrivateKey: "test-key",
+		},
+		KubeConfigPath: "/path/to/kubeconfig",
+		DKPLicenceKey:  "test-key",
+		LogLevel:       "info",
+	}, got)
+}

--- a/e2e/cfg/mode.go
+++ b/e2e/cfg/mode.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cfg
+
+import "fmt"
+
+type CreateMode string
+
+const (
+	ModeCreateNew   = "alwaysCreateNew"
+	ModeUseExisting = "alwaysUseExisting"
+)
+
+func (m *CreateMode) UnmarshalText(text []byte) error {
+	v := CreateMode(text)
+	switch v {
+	case ModeCreateNew, ModeUseExisting:
+		*m = v
+		return nil
+	default:
+		return fmt.Errorf("invalid MODE: %q (allowed: alwaysCreateNew, alwaysUseExisting)", text)
+	}
+}

--- a/e2e/cfg/validation.go
+++ b/e2e/cfg/validation.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cfg
+
+import "fmt"
+
+func validate() error {
+	if cfg.TestCluster.CreateMode == ModeCreateNew && cfg.DKPLicenceKey == "" {
+		return fmt.Errorf("if create mode is set, DKP_LICENSE_KEY required")
+	}
+	return nil
+}

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -3,11 +3,13 @@ module github.com/deckhouse/sds-node-configurator/e2e
 go 1.25.7
 
 require (
+	github.com/caarlos0/env/v11 v11.4.1
 	github.com/deckhouse/sds-node-configurator/api v0.0.0-20260114125558-7fd7152586ff
 	github.com/deckhouse/storage-e2e v0.0.0-20260303112441-16b274872c5f
 	github.com/deckhouse/virtualization/api v1.0.0
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.37.0
+	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
@@ -43,7 +45,8 @@ require (
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.10 // indirect
-	github.com/spf13/pflag v1.0.7 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -8,6 +8,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
+github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -186,8 +188,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
-github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/e2e/tests/sds_node_configurator_suite_test.go
+++ b/e2e/tests/sds_node_configurator_suite_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package tests
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	e2ecfg "github.com/deckhouse/sds-node-configurator/e2e/cfg"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -29,6 +30,9 @@ import (
 var _ = BeforeSuite(func() {
 	err := setup.Init()
 	Expect(err).NotTo(HaveOccurred(), "Failed to initialize storage-e2e setup")
+
+	_, cfgErr := e2ecfg.New()
+	Expect(cfgErr).NotTo(HaveOccurred(), "Failed to load config")
 	// Before any spec: Ginkgo may shuffle root Ordered Describes; nested cluster must exist first.
 	e2eEnsureSharedNestedTestCluster()
 })


### PR DESCRIPTION
## Summary

This PR introduces centralized E2E configuration loading from environment variables.

### What changed

- Added new `e2e/cfg` package with typed config structures:
  - `Config` (root)
  - `TestCluster`
  - `SSH`
- Implemented env parsing via `github.com/caarlos0/env/v11`.
- Added `CreateMode` enum with strict values:
  - `alwaysCreateNew`
  - `alwaysUseExisting`
- Added config validation:
  - `DKP_LICENSE_KEY` is required when `TEST_CLUSTER_CREATE_MODE=alwaysCreateNew`.
- Added unit test for config loading/defaults in `e2e/cfg/config_test.go`.
- Wired config initialization into E2E `BeforeSuite` to fail fast on invalid/missing env values.
- Updated `e2e/go.mod` and `e2e/go.sum` with new dependencies.

## Why

Configuration handling in E2E was scattered and weakly validated.  
This change centralizes config, makes it type-safe, and surfaces misconfiguration early at suite startup.

## Test plan

- `go test ./e2e/cfg`
- Run E2E with both modes:
  - `TEST_CLUSTER_CREATE_MODE=alwaysCreateNew` (with `DKP_LICENSE_KEY`)
  - `TEST_CLUSTER_CREATE_MODE=alwaysUseExisting`
- Verify suite fails early with clear error if required env vars are missing/invalid.