### PR TITLE
E2E Test for Block Device Stability

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -439,7 +439,7 @@ jobs:
             done
             shopt -u nullglob
           fi
-          go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' 2>&1 | tee ../e2e-test-output.log
+          go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.focus='BlockDeviceStable' 2>&1 | tee ../e2e-test-output.log
           TEST_EXIT_CODE=${PIPESTATUS[0]}
           echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
           echo "${TEST_EXIT_CODE}" > ../e2e-test-exit-code.txt

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -439,7 +439,7 @@ jobs:
             done
             shopt -u nullglob
           fi
-          go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.focus='Block device stability with explicit lifecycle stages' 2>&1 | tee ../e2e-test-output.log
+          go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' 2>&1 | tee ../e2e-test-output.log
           TEST_EXIT_CODE=${PIPESTATUS[0]}
           echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
           echo "${TEST_EXIT_CODE}" > ../e2e-test-exit-code.txt

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -439,7 +439,7 @@ jobs:
             done
             shopt -u nullglob
           fi
-          go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.focus='BlockDeviceStable' 2>&1 | tee ../e2e-test-output.log
+          go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.focus='Block device stability with explicit lifecycle stages' 2>&1 | tee ../e2e-test-output.log
           TEST_EXIT_CODE=${PIPESTATUS[0]}
           echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
           echo "${TEST_EXIT_CODE}" > ../e2e-test-exit-code.txt

--- a/e2e/cfg/config.go
+++ b/e2e/cfg/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	DKPLicenceKey     string      `env:"DKP_LICENSE_KEY"`
 	LogLevel          string      `env:"LOG_LEVEL" envDefault:"info"`
 	YamlClusterConfig string      `env:"YAML_CONFIG_FILENAME" envDefault:"cluster_config.yml"`
+	ModulesImageTag   string      `env:"MODULES_MODULE_TAG,required"`
 }
 
 type TestCluster struct {

--- a/e2e/cfg/config.go
+++ b/e2e/cfg/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	DKPLicenceKey     string      `env:"DKP_LICENSE_KEY"`
 	LogLevel          string      `env:"LOG_LEVEL" envDefault:"info"`
 	YamlClusterConfig string      `env:"YAML_CONFIG_FILENAME" envDefault:"cluster_config.yml"`
-	ModulesImageTag   string      `env:"MODULES_MODULE_TAG,required"`
+	ModulesImageTag   string      `env:"MODULES_MODULE_TAG,required" envDefault:"main"`
 }
 
 type TestCluster struct {

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/deckhouse/sds-node-configurator/api v0.0.0-20260114125558-7fd7152586ff
-	github.com/deckhouse/storage-e2e v0.0.0-20260507080012-c7702ad03b8a
+	github.com/deckhouse/storage-e2e v0.0.0-20260514131150-0190e0b5acf6
 	github.com/deckhouse/virtualization/api v1.8.0
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.37.0

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -24,8 +24,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckhouse/deckhouse v1.74.0 h1:a/gEuLKutoV6ReWaBWMDJ+VLlOkkCwS4VMvR/sHQscw=
 github.com/deckhouse/deckhouse v1.74.0/go.mod h1:qMuvDbP8AYghXkWmDjoFPc6r1w9uw/cWxl/hmvA0BzA=
-github.com/deckhouse/storage-e2e v0.0.0-20260507080012-c7702ad03b8a h1:kUhUIHG5gcdJaHJlb2Lhh6EFOteroBHRiFwb6kWbWU8=
-github.com/deckhouse/storage-e2e v0.0.0-20260507080012-c7702ad03b8a/go.mod h1:XZNxsSGcxa4G2hXCN8x3YWD2FRiDmBntGP2RulfY+6s=
+github.com/deckhouse/storage-e2e v0.0.0-20260514074746-0c9390535d62 h1:dMx0qcsb1O3/VD8nT/rymskCtpGR4OnCqL+yMvlGGII=
+github.com/deckhouse/storage-e2e v0.0.0-20260514074746-0c9390535d62/go.mod h1:XZNxsSGcxa4G2hXCN8x3YWD2FRiDmBntGP2RulfY+6s=
+github.com/deckhouse/storage-e2e v0.0.0-20260514131150-0190e0b5acf6 h1:pdJevPMH/FVgAg1lixYE0uuMe8OIT93oRQsxTTTtjUc=
+github.com/deckhouse/storage-e2e v0.0.0-20260514131150-0190e0b5acf6/go.mod h1:XZNxsSGcxa4G2hXCN8x3YWD2FRiDmBntGP2RulfY+6s=
 github.com/deckhouse/virtualization/api v1.8.0 h1:wR4Ivcg56OWJRGWrZjEL+0mQrHFEG0gKn0xrq1yzjy0=
 github.com/deckhouse/virtualization/api v1.8.0/go.mod h1:jqKdfrs7bhU5kbn6JTJUix8N180UkugJIa3TnOTqdmA=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,6 +46,9 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 		targetVM                    string
 		initialBlockDevice          kubernetes.BlockDevice
 		virtualDiskAttachmentResult *kubernetes.VirtualDiskAttachmentResult
+
+		mpoGVR schema.GroupVersionResource
+		dyn    dynamic.Interface
 	)
 
 	BeforeAll(func() {
@@ -83,25 +87,15 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 
 		virtualDiskAttachmentResult = attachResult
 
-		if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
-			By("Reading ModulePullOverride spec for debug output in pull_request runs")
-			dyn, err := kubernetes.NewDynamicClientWithRetry(ctx, res.Kubeconfig)
-			Expect(err).NotTo(HaveOccurred())
-
-			mpoGVR := schema.GroupVersionResource{
-				Group:    "deckhouse.io",
-				Version:  "v1alpha2",
-				Resource: "modulepulloverrides",
-			}
-
-			mpo, err := dyn.Resource(mpoGVR).Get(ctx, "sds-node-configurator", metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			spec, found, err := unstructured.NestedMap(mpo.Object, "spec")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(BeTrue())
-			GinkgoWriter.Printf("ImageTag: %s", spec["imageTag"])
+		By("Preparing GVR and K8s dynamic clients")
+		mpoGVR = schema.GroupVersionResource{
+			Group:    "deckhouse.io",
+			Version:  "v1alpha2",
+			Resource: "modulepulloverrides",
 		}
+		var dynErr error
+		dyn, dynErr = kubernetes.NewDynamicClientWithRetry(ctx, res.Kubeconfig)
+		Expect(dynErr).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func() {
@@ -179,7 +173,7 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 							ctx,
 							&v1.Pod{},
 							client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
-							client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
+							client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentName},
 							client.MatchingFields{"spec.nodeName": targetVM},
 						)
 						Expect(err).NotTo(HaveOccurred())
@@ -191,7 +185,7 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 								ctx,
 								&pods,
 								client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
-								client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
+								client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentName},
 								client.MatchingFields{"spec.nodeName": targetVM},
 							)).To(Succeed())
 
@@ -211,6 +205,47 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 						Expect(blockDevices).To(HaveLen(1))
 						Expect(blockDevices[0]).To(Equal(initialBlockDevice))
 					})
+				})
+			})
+
+			When("running in pull_request and agent is updated to PR version", func() {
+				BeforeAll(func() {
+					if os.Getenv("GITHUB_EVENT_NAME") != "pull_request" {
+						Skip("PR-only scenario")
+					}
+
+					mpo, err := dyn.Resource(mpoGVR).Get(ctx, consts.SdsNodeConfiguratorAgentName, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = unstructured.SetNestedField(mpo.Object, conf.ModulesImageTag, "spec", "imageTag")
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = dyn.Resource(mpoGVR).Update(ctx, mpo, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubernetes.WaitForModuleReady(ctx, res.Kubeconfig, consts.SdsNodeConfiguratorAgentName, 10*time.Minute)).To(Succeed())
+				})
+
+				It("has the same consumable block device", func() {
+					By("Checking that consumable BlockDevice name remains unchanged after agent update")
+					Expect(initialBlockDevice.Name).NotTo(BeEmpty())
+					Eventually(func(g Gomega) {
+						blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
+						g.Expect(getBDErr).NotTo(HaveOccurred())
+						g.Expect(blockDevices).To(HaveLen(1))
+						g.Expect(blockDevices[0].Name).To(Equal(initialBlockDevice.Name))
+					}, 5*time.Minute, 5*time.Second).Should(Succeed())
+				})
+
+				AfterAll(func() {
+					mpo, err := dyn.Resource(mpoGVR).Get(ctx, consts.SdsNodeConfiguratorAgentName, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = unstructured.SetNestedField(mpo.Object, "main", "spec", "imageTag")
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = dyn.Resource(mpoGVR).Update(ctx, mpo, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tests
+
+import (
+	"context"
+	"os"
+	"slices"
+	"time"
+
+	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
+	"github.com/deckhouse/sds-node-configurator/e2e/tests/utils/consts"
+	"github.com/deckhouse/storage-e2e/pkg/cluster"
+	"github.com/deckhouse/storage-e2e/pkg/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("BlockDeviceStable", Ordered, func() {
+	var (
+		ctx       context.Context
+		res       *cluster.TestClusterResources
+		conf      *cfg.Config
+		k8sClient client.Client
+
+		targetVM                    string
+		virtualDiskAttachmentResult *kubernetes.VirtualDiskAttachmentResult
+	)
+
+	BeforeAll(func() {
+		By("Run before all")
+		ctx = context.Background()
+		res = e2eNestedTestClusterOrNil()
+		Expect(res).NotTo(BeNil())
+		conf = cfg.Load()
+		Expect(conf).ToNot(BeNil())
+		ensureE2EK8sClient(res, &k8sClient, ctx)
+		Expect(k8sClient).NotTo(BeNil())
+
+		By("Creating virtualization client")
+		virtClient, createVirtClientError := kubernetes.NewVirtualizationClient(ctx, res.BaseKubeconfig)
+		Expect(createVirtClientError).NotTo(HaveOccurred())
+		Expect(virtClient).NotTo(BeNil())
+
+		By("Listing virtual machines to select target VM")
+		vms, listVmErr := kubernetes.ListVirtualMachineNames(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace)
+		Expect(listVmErr).NotTo(HaveOccurred())
+		slices.Sort(vms)
+		targetVM = vms[0]
+
+		By("Creating virtual disk attachment")
+		attachResult, attachErr := kubernetes.AttachVirtualDiskToVM(ctx, res.BaseKubeconfig,
+			kubernetes.VirtualDiskAttachmentConfig{
+				VMName:           targetVM,
+				Namespace:        conf.TestCluster.Namespace,
+				DiskName:         "block-device-stable",
+				DiskSize:         "5Gi",
+				StorageClassName: conf.TestCluster.StorageClass,
+			})
+		Expect(attachErr).NotTo(HaveOccurred())
+		Expect(attachResult).NotTo(BeNil())
+
+		By("Waiting for virtual disk attachment to become ready")
+		attachWaitErr := kubernetes.WaitForVirtualDiskAttached(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
+			attachResult.AttachmentName, 5*time.Second)
+		Expect(attachWaitErr).NotTo(HaveOccurred())
+
+		virtualDiskAttachmentResult = attachResult
+	})
+
+	AfterAll(func() {
+		if virtualDiskAttachmentResult != nil {
+			By("Deleting virtual disk attachment and virtual disk")
+			deleteVDErr := kubernetes.DetachAndDeleteVirtualDisk(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
+				virtualDiskAttachmentResult.AttachmentName, virtualDiskAttachmentResult.DiskName)
+			if deleteVDErr != nil {
+				GinkgoWriter.Println(deleteVDErr)
+			}
+		}
+	})
+
+	Context("Testing block device stability", Ordered, func() {
+		var (
+			blockDevice kubernetes.BlockDevice
+		)
+		It("Has consumable block device", func() {
+			By("Getting consumable block devices on node - %s")
+			blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
+			Expect(getBDErr).NotTo(HaveOccurred())
+			Expect(len(blockDevices)).To(BeNumerically(">", 0))
+			Expect(len(blockDevices)).To(BeNumerically("<", 2))
+
+			blockDevice = blockDevices[0]
+		})
+
+		When("Virtual disk is reattached", func() {
+			BeforeAll(func() {
+				By("Detaching the block device from the vm")
+				detachErr := kubernetes.DetachAndDeleteVirtualDisk(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
+					virtualDiskAttachmentResult.AttachmentName, "")
+				Expect(detachErr).NotTo(HaveOccurred())
+			})
+
+			AfterAll(func() {
+				By("Reattaching the virtual disk to the vm")
+				reattachResult, reattachErr := kubernetes.ReattachVirtualDiskToVM(ctx, res.BaseKubeconfig, kubernetes.VirtualDiskReattachmentConfig{
+					AttachmentName: virtualDiskAttachmentResult.AttachmentName,
+					VMName:         targetVM,
+					Namespace:      conf.TestCluster.Namespace,
+					DiskName:       virtualDiskAttachmentResult.DiskName,
+				})
+				Expect(reattachErr).NotTo(HaveOccurred())
+				Expect(reattachResult).NotTo(BeNil())
+				By("Waiting for virtual disk attachment to become ready")
+				waitReattachErr := kubernetes.WaitForVirtualDiskAttached(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
+					reattachResult.AttachmentName, 5*time.Second)
+				Expect(waitReattachErr).NotTo(HaveOccurred())
+				virtualDiskAttachmentResult = reattachResult
+			})
+
+			It("Has not consumable block device", func() {
+				Eventually(func(g Gomega) {
+					blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
+					g.Expect(getBDErr).NotTo(HaveOccurred())
+					g.Expect(len(blockDevices)).To(BeNumerically("==", 0))
+				}, time.Minute, 2*time.Second).Should(Succeed())
+			})
+		})
+
+		When("reattached virtual disk to vm", func() {
+			It("Has same consumable block device", func() {
+				blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
+				Expect(getBDErr).NotTo(HaveOccurred())
+				Expect(len(blockDevices)).To(BeNumerically(">", 0))
+				Expect(len(blockDevices)).To(BeNumerically("<", 2))
+				newBlockDevice := blockDevices[0]
+				Expect(newBlockDevice).To(Equal(blockDevice))
+			})
+		})
+
+		When("Restarting sds-node-configurator agent", func() {
+			restartAt := time.Now()
+
+			err := k8sClient.DeleteAllOf(
+				ctx,
+				&v1.Pod{},
+				client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
+				client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
+				client.MatchingFields{"spec.nodeName": targetVM},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				var pods v1.PodList
+				g.Expect(k8sClient.List(
+					ctx,
+					&pods,
+					client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
+					client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
+					client.MatchingFields{"spec.nodeName": targetVM},
+				)).To(Succeed())
+
+				g.Expect(pods.Items).To(HaveLen(1))
+				p := pods.Items[0]
+
+				g.Expect(p.CreationTimestamp.Time.After(restartAt)).To(BeTrue(), "ожидаем новый pod после рестарта")
+				g.Expect(p.DeletionTimestamp).To(BeNil())
+				g.Expect(p.Status.Phase).To(Equal(v1.PodRunning))
+				g.Expect(isPodReady(&p)).To(BeTrue())
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+			It("sdasdas", func() {
+				By("Getting sdasdasd on node - %s")
+			})
+		})
+
+		if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
+			By("Getting ModulePullOverride spec")
+			dyn, err := kubernetes.NewDynamicClientWithRetry(ctx, res.Kubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			mpoGVR := schema.GroupVersionResource{
+				Group:    "deckhouse.io",
+				Version:  "v1alpha2",
+				Resource: "modulepulloverrides",
+			}
+
+			mpo, err := dyn.Resource(mpoGVR).Get(ctx, "sds-node-configurator", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			spec, found, err := unstructured.NestedMap(mpo.Object, "spec")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			GinkgoWriter.Printf("ImageTag: %s", spec["imageTag"])
+		}
+	})
+})

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -206,46 +206,68 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 						Expect(blockDevices[0]).To(Equal(initialBlockDevice))
 					})
 				})
-			})
 
-			When("running in pull_request and agent is updated to PR version", func() {
-				BeforeAll(func() {
-					if os.Getenv("GITHUB_EVENT_NAME") != "pull_request" {
-						Skip("PR-only scenario")
-					}
+				When("running in pull_request and agent imageTag is switched to main", func() {
+					var (
+						originalImageTag string
+					)
 
-					mpo, err := dyn.Resource(mpoGVR).Get(ctx, consts.SdsNodeConfiguratorAgentName, metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
+					BeforeAll(func() {
+						if os.Getenv("GITHUB_EVENT_NAME") != "pull_request" {
+							Skip("PR-only scenario")
+						}
 
-					err = unstructured.SetNestedField(mpo.Object, conf.ModulesImageTag, "spec", "imageTag")
-					Expect(err).NotTo(HaveOccurred())
+						mpo, err := dyn.Resource(mpoGVR).Get(ctx, consts.SdsNodeConfiguratorAgentName, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
 
-					_, err = dyn.Resource(mpoGVR).Update(ctx, mpo, metav1.UpdateOptions{})
-					Expect(err).NotTo(HaveOccurred())
+						currentImageTag, found, err := unstructured.NestedString(mpo.Object, "spec", "imageTag")
+						Expect(err).NotTo(HaveOccurred())
+						Expect(found).To(BeTrue(), "expected spec.imageTag to be set")
 
-					Expect(kubernetes.WaitForModuleReady(ctx, res.Kubeconfig, consts.SdsNodeConfiguratorAgentName, 10*time.Minute)).To(Succeed())
-				})
+						originalImageTag = currentImageTag
 
-				It("has the same consumable block device", func() {
-					By("Checking that consumable BlockDevice name remains unchanged after agent update")
-					Expect(initialBlockDevice.Name).NotTo(BeEmpty())
-					Eventually(func(g Gomega) {
-						blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
-						g.Expect(getBDErr).NotTo(HaveOccurred())
-						g.Expect(blockDevices).To(HaveLen(1))
-						g.Expect(blockDevices[0].Name).To(Equal(initialBlockDevice.Name))
-					}, 5*time.Minute, 5*time.Second).Should(Succeed())
-				})
+						err = unstructured.SetNestedField(mpo.Object, conf.ModulesImageTag, "spec", "imageTag")
+						Expect(err).NotTo(HaveOccurred())
 
-				AfterAll(func() {
-					mpo, err := dyn.Resource(mpoGVR).Get(ctx, consts.SdsNodeConfiguratorAgentName, metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
+						_, err = dyn.Resource(mpoGVR).Update(ctx, mpo, metav1.UpdateOptions{})
+						Expect(err).NotTo(HaveOccurred())
 
-					err = unstructured.SetNestedField(mpo.Object, "main", "spec", "imageTag")
-					Expect(err).NotTo(HaveOccurred())
+						Expect(kubernetes.WaitForModuleReady(
+							ctx,
+							res.Kubeconfig,
+							consts.SdsNodeConfiguratorAgentName,
+							10*time.Minute,
+						)).To(Succeed())
+					})
 
-					_, err = dyn.Resource(mpoGVR).Update(ctx, mpo, metav1.UpdateOptions{})
-					Expect(err).NotTo(HaveOccurred())
+					AfterAll(func() {
+						mpo, err := dyn.Resource(mpoGVR).Get(ctx, consts.SdsNodeConfiguratorAgentName, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+
+						err = unstructured.SetNestedField(mpo.Object, originalImageTag, "spec", "imageTag")
+						Expect(err).NotTo(HaveOccurred())
+
+						_, err = dyn.Resource(mpoGVR).Update(ctx, mpo, metav1.UpdateOptions{})
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(kubernetes.WaitForModuleReady(
+							ctx,
+							res.Kubeconfig,
+							consts.SdsNodeConfiguratorAgentName,
+							10*time.Minute,
+						)).To(Succeed())
+					})
+
+					It("has the same consumable block device after agent imageTag switch", func() {
+						By("Checking that consumable block device remains unchanged after imageTag switch")
+						Expect(initialBlockDevice.Name).NotTo(BeEmpty())
+						Eventually(func(g Gomega) {
+							blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
+							g.Expect(getBDErr).NotTo(HaveOccurred())
+							g.Expect(blockDevices).To(HaveLen(1))
+							g.Expect(blockDevices[0].Name).To(Equal(initialBlockDevice.Name))
+						}, 5*time.Minute, 5*time.Second).Should(Succeed())
+					})
 				})
 			})
 		})

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -19,7 +19,7 @@ package tests
 import (
 	"context"
 	"os"
-	"slices"
+	"strings"
 	"time"
 
 	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
@@ -65,8 +65,14 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 		vms, listVmErr := kubernetes.ListVirtualMachineNames(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace)
 		Expect(listVmErr).NotTo(HaveOccurred())
 		Expect(vms).NotTo(BeEmpty())
-		slices.Sort(vms)
-		targetVM = vms[0]
+
+		for _, vm := range vms {
+			if strings.HasPrefix(vm, "bootstrap-node-") {
+				continue
+			}
+			targetVM = vm
+			break
+		}
 
 		By("Attaching a virtual disk to the target VM")
 		attachResult, attachErr := kubernetes.AttachVirtualDiskToVM(ctx, res.BaseKubeconfig,

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -84,6 +84,26 @@ var _ = Describe("BlockDeviceStable", Ordered, func() {
 		Expect(attachWaitErr).NotTo(HaveOccurred())
 
 		virtualDiskAttachmentResult = attachResult
+
+		if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
+			By("Getting ModulePullOverride spec")
+			dyn, err := kubernetes.NewDynamicClientWithRetry(ctx, res.Kubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			mpoGVR := schema.GroupVersionResource{
+				Group:    "deckhouse.io",
+				Version:  "v1alpha2",
+				Resource: "modulepulloverrides",
+			}
+
+			mpo, err := dyn.Resource(mpoGVR).Get(ctx, "sds-node-configurator", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			spec, found, err := unstructured.NestedMap(mpo.Object, "spec")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			GinkgoWriter.Printf("ImageTag: %s", spec["imageTag"])
+		}
 	})
 
 	AfterAll(func() {
@@ -157,58 +177,41 @@ var _ = Describe("BlockDeviceStable", Ordered, func() {
 		})
 
 		When("Restarting sds-node-configurator agent", func() {
-			restartAt := time.Now()
+			BeforeAll(func() {
+				restartAt := time.Now()
 
-			err := k8sClient.DeleteAllOf(
-				ctx,
-				&v1.Pod{},
-				client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
-				client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
-				client.MatchingFields{"spec.nodeName": targetVM},
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func(g Gomega) {
-				var pods v1.PodList
-				g.Expect(k8sClient.List(
+				err := k8sClient.DeleteAllOf(
 					ctx,
-					&pods,
+					&v1.Pod{},
 					client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
 					client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
 					client.MatchingFields{"spec.nodeName": targetVM},
-				)).To(Succeed())
+				)
+				Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(pods.Items).To(HaveLen(1))
-				p := pods.Items[0]
+				Eventually(func(g Gomega) {
+					var pods v1.PodList
+					g.Expect(k8sClient.List(
+						ctx,
+						&pods,
+						client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
+						client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
+						client.MatchingFields{"spec.nodeName": targetVM},
+					)).To(Succeed())
 
-				g.Expect(p.CreationTimestamp.Time.After(restartAt)).To(BeTrue(), "ожидаем новый pod после рестарта")
-				g.Expect(p.DeletionTimestamp).To(BeNil())
-				g.Expect(p.Status.Phase).To(Equal(v1.PodRunning))
-				g.Expect(isPodReady(&p)).To(BeTrue())
-			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+					g.Expect(pods.Items).To(HaveLen(1))
+					p := pods.Items[0]
+
+					g.Expect(p.CreationTimestamp.Time.After(restartAt)).To(BeTrue(), "ожидаем новый pod после рестарта")
+					g.Expect(p.DeletionTimestamp).To(BeNil())
+					g.Expect(p.Status.Phase).To(Equal(v1.PodRunning))
+					g.Expect(isPodReady(&p)).To(BeTrue())
+				}, 5*time.Minute, 5*time.Second).Should(Succeed())
+			})
+
 			It("sdasdas", func() {
 				By("Getting sdasdasd on node - %s")
 			})
 		})
-
-		if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
-			By("Getting ModulePullOverride spec")
-			dyn, err := kubernetes.NewDynamicClientWithRetry(ctx, res.Kubeconfig)
-			Expect(err).NotTo(HaveOccurred())
-
-			mpoGVR := schema.GroupVersionResource{
-				Group:    "deckhouse.io",
-				Version:  "v1alpha2",
-				Resource: "modulepulloverrides",
-			}
-
-			mpo, err := dyn.Resource(mpoGVR).Get(ctx, "sds-node-configurator", metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			spec, found, err := unstructured.NestedMap(mpo.Object, "spec")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(BeTrue())
-			GinkgoWriter.Printf("ImageTag: %s", spec["imageTag"])
-		}
 	})
 })

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -1,18 +1,19 @@
 /*
-Copyright 2026 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
+
 package tests
 
 import (
@@ -34,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("BlockDeviceStable", Ordered, func() {
+var _ = Describe("Block device stability with explicit lifecycle stages", Ordered, func() {
 	var (
 		ctx       context.Context
 		res       *cluster.TestClusterResources
@@ -42,36 +43,33 @@ var _ = Describe("BlockDeviceStable", Ordered, func() {
 		k8sClient client.Client
 
 		targetVM                    string
+		initialBlockDevice          kubernetes.BlockDevice
 		virtualDiskAttachmentResult *kubernetes.VirtualDiskAttachmentResult
 	)
 
 	BeforeAll(func() {
-		By("Run before all")
+		By("Preparing shared test context and Kubernetes clients")
 		ctx = context.Background()
 		res = e2eNestedTestClusterOrNil()
 		Expect(res).NotTo(BeNil())
 		conf = cfg.Load()
-		Expect(conf).ToNot(BeNil())
+		Expect(conf).NotTo(BeNil())
 		ensureE2EK8sClient(res, &k8sClient, ctx)
 		Expect(k8sClient).NotTo(BeNil())
-
-		By("Creating virtualization client")
-		virtClient, createVirtClientError := kubernetes.NewVirtualizationClient(ctx, res.BaseKubeconfig)
-		Expect(createVirtClientError).NotTo(HaveOccurred())
-		Expect(virtClient).NotTo(BeNil())
 
 		By("Listing virtual machines to select target VM")
 		vms, listVmErr := kubernetes.ListVirtualMachineNames(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace)
 		Expect(listVmErr).NotTo(HaveOccurred())
+		Expect(vms).NotTo(BeEmpty())
 		slices.Sort(vms)
 		targetVM = vms[0]
 
-		By("Creating virtual disk attachment")
+		By("Attaching a virtual disk to the target VM")
 		attachResult, attachErr := kubernetes.AttachVirtualDiskToVM(ctx, res.BaseKubeconfig,
 			kubernetes.VirtualDiskAttachmentConfig{
 				VMName:           targetVM,
 				Namespace:        conf.TestCluster.Namespace,
-				DiskName:         "block-device-stable",
+				DiskName:         "block-device-stable-readable",
 				DiskSize:         "5Gi",
 				StorageClassName: conf.TestCluster.StorageClass,
 			})
@@ -86,7 +84,7 @@ var _ = Describe("BlockDeviceStable", Ordered, func() {
 		virtualDiskAttachmentResult = attachResult
 
 		if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
-			By("Getting ModulePullOverride spec")
+			By("Reading ModulePullOverride spec for debug output in pull_request runs")
 			dyn, err := kubernetes.NewDynamicClientWithRetry(ctx, res.Kubeconfig)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -107,110 +105,112 @@ var _ = Describe("BlockDeviceStable", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		if virtualDiskAttachmentResult != nil {
-			By("Deleting virtual disk attachment and virtual disk")
-			deleteVDErr := kubernetes.DetachAndDeleteVirtualDisk(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
-				virtualDiskAttachmentResult.AttachmentName, virtualDiskAttachmentResult.DiskName)
-			if deleteVDErr != nil {
-				GinkgoWriter.Println(deleteVDErr)
-			}
+		if virtualDiskAttachmentResult == nil {
+			return
+		}
+
+		By("Cleaning up virtual disk attachment and virtual disk")
+		deleteVDErr := kubernetes.DetachAndDeleteVirtualDisk(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
+			virtualDiskAttachmentResult.AttachmentName, virtualDiskAttachmentResult.DiskName)
+		if deleteVDErr != nil {
+			GinkgoWriter.Println(deleteVDErr)
 		}
 	})
 
-	Context("Testing block device stability", Ordered, func() {
-		var (
-			blockDevice kubernetes.BlockDevice
-		)
-		It("Has consumable block device", func() {
-			By("Getting consumable block devices on node - %s")
+	Context("with disk initially attached to the VM", func() {
+		It("has exactly one consumable block device", func() {
+			By("Getting consumable block devices on the target node")
 			blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
 			Expect(getBDErr).NotTo(HaveOccurred())
-			Expect(len(blockDevices)).To(BeNumerically(">", 0))
-			Expect(len(blockDevices)).To(BeNumerically("<", 2))
+			Expect(blockDevices).To(HaveLen(1))
 
-			blockDevice = blockDevices[0]
+			initialBlockDevice = blockDevices[0]
 		})
 
-		When("Virtual disk is reattached", func() {
+		When("disk is detached from the VM", func() {
 			BeforeAll(func() {
-				By("Detaching the block device from the vm")
+				By("Detaching the virtual disk from the VM")
 				detachErr := kubernetes.DetachAndDeleteVirtualDisk(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
 					virtualDiskAttachmentResult.AttachmentName, "")
 				Expect(detachErr).NotTo(HaveOccurred())
 			})
 
-			AfterAll(func() {
-				By("Reattaching the virtual disk to the vm")
-				reattachResult, reattachErr := kubernetes.ReattachVirtualDiskToVM(ctx, res.BaseKubeconfig, kubernetes.VirtualDiskReattachmentConfig{
-					AttachmentName: virtualDiskAttachmentResult.AttachmentName,
-					VMName:         targetVM,
-					Namespace:      conf.TestCluster.Namespace,
-					DiskName:       virtualDiskAttachmentResult.DiskName,
-				})
-				Expect(reattachErr).NotTo(HaveOccurred())
-				Expect(reattachResult).NotTo(BeNil())
-				By("Waiting for virtual disk attachment to become ready")
-				waitReattachErr := kubernetes.WaitForVirtualDiskAttached(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
-					reattachResult.AttachmentName, 5*time.Second)
-				Expect(waitReattachErr).NotTo(HaveOccurred())
-				virtualDiskAttachmentResult = reattachResult
-			})
-
-			It("Has not consumable block device", func() {
+			It("has zero consumable block devices", func() {
 				Eventually(func(g Gomega) {
 					blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
 					g.Expect(getBDErr).NotTo(HaveOccurred())
-					g.Expect(len(blockDevices)).To(BeNumerically("==", 0))
+					g.Expect(blockDevices).To(BeEmpty())
 				}, time.Minute, 2*time.Second).Should(Succeed())
 			})
-		})
 
-		When("reattached virtual disk to vm", func() {
-			It("Has same consumable block device", func() {
-				blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
-				Expect(getBDErr).NotTo(HaveOccurred())
-				Expect(len(blockDevices)).To(BeNumerically(">", 0))
-				Expect(len(blockDevices)).To(BeNumerically("<", 2))
-				newBlockDevice := blockDevices[0]
-				Expect(newBlockDevice).To(Equal(blockDevice))
-			})
-		})
+			When("disk is reattached to the VM", func() {
+				BeforeAll(func() {
+					By("Reattaching the virtual disk to the VM")
+					reattachResult, reattachErr := kubernetes.ReattachVirtualDiskToVM(ctx, res.BaseKubeconfig,
+						kubernetes.VirtualDiskReattachmentConfig{
+							AttachmentName: virtualDiskAttachmentResult.AttachmentName,
+							VMName:         targetVM,
+							Namespace:      conf.TestCluster.Namespace,
+							DiskName:       virtualDiskAttachmentResult.DiskName,
+						})
+					Expect(reattachErr).NotTo(HaveOccurred())
+					Expect(reattachResult).NotTo(BeNil())
 
-		When("Restarting sds-node-configurator agent", func() {
-			BeforeAll(func() {
-				restartAt := time.Now()
+					By("Waiting for virtual disk attachment to become ready")
+					waitReattachErr := kubernetes.WaitForVirtualDiskAttached(ctx, res.BaseKubeconfig, conf.TestCluster.Namespace,
+						reattachResult.AttachmentName, 5*time.Second)
+					Expect(waitReattachErr).NotTo(HaveOccurred())
+					virtualDiskAttachmentResult = reattachResult
+				})
 
-				err := k8sClient.DeleteAllOf(
-					ctx,
-					&v1.Pod{},
-					client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
-					client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
-					client.MatchingFields{"spec.nodeName": targetVM},
-				)
-				Expect(err).NotTo(HaveOccurred())
+				It("has the same consumable block device as before detach", func() {
+					blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
+					Expect(getBDErr).NotTo(HaveOccurred())
+					Expect(blockDevices).To(HaveLen(1))
+					Expect(blockDevices[0]).To(Equal(initialBlockDevice))
+				})
 
-				Eventually(func(g Gomega) {
-					var pods v1.PodList
-					g.Expect(k8sClient.List(
-						ctx,
-						&pods,
-						client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
-						client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
-						client.MatchingFields{"spec.nodeName": targetVM},
-					)).To(Succeed())
+				When("sds-node-configurator-agent pod is restarted on the node", func() {
+					BeforeAll(func() {
+						restartAt := time.Now()
 
-					g.Expect(pods.Items).To(HaveLen(1))
-					p := pods.Items[0]
+						err := k8sClient.DeleteAllOf(
+							ctx,
+							&v1.Pod{},
+							client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
+							client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
+							client.MatchingFields{"spec.nodeName": targetVM},
+						)
+						Expect(err).NotTo(HaveOccurred())
 
-					g.Expect(p.CreationTimestamp.Time.After(restartAt)).To(BeTrue(), "ожидаем новый pod после рестарта")
-					g.Expect(p.DeletionTimestamp).To(BeNil())
-					g.Expect(p.Status.Phase).To(Equal(v1.PodRunning))
-					g.Expect(isPodReady(&p)).To(BeTrue())
-				}, 5*time.Minute, 5*time.Second).Should(Succeed())
-			})
+						Eventually(func(g Gomega) {
+							By("Waiting for sds-node-configurator-agent pod to be recreated and become ready")
+							var pods v1.PodList
+							g.Expect(k8sClient.List(
+								ctx,
+								&pods,
+								client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
+								client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentAppLabel},
+								client.MatchingFields{"spec.nodeName": targetVM},
+							)).To(Succeed())
 
-			It("sdasdas", func() {
-				By("Getting sdasdasd on node - %s")
+							g.Expect(pods.Items).To(HaveLen(1))
+							p := pods.Items[0]
+
+							g.Expect(p.CreationTimestamp.Time.After(restartAt)).To(BeTrue(), "expected a new pod after restart")
+							g.Expect(p.DeletionTimestamp).To(BeNil())
+							g.Expect(p.Status.Phase).To(Equal(v1.PodRunning))
+						}, 5*time.Minute, 5*time.Second).Should(Succeed())
+					})
+
+					It("keeps block device state stable after agent restart", func() {
+						By("Checking block device visibility on the target node after agent restart")
+						blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
+						Expect(getBDErr).NotTo(HaveOccurred())
+						Expect(blockDevices).To(HaveLen(1))
+						Expect(blockDevices[0]).To(Equal(initialBlockDevice))
+					})
+				})
 			})
 		})
 	})

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -120,11 +120,12 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 	Context("with disk initially attached to the VM", func() {
 		It("has exactly one consumable block device", func() {
 			By("Getting consumable block devices on the target node")
-			blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
-			Expect(getBDErr).NotTo(HaveOccurred())
-			Expect(blockDevices).To(HaveLen(1))
-
-			initialBlockDevice = blockDevices[0]
+			Eventually(func(g Gomega) {
+				blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
+				g.Expect(getBDErr).NotTo(HaveOccurred())
+				g.Expect(blockDevices).To(HaveLen(1))
+				initialBlockDevice = blockDevices[0]
+			}, 5*time.Minute, 2*time.Second).Should(Succeed())
 		})
 
 		When("disk is detached from the VM", func() {
@@ -140,7 +141,7 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 					blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, res.Kubeconfig, targetVM)
 					g.Expect(getBDErr).NotTo(HaveOccurred())
 					g.Expect(blockDevices).To(BeEmpty())
-				}, time.Minute, 2*time.Second).Should(Succeed())
+				}, 5*time.Minute, 5*time.Second).Should(Succeed())
 			})
 
 			When("disk is reattached to the VM", func() {

--- a/e2e/tests/sds_node_configurator_suite_test.go
+++ b/e2e/tests/sds_node_configurator_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	e2ecfg "github.com/deckhouse/sds-node-configurator/e2e/cfg"
 	"github.com/deckhouse/storage-e2e/pkg/cluster"
@@ -38,12 +39,14 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	res := e2eNestedTestClusterOrNil()
 	if res != nil {
-		locked, lockErr := cluster.IsClusterLocked(context.Background(), res.Kubeconfig)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		locked, lockErr := cluster.IsClusterLocked(ctx, res.Kubeconfig)
 		if lockErr != nil {
 			GinkgoWriter.Println(lockErr)
 		}
 		if locked {
-			releaseErr := cluster.ReleaseClusterLock(context.Background(), res.Kubeconfig)
+			releaseErr := cluster.ReleaseClusterLock(ctx, res.Kubeconfig)
 			if releaseErr != nil {
 				GinkgoWriter.Println(releaseErr)
 			}

--- a/e2e/tests/sds_node_configurator_suite_test.go
+++ b/e2e/tests/sds_node_configurator_suite_test.go
@@ -17,10 +17,12 @@
 package tests
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	e2ecfg "github.com/deckhouse/sds-node-configurator/e2e/cfg"
+	"github.com/deckhouse/storage-e2e/pkg/cluster"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -34,6 +36,21 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	res := e2eNestedTestClusterOrNil()
+	if res != nil {
+		locked, lockErr := cluster.IsClusterLocked(context.Background(), res.Kubeconfig)
+		if lockErr != nil {
+			GinkgoWriter.Println(lockErr)
+		}
+		if locked {
+			releaseErr := cluster.ReleaseClusterLock(context.Background(), res.Kubeconfig)
+			if releaseErr != nil {
+				GinkgoWriter.Println(releaseErr)
+			}
+			GinkgoWriter.Println("Released cluster lock")
+		}
+	}
+
 	e2eCleanupNestedTestClusterAfterSuite()
 })
 

--- a/e2e/tests/utils/consts/consts.go
+++ b/e2e/tests/utils/consts/consts.go
@@ -1,0 +1,22 @@
+/*
+	Copyright 2026 Flant JSC
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package consts
+
+const (
+	SdsNodeConfiguratorAgentNamespace = "d8-sds-node-configurator"
+	SdsNodeConfiguratorAgentAppLabel  = "sds-node-configurator"
+)

--- a/e2e/tests/utils/consts/consts.go
+++ b/e2e/tests/utils/consts/consts.go
@@ -18,5 +18,5 @@ package consts
 
 const (
 	SdsNodeConfiguratorAgentNamespace = "d8-sds-node-configurator"
-	SdsNodeConfiguratorAgentAppLabel  = "sds-node-configurator"
+	SdsNodeConfiguratorAgentName      = "sds-node-configurator"
 )


### PR DESCRIPTION
This pull request enhances the E2E testing suite for the SDS Node Configurator by introducing a comprehensive stability test for block device lifecycle management, improving cluster resource cleanup, and making configuration and dependency updates. The main focus is on ensuring block device stability across attach/detach operations, agent restarts, and image tag changes, as well as improving test infrastructure reliability.

**New E2E Test for Block Device Stability:**

* Added a new test `block_device_stable_test.go` that verifies block device stability through attach, detach, reattach, agent restart, and image tag switch scenarios, ensuring the system maintains correct block device state throughout these lifecycle events.

**Test Infrastructure & Reliability Improvements:**

* Enhanced the `AfterSuite` cleanup in `sds_node_configurator_suite_test.go` to automatically release cluster locks, improving resource management and reducing the risk of resource contention in CI environments.
* Introduced a new constants file `consts.go` for shared test constants, improving maintainability and reducing duplication.
* Updated the test runner in `.github/workflows/build_dev.yml` to focus on the new stability test by using the `-ginkgo.focus` flag, ensuring targeted execution in CI.

**Configuration & Dependency Updates:**

* Added a new `ModulesImageTag` field to the test configuration struct to allow dynamic control of the agent image tag during tests, supporting image tag switching scenarios.
* Updated the `storage-e2e` dependency to the latest version for compatibility and new features.
* Minor imports update to support new test logic.