### PR TITLE
Test/e2e netlink discovery change

### DIFF
--- a/e2e/tests/netlink_discovery_test.go
+++ b/e2e/tests/netlink_discovery_test.go
@@ -61,6 +61,7 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 		agentPod          *v1.Pod
 
 		addSince    metav1.Time
+		changeSince metav1.Time
 		removeSince metav1.Time
 	)
 
@@ -163,6 +164,69 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 			g.Expect(logErr).NotTo(HaveOccurred())
 			return logText
 		}, time.Minute, 2*time.Second).Should(MatchRegexp(netlinkAddEventLogPattern))
+	})
+
+	It("updates BlockDevice after VirtualDisk resize (CHANGE)", func() {
+		Expect(netlinkDiskAttach).NotTo(BeNil(), "disk must be attached in previous step")
+		Expect(blockDevice).NotTo(BeNil(), "blockDevice must be discovered in previous step")
+
+		bdName := blockDevice.Name
+		bdNode := blockDevice.Status.NodeName
+		baselineBDSize := blockDevice.Status.Size.Value()
+
+		changeSince = metav1.NewTime(time.Now())
+
+		By(fmt.Sprintf("Growing VirtualDisk %s from %s to %s", netlinkDiskAttach.DiskName, netlinkDiskSize, netlinkDiskResizedSize))
+		Expect(e2ePatchVirtualDiskSize(
+			ctx,
+			testClusterResources.BaseKubeconfig,
+			conf.TestCluster.Namespace,
+			netlinkDiskAttach.DiskName,
+			netlinkDiskResizedSize,
+		)).To(Succeed())
+
+		By("Waiting until the same BlockDevice reflects increased size")
+		Eventually(func(g Gomega) {
+			var bd v1alpha1.BlockDevice
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: bdName}, &bd)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(bd.Status.Type).To(Equal("disk"))
+			g.Expect(bd.Status.NodeName).To(Equal(bdNode), "BlockDevice should stay on the same node after resize")
+
+			g.Expect(bd.Status.Size.Value()).To(BeNumerically(">", baselineBDSize),
+				"BlockDevice size should increase after VirtualDisk resize (was %d)", baselineBDSize)
+
+			maxSize := resource.MustParse(netlinkDiskResizedSize)
+			maxSize.Add(resource.MustParse("16Mi"))
+			g.Expect(bd.Status.Size.Cmp(maxSize)).NotTo(BeNumerically(">", 0),
+				"BD size must be <= requested resized size + 16Mi (%s), got %s", maxSize.String(), bd.Status.Size.String())
+
+			blockDevice = &bd
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	It("writes udev change event to agent logs", func(ctx SpecContext) {
+		Skip("not implemented netlink logs")
+
+		var fnErr error
+		agentPod, fnErr = pod.FindRunningPodOnNode(
+			ctx, k8sClient, targetVM,
+			client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
+			client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentName},
+		)
+		Expect(fnErr).NotTo(HaveOccurred())
+
+		logOpts := v1.PodLogOptions{
+			Container:  consts.SdsNodeConfiguratorAgentContainer,
+			SinceTime:  &changeSince,
+			Timestamps: true,
+		}
+		Eventually(func(g Gomega) string {
+			logText, logErr := pod.GetLogs(ctx, cs, consts.SdsNodeConfiguratorAgentNamespace, agentPod.Name, logOpts)
+			g.Expect(logErr).NotTo(HaveOccurred())
+			return logText
+		}, time.Minute, 2*time.Second).Should(MatchRegexp(netlinkChangeEventLogPattern))
 	})
 
 	It("removes BlockDevice after VirtualDisk detach", func() {

--- a/e2e/tests/netlink_discovery_test.go
+++ b/e2e/tests/netlink_discovery_test.go
@@ -142,7 +142,7 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 			"BD size must be <= requested size + 16Mi (%s), got %s", maxSize.String(), blockDevice.Status.Size.String())
 	})
 
-	It("writes udev add event to agent logs", func(ctx SpecContext) {
+	It("writes udev add event to agent logs", func() {
 		Skip("not implemented netlink logs")
 
 		var fnErr error
@@ -163,9 +163,9 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 			g.Expect(logErr).NotTo(HaveOccurred())
 			return logText
 		}, time.Minute, 2*time.Second).Should(MatchRegexp(netlinkAddEventLogPattern))
-	}, SpecTimeout(2*time.Minute))
+	})
 
-	It("removes BlockDevice after VirtualDisk detach", func(ctx SpecContext) {
+	It("removes BlockDevice after VirtualDisk detach", func() {
 		Expect(netlinkDiskAttach).NotTo(BeNil(), "disk must be attached in previous step")
 
 		removeSince = metav1.NewTime(time.Now())
@@ -183,9 +183,9 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
 				"BlockDevice %s should be deleted after detach; err=%v", bdName, err)
 		}, 30*time.Second, time.Second).Should(Succeed())
-	}, SpecTimeout(1*time.Minute))
+	})
 
-	It("writes udev remove event to agent logs", func(ctx SpecContext) {
+	It("writes udev remove event to agent logs", func() {
 		Skip("not implemented netlink logs")
 		logOpts := v1.PodLogOptions{
 			Container:  consts.SdsNodeConfiguratorAgentContainer,
@@ -197,5 +197,5 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 			g.Expect(logErr).NotTo(HaveOccurred())
 			return logText
 		}, time.Minute, 2*time.Second).Should(MatchRegexp(netlinkRemoveEventLogPattern))
-	}, SpecTimeout(2*time.Minute))
+	})
 })

--- a/e2e/tests/netlink_discovery_test.go
+++ b/e2e/tests/netlink_discovery_test.go
@@ -47,14 +47,14 @@ const (
 	netlinkChangeEventLogPattern = `(?i)\[HandleEvent\].*udev event.*action=change`
 )
 
-var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, func(ctx context.Context) {
+var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, func() {
 	var (
 		testClusterResources *cluster.TestClusterResources
 		k8sClient            client.Client
 		cs                   *k8sclient.Clientset
 		conf                 *cfg.Config
-
-		targetVM string
+		ctx                  context.Context
+		targetVM             string
 
 		netlinkDiskAttach *kubernetes.VirtualDiskAttachmentResult
 		blockDevice       *v1alpha1.BlockDevice
@@ -66,6 +66,7 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 	)
 
 	BeforeAll(func() {
+		ctx = context.Background()
 		testClusterResources = e2eNestedTestClusterOrNil()
 		Expect(testClusterResources).NotTo(BeNil(),
 			"nested cluster must be created in BeforeSuite (e2eEnsureSharedNestedTestCluster)")

--- a/e2e/tests/netlink_discovery_test.go
+++ b/e2e/tests/netlink_discovery_test.go
@@ -19,10 +19,12 @@ package tests
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
+	"github.com/deckhouse/sds-node-configurator/e2e/tests/utils/consts"
 	"github.com/deckhouse/sds-node-configurator/e2e/tests/utils/pod"
 	"github.com/deckhouse/storage-e2e/pkg/cluster"
 	"github.com/deckhouse/storage-e2e/pkg/kubernetes"
@@ -37,20 +39,17 @@ import (
 )
 
 const (
-	netlinkAgentNamespace = "d8-sds-node-configurator"
-	netlinkAgentAppLabel  = "sds-node-configurator"
-	netlinkAgentContainer = "sds-node-configurator-agent"
-
-	netlinkDiskSize = "5Gi"
+	netlinkDiskSize        = "5Gi"
+	netlinkDiskResizedSize = "8Gi"
 
 	netlinkAddEventLogPattern    = `(?i)\[HandleEvent\].*udev event.*action=add`
 	netlinkRemoveEventLogPattern = `(?i)\[HandleEvent\].*udev event.*action=remove`
+	netlinkChangeEventLogPattern = `(?i)\[HandleEvent\].*udev event.*action=change`
 )
 
-var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, func() {
+var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, func(ctx context.Context) {
 	var (
 		testClusterResources *cluster.TestClusterResources
-		e2eCtx               context.Context
 		k8sClient            client.Client
 		cs                   *k8sclient.Clientset
 		conf                 *cfg.Config
@@ -66,53 +65,55 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 	)
 
 	BeforeAll(func() {
-		e2eCtx = context.Background()
-
 		testClusterResources = e2eNestedTestClusterOrNil()
 		Expect(testClusterResources).NotTo(BeNil(),
 			"nested cluster must be created in BeforeSuite (e2eEnsureSharedNestedTestCluster)")
 
-		ensureE2EK8sClient(testClusterResources, &k8sClient, e2eCtx)
+		ensureE2EK8sClient(testClusterResources, &k8sClient, ctx)
 		Expect(testClusterResources.BaseKubeconfig).NotTo(BeNil(), "test requires nested virtualization")
 
 		conf = cfg.Load()
 
-		vms := e2eListClusterVMNames(e2eCtx, testClusterResources, conf.TestCluster.Namespace)
+		vms, vmListErr := kubernetes.ListVirtualMachineNames(ctx, testClusterResources.BaseKubeconfig, conf.TestCluster.Namespace)
+		Expect(vmListErr).NotTo(HaveOccurred())
 		Expect(vms).NotTo(BeEmpty())
-		targetVM = vms[0]
+
+		for _, vm := range vms {
+			if strings.HasPrefix(vm, "bootstrap-node-") {
+				continue
+			}
+
+			targetVM = vm
+		}
 
 		var csErr error
-		cs, csErr = k8sclient.NewForConfig(testClusterResources.Kubeconfig)
+		cs, csErr = kubernetes.NewClientsetWithRetry(ctx, testClusterResources.Kubeconfig)
 		Expect(csErr).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func() {
 		if netlinkDiskAttach != nil && testClusterResources != nil && testClusterResources.BaseKubeconfig != nil {
-			ns := e2eConfigNamespace()
-			dErr := kubernetes.DetachAndDeleteVirtualDisk(e2eCtx, testClusterResources.BaseKubeconfig, ns, netlinkDiskAttach.AttachmentName, netlinkDiskAttach.DiskName)
+			dErr := kubernetes.DetachAndDeleteVirtualDisk(ctx, testClusterResources.BaseKubeconfig, conf.TestCluster.Namespace, netlinkDiskAttach.AttachmentName, netlinkDiskAttach.DiskName)
 			GinkgoWriter.Printf("Detach error - %v", dErr)
-		}
-		if blockDevice != nil {
-			forceDeleteBlockDevicesByNames(e2eCtx, k8sClient, []string{blockDevice.Name})
 		}
 	})
 
 	It("attaches VirtualDisk and discovers BlockDevice", func() {
 		addSince = metav1.NewTime(time.Now())
 
-		attachResult, attachError := attachVirtualDiskWithRetry(e2eCtx, testClusterResources.BaseKubeconfig, kubernetes.VirtualDiskAttachmentConfig{
+		attachResult, attachError := kubernetes.AttachVirtualDiskToVM(ctx, testClusterResources.BaseKubeconfig, kubernetes.VirtualDiskAttachmentConfig{
 			VMName:           targetVM,
 			Namespace:        conf.TestCluster.Namespace,
 			DiskName:         fmt.Sprintf("e2e-netlink-%d", time.Now().UnixNano()),
 			DiskSize:         netlinkDiskSize,
 			StorageClassName: conf.TestCluster.StorageClass,
-		}, e2eVirtualDiskAttachMaxRetries, e2eVirtualDiskAttachRetryInterval)
+		})
 		Expect(attachError).NotTo(HaveOccurred(), "failed to attach virtual disk")
 		Expect(attachResult).NotTo(BeNil())
 
 		netlinkDiskAttach = attachResult
 
-		attachCtx, attachCancel := context.WithTimeout(e2eCtx, e2eVirtualDiskAttachWaitTimeout)
+		attachCtx, attachCancel := context.WithTimeout(ctx, consts.VirtualDiskAttachWaitTimeout)
 		defer attachCancel()
 		Expect(kubernetes.WaitForVirtualDiskAttached(
 			attachCtx, testClusterResources.BaseKubeconfig,
@@ -120,7 +121,7 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 		)).NotTo(HaveOccurred(), "virtual disk did not become attached in time")
 
 		blockDevice = e2eWaitConsumableBlockDeviceForVirtualDisk(
-			e2eCtx, testClusterResources.BaseKubeconfig, k8sClient,
+			ctx, testClusterResources.BaseKubeconfig, k8sClient,
 			conf.TestCluster.Namespace, netlinkDiskAttach.DiskName, netlinkDiskAttach.AttachmentName, targetVM,
 		)
 		Expect(blockDevice).NotTo(BeNil())
@@ -146,19 +147,19 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 
 		var fnErr error
 		agentPod, fnErr = pod.FindRunningPodOnNode(
-			e2eCtx, k8sClient, targetVM,
-			client.InNamespace(netlinkAgentNamespace),
-			client.MatchingLabels{"app": netlinkAgentAppLabel},
+			ctx, k8sClient, targetVM,
+			client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
+			client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentName},
 		)
 		Expect(fnErr).NotTo(HaveOccurred())
 
 		logOpts := v1.PodLogOptions{
-			Container:  netlinkAgentContainer,
+			Container:  consts.SdsNodeConfiguratorAgentContainer,
 			SinceTime:  &addSince,
 			Timestamps: true,
 		}
 		Eventually(func(g Gomega) string {
-			logText, logErr := pod.GetLogs(ctx, cs, netlinkAgentNamespace, agentPod.Name, logOpts)
+			logText, logErr := pod.GetLogs(ctx, cs, consts.SdsNodeConfiguratorAgentNamespace, agentPod.Name, logOpts)
 			g.Expect(logErr).NotTo(HaveOccurred())
 			return logText
 		}, time.Minute, 2*time.Second).Should(MatchRegexp(netlinkAddEventLogPattern))
@@ -169,7 +170,7 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 
 		removeSince = metav1.NewTime(time.Now())
 		Expect(kubernetes.DetachAndDeleteVirtualDisk(
-			e2eCtx, testClusterResources.BaseKubeconfig,
+			ctx, testClusterResources.BaseKubeconfig,
 			conf.TestCluster.Namespace, netlinkDiskAttach.AttachmentName, netlinkDiskAttach.DiskName,
 		)).To(Succeed())
 
@@ -187,12 +188,12 @@ var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, fu
 	It("writes udev remove event to agent logs", func(ctx SpecContext) {
 		Skip("not implemented netlink logs")
 		logOpts := v1.PodLogOptions{
-			Container:  netlinkAgentContainer,
+			Container:  consts.SdsNodeConfiguratorAgentContainer,
 			SinceTime:  &removeSince,
 			Timestamps: true,
 		}
 		Eventually(func(g Gomega) string {
-			logText, logErr := pod.GetLogs(ctx, cs, netlinkAgentNamespace, agentPod.Name, logOpts)
+			logText, logErr := pod.GetLogs(ctx, cs, consts.SdsNodeConfiguratorAgentNamespace, agentPod.Name, logOpts)
 			g.Expect(logErr).NotTo(HaveOccurred())
 			return logText
 		}, time.Minute, 2*time.Second).Should(MatchRegexp(netlinkRemoveEventLogPattern))

--- a/e2e/tests/utils/consts/consts.go
+++ b/e2e/tests/utils/consts/consts.go
@@ -19,4 +19,5 @@ package consts
 const (
 	SdsNodeConfiguratorAgentNamespace = "d8-sds-node-configurator"
 	SdsNodeConfiguratorAgentName      = "sds-node-configurator"
+	SdsNodeConfiguratorAgentContainer = "sds-node-configurator-agent"
 )

--- a/e2e/tests/utils/consts/timeout.go
+++ b/e2e/tests/utils/consts/timeout.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package consts
+
+import "time"
+
+const (
+	VirtualDiskAttachWaitTimeout = 15 * time.Minute
+)


### PR DESCRIPTION
This pull request refactors and extends the `netlink_discovery_test.go` E2E test to improve maintainability, standardize constants usage, and add a new test for BlockDevice resizing. It moves hardcoded values to a centralized constants package, updates test logic for clarity, and introduces a test for handling VirtualDisk resize events.

**Test improvements and new functionality:**

* Added a new test case that verifies BlockDevice updates after resizing a VirtualDisk, ensuring the BlockDevice size increases and is reflected in the cluster.
* Added a corresponding log pattern and test for the "udev change" event, though the log assertion is currently skipped as not implemented. [[1]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L40-R126) [[2]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L144-R238)

**Constants and code organization:**

* Replaced hardcoded namespace, app label, and container name values in `netlink_discovery_test.go` with centralized constants from the new or updated `consts` package, improving maintainability and clarity. [[1]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2R22-R27) [[2]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L144-R238) [[3]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L185-R265) [[4]](diffhunk://#diff-d7710512668adcfad3e0f1103fa985c8c2b87b75c27def48233bbed5944bc7e3R22)
* Introduced a new `timeout.go` file in the `consts` package to define the `VirtualDiskAttachWaitTimeout` constant, standardizing timeout usage across tests.

**Test logic and reliability:**

* Improved test reliability by updating VM selection logic to skip bootstrap nodes and by using more robust client initialization and retry logic.
* Refactored context and resource management for consistency and to avoid potential resource leaks.

These changes collectively enhance test clarity, maintainability, and coverage for VirtualDisk and BlockDevice lifecycle events.