### PR TITLE
chore: unify .helmignore

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,5 +1,6 @@
 *.md
 CHANGELOG
+api
 crds
 docs
 enabled
@@ -14,5 +15,7 @@ openapi
 release.yaml
 scripts
 template_tests
+testing
+tools
 werf*.yaml
 e2e

--- a/.helmignore
+++ b/.helmignore
@@ -1,9 +1,10 @@
 *.md
+CHANGELOG
 crds
-# charts
 docs
 enabled
 hooks
+hack
 images
 images_digests.json
 lib
@@ -14,3 +15,4 @@ release.yaml
 scripts
 template_tests
 werf*.yaml
+e2e


### PR DESCRIPTION
## Description

Unify `.helmignore` across storage modules: align with `sds-node-configurator` baseline entries and add `hack`, `e2e`, and `CHANGELOG` so build artifacts and non-chart directories are excluded consistently from the Helm chart package.

## Why do we need it, and what problem does it solve?

`.helmignore` lists differed between modules (some lacked `images_digests.json`, `monitoring_test`, `scripts`, `template_tests`, etc.; `hack` was missing everywhere). Inconsistent ignores can let non-template paths into the chart bundle or omit paths that should stay out of the release artifact.

## What is the expected result?

All updated modules share the same `.helmignore` content (except `backup` and `sds-elastic`, out of scope). Helm packaging excludes `hooks`, `hack`, `e2e`, `CHANGELOG`, and the other listed paths consistently.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
