### PR TITLE
E2E added thin-pool removal test

### DIFF
--- a/e2e/tests/e2e_node_ssh_test.go
+++ b/e2e/tests/e2e_node_ssh_test.go
@@ -25,6 +25,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,6 +39,17 @@ import (
 )
 
 const e2eSSHJumpDialRetries = 5
+
+type e2eNodeSSHEntry struct {
+	client *e2eNodeSSHClient
+	nodeIP string
+}
+
+var (
+	e2eNodeSSHCacheMu sync.Mutex
+	e2eNodeSSHCache   = make(map[string]*e2eNodeSSHEntry)
+	e2eSSHHopLogged   sync.Map // hop route string → struct{}
+)
 
 // e2eNodeSSHClient runs commands on a test-cluster worker VM (direct or via jump host).
 type e2eNodeSSHClient struct {
@@ -243,7 +255,10 @@ func e2eNewNodeSSHClient(sshUser, nodeIP, keyPath string) (*e2eNodeSSHClient, er
 		jumpKeyPath = keyPath
 	}
 
-	GinkgoWriter.Printf("      SSH hop to node %s@%s via %s@%s (%s)\n", sshUser, nodeIP, jumpUser, jumpHost, jumpSource)
+	hopKey := fmt.Sprintf("%s@%s|%s@%s|%s", jumpUser, jumpHost, sshUser, nodeIP, jumpSource)
+	if _, loaded := e2eSSHHopLogged.LoadOrStore(hopKey, struct{}{}); !loaded {
+		GinkgoWriter.Printf("      SSH hop to node %s@%s via %s@%s (%s)\n", sshUser, nodeIP, jumpUser, jumpHost, jumpSource)
+	}
 
 	jumpClient, err := e2eDialSSH(jumpUser, jumpHost, jumpKeyPath)
 	if err != nil {
@@ -311,7 +326,22 @@ func e2eGetNodeInternalIP(ctx context.Context, kubeconfig *rest.Config, nodeName
 	return "", fmt.Errorf("node %s has no InternalIP", nodeName)
 }
 
+func e2eNodeSSHCacheKey(nodeName, sshUser string) string {
+	return nodeName + "\x00" + sshUser
+}
+
+// e2eConnectToTestClusterNode returns a cached SSH client per (nodeName, sshUser) for the suite run.
+// Reuses the jump tunnel instead of redialing on every Eventually poll; call e2eCloseNodeSSHCache in AfterSuite.
 func e2eConnectToTestClusterNode(ctx context.Context, testKubeconfig *rest.Config, nodeName, sshUser string) (*e2eNodeSSHClient, string, error) {
+	key := e2eNodeSSHCacheKey(nodeName, sshUser)
+
+	e2eNodeSSHCacheMu.Lock()
+	if e, ok := e2eNodeSSHCache[key]; ok && e != nil && e.client != nil {
+		e2eNodeSSHCacheMu.Unlock()
+		return e.client, e.nodeIP, nil
+	}
+	e2eNodeSSHCacheMu.Unlock()
+
 	nodeIP, err := e2eGetNodeInternalIP(ctx, testKubeconfig, nodeName)
 	if err != nil {
 		return nil, "", err
@@ -324,5 +354,24 @@ func e2eConnectToTestClusterNode(ctx context.Context, testKubeconfig *rest.Confi
 	if err != nil {
 		return nil, nodeIP, err
 	}
+
+	e2eNodeSSHCacheMu.Lock()
+	defer e2eNodeSSHCacheMu.Unlock()
+	if e, ok := e2eNodeSSHCache[key]; ok && e != nil && e.client != nil {
+		_ = client.Close()
+		return e.client, e.nodeIP, nil
+	}
+	e2eNodeSSHCache[key] = &e2eNodeSSHEntry{client: client, nodeIP: nodeIP}
 	return client, nodeIP, nil
+}
+
+func e2eCloseNodeSSHCache() {
+	e2eNodeSSHCacheMu.Lock()
+	defer e2eNodeSSHCacheMu.Unlock()
+	for k, e := range e2eNodeSSHCache {
+		if e != nil && e.client != nil {
+			_ = e.client.Close()
+		}
+		delete(e2eNodeSSHCache, k)
+	}
 }

--- a/e2e/tests/sds_node_configurator_helpers_discovery_ssh_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_discovery_ssh_test.go
@@ -110,7 +110,6 @@ func runLsblkViaDirectSSH(ctx context.Context, testKubeconfig *rest.Config, node
 	if err != nil {
 		return nil, fmt.Errorf("SSH to node %s: %w", nodeName, err)
 	}
-	defer sshClient.Close()
 	out, err := sshClient.Exec(ctx, "lsblk -b -P -o NAME,SIZE,SERIAL,PATH -n")
 	if err != nil {
 		return nil, fmt.Errorf("run lsblk on node %s (%s@%s): %w", nodeName, sshUser, nodeIP, err)
@@ -144,7 +143,6 @@ func e2eExecOnTestClusterNodeSSH(ctx context.Context, testKubeconfig *rest.Confi
 	if err != nil {
 		return "", fmt.Errorf("SSH to node %s (%s@%s): %w", nodeName, sshUser, nodeIP, err)
 	}
-	defer sshClient.Close()
 	out, err := sshClient.Exec(ctx, command)
 	if err != nil {
 		return out, fmt.Errorf("exec on node %s: %w", nodeName, err)
@@ -167,17 +165,23 @@ func e2eCountPVsInVGOnNode(ctx context.Context, testKubeconfig *rest.Config, nod
 	return n, out, nil
 }
 
-// e2eThinPoolDataLVPresentOnNode returns true when vgName has a thin-pool data LV named thinPoolName (lv_attr starts with "t").
+// e2eThinPoolDataLVPresentOnNode returns true when vgName has a thin-pool data LV for thinPoolName (lv_attr starts with "t").
+// Matches spec pool name or LVM segment names like <pool>_tdata.
 func e2eThinPoolDataLVPresentOnNode(ctx context.Context, testKubeconfig *rest.Config, nodeName, sshUser, vgName, thinPoolName string) (bool, string, error) {
 	quotedVG := strconv.Quote(vgName)
 	quotedPool := strconv.Quote(thinPoolName)
-	cmd := fmt.Sprintf(`out=$(sudo -n lvs -a -o lv_name,lv_attr --noheadings %s 2>/dev/null | sed 's/[][]//g' | awk -v p=%s '$1==p && $2 ~ /^t/ {print "yes"; exit} END {print "no"}')
-echo "${out:-no}"`, quotedVG, quotedPool)
+	cmd := fmt.Sprintf(`sudo -n lvs -a -o lv_name,lv_attr --noheadings %s 2>/dev/null | sed 's/[][]//g' | awk -v p=%s '
+  $2 ~ /^t/ && ($1 == p || $1 == p "_tdata") { found=1 }
+  END { if (found) print "yes"; else print "no" }'`, quotedVG, quotedPool)
 	out, err := e2eExecOnTestClusterNodeSSH(ctx, testKubeconfig, nodeName, sshUser, cmd)
 	if err != nil {
 		return false, out, err
 	}
-	return strings.TrimSpace(out) == "yes", out, nil
+	answer := strings.TrimSpace(out)
+	if idx := strings.Index(answer, "\n"); idx >= 0 {
+		answer = strings.TrimSpace(answer[:idx])
+	}
+	return answer == "yes", out, nil
 }
 
 func e2eCountDevicesOnLVGNode(lvg *v1alpha1.LVMVolumeGroup, nodeName string) int {

--- a/e2e/tests/sds_node_configurator_helpers_discovery_ssh_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_discovery_ssh_test.go
@@ -167,6 +167,19 @@ func e2eCountPVsInVGOnNode(ctx context.Context, testKubeconfig *rest.Config, nod
 	return n, out, nil
 }
 
+// e2eThinPoolDataLVPresentOnNode returns true when vgName has a thin-pool data LV named thinPoolName (lv_attr starts with "t").
+func e2eThinPoolDataLVPresentOnNode(ctx context.Context, testKubeconfig *rest.Config, nodeName, sshUser, vgName, thinPoolName string) (bool, string, error) {
+	quotedVG := strconv.Quote(vgName)
+	quotedPool := strconv.Quote(thinPoolName)
+	cmd := fmt.Sprintf(`out=$(sudo -n lvs -a -o lv_name,lv_attr --noheadings %s 2>/dev/null | sed 's/[][]//g' | awk -v p=%s '$1==p && $2 ~ /^t/ {print "yes"; exit} END {print "no"}')
+echo "${out:-no}"`, quotedVG, quotedPool)
+	out, err := e2eExecOnTestClusterNodeSSH(ctx, testKubeconfig, nodeName, sshUser, cmd)
+	if err != nil {
+		return false, out, err
+	}
+	return strings.TrimSpace(out) == "yes", out, nil
+}
+
 func e2eCountDevicesOnLVGNode(lvg *v1alpha1.LVMVolumeGroup, nodeName string) int {
 	return len(e2eDevicesOnLVGNode(lvg, nodeName))
 }

--- a/e2e/tests/sds_node_configurator_suite_test.go
+++ b/e2e/tests/sds_node_configurator_suite_test.go
@@ -54,6 +54,7 @@ var _ = AfterSuite(func() {
 		}
 	}
 
+	e2eCloseNodeSSHCache()
 	e2eCleanupNestedTestClusterAfterSuite()
 })
 

--- a/e2e/tests/sds_node_configurator_test.go
+++ b/e2e/tests/sds_node_configurator_test.go
@@ -2207,30 +2207,9 @@ var _ = Describe("sds-node-configurator module e2e", Ordered, func() {
 			)
 
 			var (
-				thinPoolRestoreOnce      sync.Once
-				thinPoolRestoreRunID     string
-				thinPoolRestoreAttach    *kubernetes.VirtualDiskAttachmentResult
+				thinPoolRestoreAttach     *kubernetes.VirtualDiskAttachmentResult
 				thinPoolRestoreAllocLimit = "100%"
 			)
-
-			BeforeEach(func() {
-				thinPoolRestoreOnce.Do(func() {
-					ensureE2EK8sClient(testClusterResources, &k8sClient, e2eCtx)
-					thinPoolRestoreRunID = fmt.Sprintf("%d", time.Now().Unix())
-					prepCtx, prepCancel := context.WithTimeout(context.Background(), e2eClusterCleanupTimeout)
-					defer prepCancel()
-					By("thin-pool restore suite: cleanup before test")
-					cleanupE2EPodsAndPVCsWithWait(prepCtx, k8sClient, e2eSuitePodPVCleanupPodTimeout, e2eSuitePodPVCleanupPVTimeout)
-					cleanupE2ELVMLogicalVolumes(prepCtx, k8sClient)
-					cleanupE2ELVMVolumeGroups(prepCtx, k8sClient)
-					cleanupE2ELocalStorageClasses(prepCtx, testClusterResources.Kubeconfig)
-					if testClusterResources.BaseKubeconfig != nil {
-						cleanupE2EVirtualDisks(prepCtx, testClusterResources.BaseKubeconfig, e2eConfigNamespace(), e2eSuiteVirtualDiskPrefix)
-					}
-					forceDeleteAllNonConsumableBlockDevices(prepCtx, k8sClient, 2*time.Minute)
-					forceDeleteAllBlockDevices(prepCtx, k8sClient, 3*time.Minute)
-				})
-			})
 
 			AfterEach(func() {
 				if thinPoolRestoreAttach == nil || testClusterResources == nil || testClusterResources.BaseKubeconfig == nil {
@@ -2246,7 +2225,7 @@ var _ = Describe("sds-node-configurator module e2e", Ordered, func() {
 			It("Should recreate thin-pool when the pool LV was removed manually on the node", func() {
 				ensureE2EK8sClient(testClusterResources, &k8sClient, e2eCtx)
 				Expect(testClusterResources.BaseKubeconfig).NotTo(BeNil(), "requires nested virtualization")
-				Expect(thinPoolRestoreRunID).NotTo(BeEmpty())
+				thinPoolRestoreRunID := fmt.Sprintf("%d", time.Now().Unix())
 
 				ns := e2eConfigNamespace()
 				storageClass := e2eConfigStorageClass()

--- a/e2e/tests/sds_node_configurator_test.go
+++ b/e2e/tests/sds_node_configurator_test.go
@@ -2158,17 +2158,42 @@ var _ = Describe("sds-node-configurator module e2e", Ordered, func() {
 				}
 				Expect(k8sClient.Update(e2eCtx, &cur)).To(Succeed())
 
-				By("Step 4: wait for vgextend — Ready, two devices in status, larger VG free/size")
+				vmSSH := e2eConfigVMSSHUser()
+				By("Step 4a: nudge agent/LVM scan after selector patch (vgextend + BD discoverer race on CI)")
+				e2eTriggerLVMDiscoveryOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH)
+				restartSDSNodeConfiguratorAgentOnNode(e2eCtx, k8sClient, nodeName)
+
+				By("Step 4b: wait for two PVs in VG on the node (reconciler vgextend)")
+				Eventually(func(g Gomega) {
+					pvCount, out, errSSH := e2eCountPVsInVGOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH, vgName)
+					if errSSH != nil {
+						GinkgoWriter.Printf("    vgextend pvs: err=%v out=%q\n", errSSH, out)
+					}
+					g.Expect(errSSH).NotTo(HaveOccurred())
+					g.Expect(pvCount).To(Equal(2), "VG %q should have 2 PVs; pvs: %q", vgName, strings.TrimSpace(out))
+				}, 10*time.Minute, 10*time.Second).Should(Succeed())
+
+				By(fmt.Sprintf("Step 4c: wait for BlockDevice %s linked to VG %s (BD discoverer after vgextend)", bd2.Name, vgName))
+				e2eWaitBlockDeviceLinkedToVG(e2eCtx, k8sClient, bd2.Name, vgName, e2eBlockDeviceVGLinkageTimeout)
+
+				By("Step 4d: wait for LVMVolumeGroup status — Ready, two devices, larger VG size/free")
 				Eventually(func(g Gomega) {
 					var extended v1alpha1.LVMVolumeGroup
 					g.Expect(k8sClient.Get(e2eCtx, client.ObjectKeyFromObject(lvg), &extended)).To(Succeed())
+					nDev := e2eCountDevicesOnLVGNode(&extended, nodeName)
+					GinkgoWriter.Printf("    vgextend status poll: phase=%s devices=%d vgSize=%s vgFree=%s\n",
+						extended.Status.Phase, nDev, extended.Status.VGSize.String(), extended.Status.VGFree.String())
+					for _, c := range extended.Status.Conditions {
+						if c.Status == metav1.ConditionFalse {
+							GinkgoWriter.Printf("    condition %s False: reason=%s msg=%s\n", c.Type, c.Reason, c.Message)
+						}
+					}
 					g.Expect(extended.Status.Phase).To(Equal(v1alpha1.PhaseReady), "phase=%s", extended.Status.Phase)
 					for _, c := range extended.Status.Conditions {
 						g.Expect(c.Status).NotTo(Equal(metav1.ConditionFalse),
 							"condition %s False: reason=%s message=%s", c.Type, c.Reason, c.Message)
 					}
-					g.Expect(e2eCountDevicesOnLVGNode(&extended, nodeName)).To(Equal(2),
-						"status.nodes should list two BlockDevices after vgextend")
+					g.Expect(nDev).To(Equal(2), "status.nodes should list two BlockDevices after vgextend")
 					g.Expect(extended.Status.VGFree.Value()).To(BeNumerically(">", baselineVGFree),
 						"VGFree should grow after adding second PV (baseline %d)", baselineVGFree)
 					g.Expect(extended.Status.VGSize.Value()).To(BeNumerically(">", baselineVGSize),
@@ -2176,18 +2201,7 @@ var _ = Describe("sds-node-configurator module e2e", Ordered, func() {
 					devices := e2eDevicesOnLVGNode(&extended, nodeName)
 					g.Expect(devices).To(HaveKey(bd1.Name), "status should include first BlockDevice %s", bd1.Name)
 					g.Expect(devices).To(HaveKey(bd2.Name), "status should include second BlockDevice %s", bd2.Name)
-				}, e2eLVMVolumeGroupReadyTimeout, 15*time.Second).Should(Succeed())
-
-				vmSSH := e2eConfigVMSSHUser()
-				By("Step 5: verify on node that VG has two physical volumes (pvs)")
-				Eventually(func(g Gomega) {
-					pvCount, out, errSSH := e2eCountPVsInVGOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH, vgName)
-					if errSSH != nil {
-						GinkgoWriter.Printf("    pvs on node %s: err=%v out=%q\n", nodeName, errSSH, out)
-					}
-					g.Expect(errSSH).NotTo(HaveOccurred())
-					g.Expect(pvCount).To(Equal(2), "VG %q should have 2 PVs on node; pvs output: %q", vgName, strings.TrimSpace(out))
-				}, 5*time.Minute, 10*time.Second).Should(Succeed())
+				}, e2eLVMVolumeGroupReadyTimeout, 10*time.Second).Should(Succeed())
 
 				var final v1alpha1.LVMVolumeGroup
 				Expect(k8sClient.Get(e2eCtx, client.ObjectKeyFromObject(lvg), &final)).To(Succeed())

--- a/e2e/tests/sds_node_configurator_test.go
+++ b/e2e/tests/sds_node_configurator_test.go
@@ -2317,14 +2317,9 @@ var _ = Describe("sds-node-configurator module e2e", Ordered, func() {
 					g.Expect(tp.Ready).To(BeTrue())
 				}, e2eLVMVolumeGroupReadyTimeout, 10*time.Second).Should(Succeed())
 
-				Eventually(func(g Gomega) {
-					present, out, errSSH := e2eThinPoolDataLVPresentOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH, vgName, thinPoolName)
-					if errSSH != nil {
-						GinkgoWriter.Printf("    lvs thin-pool check: err=%v out=%q\n", errSSH, out)
-					}
-					g.Expect(errSSH).NotTo(HaveOccurred())
-					g.Expect(present).To(BeTrue(), "thin-pool data LV should exist before manual removal; lvs: %q", strings.TrimSpace(out))
-				}, 2*time.Minute, 5*time.Second).Should(Succeed())
+				present, lvsOut, errLvs := e2eThinPoolDataLVPresentOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH, vgName, thinPoolName)
+				Expect(errLvs).NotTo(HaveOccurred())
+				Expect(present).To(BeTrue(), "thin-pool data LV should exist before manual removal (status already Ready); lvs: %q", strings.TrimSpace(lvsOut))
 				printLVMVolumeGroupInfo(&ready)
 
 				By("Step 2: manually remove thin-pool stack on the node (pool + metadata segments; VG and PV stay)")

--- a/e2e/tests/sds_node_configurator_test.go
+++ b/e2e/tests/sds_node_configurator_test.go
@@ -2196,6 +2196,193 @@ var _ = Describe("sds-node-configurator module e2e", Ordered, func() {
 			})
 		})
 
+		// Agent reconcileThinPoolsIfNeeded recreates spec thin-pools missing on the node (lv_attr "t").
+		// Manual removal must drop thin volumes, pool data LV, and leftover segments (_tmeta/_tdata) — see e2eShellRemoveThinPoolStackForVG.
+		Context("thin-pool removed manually", func() {
+			const (
+				e2eThinPoolRestoreDiskName = "e2e-lvg-tp-restore-disk"
+				e2eThinPoolRestoreDiskSize = "2Gi"
+				e2eThinPoolRestorePoolName = "e2e-thin-pool-restore"
+				e2eThinPoolRestorePoolSize = "60%"
+			)
+
+			var (
+				thinPoolRestoreOnce      sync.Once
+				thinPoolRestoreRunID     string
+				thinPoolRestoreAttach    *kubernetes.VirtualDiskAttachmentResult
+				thinPoolRestoreAllocLimit = "100%"
+			)
+
+			BeforeEach(func() {
+				thinPoolRestoreOnce.Do(func() {
+					ensureE2EK8sClient(testClusterResources, &k8sClient, e2eCtx)
+					thinPoolRestoreRunID = fmt.Sprintf("%d", time.Now().Unix())
+					prepCtx, prepCancel := context.WithTimeout(context.Background(), e2eClusterCleanupTimeout)
+					defer prepCancel()
+					By("thin-pool restore suite: cleanup before test")
+					cleanupE2EPodsAndPVCsWithWait(prepCtx, k8sClient, e2eSuitePodPVCleanupPodTimeout, e2eSuitePodPVCleanupPVTimeout)
+					cleanupE2ELVMLogicalVolumes(prepCtx, k8sClient)
+					cleanupE2ELVMVolumeGroups(prepCtx, k8sClient)
+					cleanupE2ELocalStorageClasses(prepCtx, testClusterResources.Kubeconfig)
+					if testClusterResources.BaseKubeconfig != nil {
+						cleanupE2EVirtualDisks(prepCtx, testClusterResources.BaseKubeconfig, e2eConfigNamespace(), e2eSuiteVirtualDiskPrefix)
+					}
+					forceDeleteAllNonConsumableBlockDevices(prepCtx, k8sClient, 2*time.Minute)
+					forceDeleteAllBlockDevices(prepCtx, k8sClient, 3*time.Minute)
+				})
+			})
+
+			AfterEach(func() {
+				if thinPoolRestoreAttach == nil || testClusterResources == nil || testClusterResources.BaseKubeconfig == nil {
+					return
+				}
+				ns := e2eConfigNamespace()
+				By("Cleaning up thin-pool restore VirtualDisk " + thinPoolRestoreAttach.DiskName)
+				_ = kubernetes.DetachAndDeleteVirtualDisk(e2eCtx, testClusterResources.BaseKubeconfig, ns,
+					thinPoolRestoreAttach.AttachmentName, thinPoolRestoreAttach.DiskName)
+				thinPoolRestoreAttach = nil
+			})
+
+			It("Should recreate thin-pool when the pool LV was removed manually on the node", func() {
+				ensureE2EK8sClient(testClusterResources, &k8sClient, e2eCtx)
+				Expect(testClusterResources.BaseKubeconfig).NotTo(BeNil(), "requires nested virtualization")
+				Expect(thinPoolRestoreRunID).NotTo(BeEmpty())
+
+				ns := e2eConfigNamespace()
+				storageClass := e2eConfigStorageClass()
+				Expect(storageClass).NotTo(BeEmpty())
+				clusterVMs := e2eListClusterVMNames(e2eCtx, testClusterResources, ns)
+				targetVM := clusterVMs[rand.Intn(len(clusterVMs))]
+				vmSSH := e2eConfigVMSSHUser()
+
+				vgName := "e2e-vg-tp-restore-" + thinPoolRestoreRunID
+				thinPoolName := e2eThinPoolRestorePoolName
+				nodeSafe := func(n string) string {
+					return strings.ReplaceAll(strings.ReplaceAll(n, ".", "-"), "_", "-")
+				}
+
+				By("Step 1: attach VirtualDisk and create LVMVolumeGroup with thin-pool")
+				att, err := attachVirtualDiskWithRetry(e2eCtx, testClusterResources.BaseKubeconfig, kubernetes.VirtualDiskAttachmentConfig{
+					VMName: targetVM, Namespace: ns, DiskName: e2eThinPoolRestoreDiskName,
+					DiskSize: e2eThinPoolRestoreDiskSize, StorageClassName: storageClass,
+				}, e2eVirtualDiskAttachMaxRetries, e2eVirtualDiskAttachRetryInterval)
+				Expect(err).NotTo(HaveOccurred())
+				thinPoolRestoreAttach = att
+
+				attachCtx, cancel := context.WithTimeout(e2eCtx, e2eVirtualDiskAttachWaitTimeout)
+				defer cancel()
+				Expect(kubernetes.WaitForVirtualDiskAttached(attachCtx, testClusterResources.BaseKubeconfig, ns, att.AttachmentName, 10*time.Second)).To(Succeed())
+
+				bd := e2eWaitConsumableBlockDeviceForVirtualDisk(e2eCtx, testClusterResources.BaseKubeconfig, k8sClient, ns,
+					att.DiskName, att.AttachmentName, targetVM)
+				nodeName := bd.Status.NodeName
+				bdMeta := bd.Labels["kubernetes.io/metadata.name"]
+				if bdMeta == "" {
+					bdMeta = bd.Name
+				}
+
+				lvgName := fmt.Sprintf("e2e-lvg-tp-restore-%s-%s", thinPoolRestoreRunID, nodeSafe(nodeName))
+				lvg := &v1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{Name: lvgName},
+					Spec: v1alpha1.LVMVolumeGroupSpec{
+						ActualVGNameOnTheNode: vgName,
+						BlockDeviceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/hostname":      nodeName,
+								"kubernetes.io/metadata.name": bdMeta,
+							},
+						},
+						ThinPools: []v1alpha1.LVMVolumeGroupThinPoolSpec{
+							{Name: thinPoolName, Size: e2eThinPoolRestorePoolSize, AllocationLimit: thinPoolRestoreAllocLimit},
+						},
+						Type:  "Local",
+						Local: v1alpha1.LVMVolumeGroupLocalSpec{NodeName: nodeName},
+					},
+				}
+				Expect(k8sClient.Create(e2eCtx, lvg)).To(Succeed())
+				defer func() { _ = k8sClient.Delete(e2eCtx, lvg) }()
+
+				var ready v1alpha1.LVMVolumeGroup
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(e2eCtx, client.ObjectKeyFromObject(lvg), &ready)).To(Succeed())
+					g.Expect(ready.Status.Phase).To(Equal(v1alpha1.PhaseReady))
+					var tp *v1alpha1.LVMVolumeGroupThinPoolStatus
+					for i := range ready.Status.ThinPools {
+						if ready.Status.ThinPools[i].Name == thinPoolName {
+							tp = &ready.Status.ThinPools[i]
+							break
+						}
+					}
+					g.Expect(tp).NotTo(BeNil())
+					g.Expect(tp.Ready).To(BeTrue())
+				}, e2eLVMVolumeGroupReadyTimeout, 10*time.Second).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					present, out, errSSH := e2eThinPoolDataLVPresentOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH, vgName, thinPoolName)
+					if errSSH != nil {
+						GinkgoWriter.Printf("    lvs thin-pool check: err=%v out=%q\n", errSSH, out)
+					}
+					g.Expect(errSSH).NotTo(HaveOccurred())
+					g.Expect(present).To(BeTrue(), "thin-pool data LV should exist before manual removal; lvs: %q", strings.TrimSpace(out))
+				}, 2*time.Minute, 5*time.Second).Should(Succeed())
+				printLVMVolumeGroupInfo(&ready)
+
+				By("Step 2: manually remove thin-pool stack on the node (pool + metadata segments; VG and PV stay)")
+				removeScript := e2eShellRemoveThinPoolStackForVG(vgName, thinPoolName)
+				outRemove, errRemove := e2eExecOnTestClusterNodeSSH(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH, removeScript)
+				if outRemove != "" {
+					GinkgoWriter.Printf("    thin-pool remove script output:\n%s\n", outRemove)
+				}
+				Expect(errRemove).NotTo(HaveOccurred(), "manual thin-pool removal on node %s", nodeName)
+
+				Eventually(func(g Gomega) {
+					present, out, errSSH := e2eThinPoolDataLVPresentOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH, vgName, thinPoolName)
+					g.Expect(errSSH).NotTo(HaveOccurred())
+					g.Expect(present).To(BeFalse(), "thin-pool data LV should be gone after manual removal; lvs: %q", strings.TrimSpace(out))
+				}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+				vgsOut, errVgs := e2eExecOnTestClusterNodeSSH(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH,
+					fmt.Sprintf("sudo -n vgs --noheadings -o vg_name %s 2>/dev/null || true", strconv.Quote(vgName)))
+				Expect(errVgs).NotTo(HaveOccurred())
+				Expect(e2eVgNameListedInVgsOutput(vgsOut, vgName)).To(BeTrue(), "VG %q must remain after thin-pool removal; vgs: %q", vgName, strings.TrimSpace(vgsOut))
+
+				By("Step 3: nudge agent and wait for controller to recreate thin-pool")
+				e2eTriggerLVMDiscoveryOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH)
+				restartSDSNodeConfiguratorAgentOnNode(e2eCtx, k8sClient, nodeName)
+
+				Eventually(func(g Gomega) {
+					var cur v1alpha1.LVMVolumeGroup
+					g.Expect(k8sClient.Get(e2eCtx, client.ObjectKeyFromObject(lvg), &cur)).To(Succeed())
+					g.Expect(cur.Status.Phase).To(Equal(v1alpha1.PhaseReady))
+					var tp *v1alpha1.LVMVolumeGroupThinPoolStatus
+					for i := range cur.Status.ThinPools {
+						if cur.Status.ThinPools[i].Name == thinPoolName {
+							tp = &cur.Status.ThinPools[i]
+							break
+						}
+					}
+					g.Expect(tp).NotTo(BeNil(), "status.thinPools should list %q", thinPoolName)
+					g.Expect(tp.Ready).To(BeTrue(), "recreated thin-pool should be Ready; ThinPools=%+v", cur.Status.ThinPools)
+					for _, c := range cur.Status.Conditions {
+						if c.Type == "VGConfigurationApplied" {
+							g.Expect(c.Status).To(Equal(metav1.ConditionTrue), "VGConfigurationApplied: %s %s", c.Reason, c.Message)
+						}
+					}
+				}, e2eLVMVolumeGroupReadyTimeout, 10*time.Second).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					present, out, errSSH := e2eThinPoolDataLVPresentOnNode(e2eCtx, testClusterResources.Kubeconfig, nodeName, vmSSH, vgName, thinPoolName)
+					g.Expect(errSSH).NotTo(HaveOccurred())
+					g.Expect(present).To(BeTrue(), "thin-pool data LV should exist after agent reconcile; lvs: %q", strings.TrimSpace(out))
+				}, e2eLVMVolumeGroupReadyTimeout, 10*time.Second).Should(Succeed())
+
+				var final v1alpha1.LVMVolumeGroup
+				Expect(k8sClient.Get(e2eCtx, client.ObjectKeyFromObject(lvg), &final)).To(Succeed())
+				printLVMVolumeGroupInfo(&final)
+				By("✓ Thin-pool removed manually; agent recreated pool; LVMVolumeGroup Ready")
+			})
+		})
+
 		Context("Multiple LVMVolumeGroups on one node", func() {
 			const (
 				e2eMultiLvgMinDisks  = 2


### PR DESCRIPTION
Signed-off-by: Nikolay Demchuk <nikolay.demchuk@flant.com>

## Description

Adds an e2e scenario that manually removes a thin-pool from an existing `LVMVolumeGroup` on the node and verifies agent recreation, plus reusable SSH/LVM helpers and cached node SSH sessions to avoid redundant jump dial noise in logs.

## Why do we need it, and what problem does it solve?

We need regression coverage for the case where the VG remains but the thin-pool LV stack was deleted on the node, and e2e must confirm that `reconcileThinPoolsIfNeeded` restores the pool instead of leaving the CR stuck unhealthy.

## What is the expected result?

After `lvremove` of the thin-pool stack (pool + metadata segments, VG/PV intact), the `LVMVolumeGroup` returns to `Phase: Ready` with `ThinPools[].Ready=true` and the thin-pool data LV is visible again in `lvs` on the node.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.