### PR TITLE
Add x-config-version: 2 to openapi config-values spec

### DIFF
--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -1,3 +1,4 @@
+x-config-version: 2
 type: object
 required: []
 properties:


### PR DESCRIPTION
## Description

Add `x-config-version: 2` to `openapi/config-values.yaml` to align the module configuration schema with Deckhouse config-values format v2 (same as in core modules, e.g. prometheus).

## Why do we need it, and what problem does it solve?

Deckhouse uses `x-config-version` to select the correct validation and conversion logic for ModuleConfig. Without version 2, the module may not follow the current platform conventions for config-values.

## What is the expected result?

`openapi/config-values.yaml` starts with `x-config-version: 2`. ModuleConfig validation and documentation generation use the v2 schema. No runtime behavior change for existing cluster configurations.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.