### PR TITLE
[scheduler-extender] Fix race with empty PVC Status.Phase and harden local-PVC filtering

### DIFF
--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
@@ -133,14 +133,15 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 		writeFailAllNodesResponse(w, servingLog, nodeNames, fmt.Sprintf("unable to extract request size: %s", err))
 		return
 	}
-	if len(pvcRequests) == 0 {
-		servingLog.Debug("No PVC requests found. Return the same nodes")
-		if err := writeNodeNamesResponse(w, servingLog, nodeNames); err != nil {
-			servingLog.Error(err, "unable to write node names response")
-			http.Error(w, "internal server error", http.StatusInternalServerError)
-		}
-		return
-	}
+	// NB: we intentionally do not short-circuit here when len(pvcRequests) == 0.
+	// For local PVCs, returning all incoming nodes would be unsafe: kube-scheduler
+	// could pick a node without a matching LVMVolumeGroup and the CSI provisioner
+	// would then fail with "error during SelectLVG". The invariant we enforce is
+	// that whenever managedPVCs contains at least one local PVC, the response must
+	// be a subset of nodes that have an LVG matching every local PVC's StorageClass.
+	// filterNodes / filterNodeForLocalPVCs enforces this even if pvcRequests is
+	// somehow empty for a PVC (LVG-match check via findMatchedSCLVG always runs;
+	// the space check trivially passes when RequestedSize == 0).
 
 	// Check if there are replicated PVCs that require node information
 	var nodes map[string]*corev1.Node

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -578,7 +578,16 @@ func getNewControlPlane(ctx context.Context, cl client.Client, log logger.Logger
 	return &_false, nil
 }
 
-// extractRequestedSize extracts the requested size from the PVC based on the PVC status phase and the StorageClass parameters.
+// extractRequestedSize extracts the requested size from the PVC based on the PVC
+// binding state (pvc.Spec.VolumeName) and the StorageClass parameters.
+//
+// Rationale for using Spec.VolumeName instead of Status.Phase: Status.Phase is set
+// by kube-controller-manager in a separate status update after the PVC is created.
+// A Pod scheduled together with its PVC reaches the extender before that update
+// happens, so Status.Phase is observed empty and a Status.Phase-based switch
+// silently drops the PVC. Spec.VolumeName, on the other hand, is set in the same
+// transaction as the binding and matches what the upstream VolumeBinding plugin
+// uses to decide whether a PVC is bound.
 func extractRequestedSize(
 	ctx context.Context,
 	cl client.Client,
@@ -589,7 +598,7 @@ func extractRequestedSize(
 	pvcRequests := make(map[string]PVCRequest, len(pvcs))
 	for _, pvc := range pvcs {
 		sc := scs[*pvc.Spec.StorageClassName]
-		log.Debug(fmt.Sprintf("[extractRequestedSize] PVC %s/%s has status phase: %s", pvc.Namespace, pvc.Name, pvc.Status.Phase))
+		log.Debug(fmt.Sprintf("[extractRequestedSize] PVC %s/%s has status phase: %q, spec.volumeName: %q", pvc.Namespace, pvc.Name, pvc.Status.Phase, pvc.Spec.VolumeName))
 
 		var deviceType string
 		isReplicated := sc.Provisioner == consts.SdsReplicatedVolumeProvisioner
@@ -620,22 +629,20 @@ func extractRequestedSize(
 			return nil, fmt.Errorf("[extractRequestedSize] unable to determine device type for PVC %s/%s", pvc.Namespace, pvc.Name)
 		}
 
-		switch pvc.Status.Phase {
-		case corev1.ClaimPending:
-			pvcRequests[pvc.Name] = PVCRequest{
-				DeviceType:    deviceType,
-				RequestedSize: pvc.Spec.Resources.Requests.Storage().Value(),
-			}
-
-		case corev1.ClaimBound:
+		var requestedSize int64
+		if pvc.Spec.VolumeName == "" {
+			requestedSize = pvc.Spec.Resources.Requests.Storage().Value()
+		} else {
 			pv := &corev1.PersistentVolume{}
 			if err := cl.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv); err != nil {
 				return nil, fmt.Errorf("[extractRequestedSize] error getting PV %s: %v", pvc.Spec.VolumeName, err)
 			}
-			pvcRequests[pvc.Name] = PVCRequest{
-				DeviceType:    deviceType,
-				RequestedSize: pvc.Spec.Resources.Requests.Storage().Value() - pv.Spec.Capacity.Storage().Value(),
-			}
+			requestedSize = pvc.Spec.Resources.Requests.Storage().Value() - pv.Spec.Capacity.Storage().Value()
+		}
+
+		pvcRequests[pvc.Name] = PVCRequest{
+			DeviceType:    deviceType,
+			RequestedSize: requestedSize,
 		}
 	}
 

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
@@ -943,6 +943,248 @@ func TestFilter_FailedExtractSize_RejectsAllNodes(t *testing.T) {
 	assert.NotEmpty(t, result.FailedNodes, "FailedNodes must contain a reason")
 }
 
+// TestExtractRequestedSize_PhaseLag locks in the regression fix for the
+// race described in the scheduler-extender bug report: when a Pod and its PVC
+// are created together, kube-scheduler may consult the extender before
+// kube-controller-manager has updated PVC.Status.Phase. extractRequestedSize
+// MUST decide "bound vs pending" via PVC.Spec.VolumeName so that an empty
+// Status.Phase does not silently drop the PVC from the request map (which
+// previously made filter/prioritize return all nodes for a local PVC and
+// caused the CSI provisioner to fail with "error during SelectLVG").
+func TestExtractRequestedSize_PhaseLag(t *testing.T) {
+	scName := "local-sc"
+	provisioner := consts.SdsLocalVolumeProvisioner
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scName},
+		Provisioner: provisioner,
+		Parameters: map[string]string{
+			consts.LvmTypeParamKey:         consts.Thick,
+			consts.LVMVolumeGroupsParamKey: `[{"name":"lvg1"}]`,
+		},
+	}
+	scs := map[string]*storagev1.StorageClass{scName: sc}
+
+	requestQty := resource.MustParse("100Mi")
+	pvCapacity := resource.MustParse("100Mi")
+	pvName := "pv-bound-1"
+
+	pvFreshlyCreatedNoPhase := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-empty-phase", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: requestQty},
+			},
+		},
+	}
+	pvcExplicitlyPending := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-pending", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: requestQty},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+	pvcBound := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bound", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			VolumeName:       pvName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: requestQty},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: pvName},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity:         corev1.ResourceList{corev1.ResourceStorage: pvCapacity},
+			StorageClassName: scName,
+		},
+	}
+
+	cl := newFakeClient(pv)
+	log, _ := logger.NewLogger("0")
+
+	t.Run("empty phase is treated as pending (regression)", func(t *testing.T) {
+		pvcs := map[string]*corev1.PersistentVolumeClaim{
+			pvFreshlyCreatedNoPhase.Name: pvFreshlyCreatedNoPhase,
+		}
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs)
+		require.NoError(t, err)
+		require.Contains(t, got, pvFreshlyCreatedNoPhase.Name, "PVC with empty Status.Phase must NOT be dropped")
+		assert.Equal(t, requestQty.Value(), got[pvFreshlyCreatedNoPhase.Name].RequestedSize)
+		assert.Equal(t, consts.Thick, got[pvFreshlyCreatedNoPhase.Name].DeviceType)
+	})
+
+	t.Run("explicit pending phase still requests full size", func(t *testing.T) {
+		pvcs := map[string]*corev1.PersistentVolumeClaim{
+			pvcExplicitlyPending.Name: pvcExplicitlyPending,
+		}
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs)
+		require.NoError(t, err)
+		require.Contains(t, got, pvcExplicitlyPending.Name)
+		assert.Equal(t, requestQty.Value(), got[pvcExplicitlyPending.Name].RequestedSize)
+	})
+
+	t.Run("bound PVC reports resize delta", func(t *testing.T) {
+		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcBound.Name: pvcBound}
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs)
+		require.NoError(t, err)
+		require.Contains(t, got, pvcBound.Name)
+		assert.Equal(t, requestQty.Value()-pvCapacity.Value(), got[pvcBound.Name].RequestedSize,
+			"bound PVC must report only the resize delta (requested - pv.capacity)")
+	})
+
+	t.Run("bound PVC with phase still empty also reports resize delta", func(t *testing.T) {
+		pvcBoundNoPhase := pvcBound.DeepCopy()
+		pvcBoundNoPhase.Name = "pvc-bound-no-phase"
+		pvcBoundNoPhase.Status = corev1.PersistentVolumeClaimStatus{}
+		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcBoundNoPhase.Name: pvcBoundNoPhase}
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs)
+		require.NoError(t, err)
+		require.Contains(t, got, pvcBoundNoPhase.Name,
+			"a PVC with Spec.VolumeName set but empty Status.Phase must be treated as bound, not dropped")
+		assert.Equal(t, requestQty.Value()-pvCapacity.Value(), got[pvcBoundNoPhase.Name].RequestedSize)
+	})
+}
+
+// TestFilter_LocalPVC_EmptyPhase_NoMatchingLVG is the end-to-end regression for
+// the original bug: a Pod with a freshly-created local PVC (Status.Phase empty)
+// is consulted on a set of nodes where none has a matching LVMVolumeGroup for
+// the StorageClass. The filter MUST NOT pass through "all nodes" -- it must
+// return an empty NodeNames list with per-node reasons populated in FailedNodes
+// so that the Pod stays Pending instead of being scheduled onto a node where
+// the CSI provisioner cannot create the volume.
+func TestFilter_LocalPVC_EmptyPhase_NoMatchingLVG(t *testing.T) {
+	scName := "local-sc"
+	provisioner := consts.SdsLocalVolumeProvisioner
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scName},
+		Provisioner: provisioner,
+		Parameters: map[string]string{
+			consts.LvmTypeParamKey:         consts.Thick,
+			consts.LVMVolumeGroupsParamKey: `[{"name":"lvg-not-on-any-node"}]`,
+		},
+	}
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-empty-phase", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("100Mi")},
+			},
+		},
+	}
+
+	cl := newFakeClient(sc, pvc)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{provisioner}
+
+	nodeNames := []string{"node1", "node2", "node3"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-empty-phase"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "filter must return 200 so kube-scheduler honors the response")
+
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.NotNil(t, result.NodeNames)
+	assert.Empty(t, *result.NodeNames, "no node has a matching LVG -- filter MUST NOT return any node")
+	assert.Len(t, result.FailedNodes, len(nodeNames), "every input node must be reported with a reason")
+}
+
+// TestFilter_LocalPVC_EmptyPhase_KeepsMatchingNode verifies that the same
+// empty-phase PVC, when paired with a node that DOES have a matching LVG, is
+// allowed through. This locks in the invariant that the response is exactly
+// "subset of nodes with a matching LVG" -- neither all nodes nor an empty
+// list.
+func TestFilter_LocalPVC_EmptyPhase_KeepsMatchingNode(t *testing.T) {
+	scName := "local-sc"
+	provisioner := consts.SdsLocalVolumeProvisioner
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scName},
+		Provisioner: provisioner,
+		Parameters: map[string]string{
+			consts.LvmTypeParamKey:         consts.Thick,
+			consts.LVMVolumeGroupsParamKey: `[{"name":"lvg1"}]`,
+		},
+	}
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-empty-phase", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("100Mi")},
+			},
+		},
+	}
+	hundredGiB := int64(100 * 1024 * 1024 * 1024)
+	lvg := readyLVGOnNode("lvg1", "node-with-lvg", hundredGiB, hundredGiB)
+
+	cl := newFakeClient(sc, pvc, lvg)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{provisioner}
+
+	nodeNames := []string{"node-with-lvg", "node-without-lvg"}
+	args := ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "v1", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-empty-phase"},
+					}},
+				},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.NotNil(t, result.NodeNames)
+	assert.Equal(t, []string{"node-with-lvg"}, *result.NodeNames,
+		"only the node with a matching LVG must pass; all-nodes pass-through would re-introduce the SelectLVG bug")
+	if assert.Len(t, result.FailedNodes, 1) {
+		_, hasFailed := result.FailedNodes["node-without-lvg"]
+		assert.True(t, hasFailed, "node-without-lvg must be in FailedNodes with a reason")
+	}
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
@@ -119,14 +119,10 @@ func (s *scheduler) prioritize(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
-	if len(pvcRequests) == 0 {
-		servingLog.Debug("No PVC requests found. Return the same nodes with 0 score")
-		if err := writeNodeScoresResponse(w, servingLog, nodeNames, 0); err != nil {
-			servingLog.Error(err, "unable to write node scores response")
-			http.Error(w, "internal server error", http.StatusInternalServerError)
-		}
-		return
-	}
+	// Mirror of filter: do not short-circuit when len(pvcRequests) == 0. Scoring
+	// always runs so the response is consistent with the filter contract (the
+	// filter never returns "all nodes" for a local PVC; therefore prioritize
+	// must score whatever the scheduler actually passed us).
 	servingLog.Debug("successfully extracted the PVC requested sizes")
 
 	servingLog.Debug("starts to score the nodes for Pod")
@@ -303,7 +299,12 @@ func scoreNodes(
 						volumeAccess = srv.VolumeAccessPreferablyLocal
 					}
 
-					if pvc.Status.Phase == corev1.ClaimBound {
+					// Use Spec.VolumeName, not Status.Phase, to detect binding:
+					// Status.Phase is updated by kube-controller-manager separately
+					// and lags behind binding, so a freshly bound (or freshly created)
+					// PVC may temporarily show an out-of-date phase here. See the
+					// rationale on extractRequestedSize.
+					if pvc.Spec.VolumeName != "" {
 						switch volumeAccess {
 						case srv.VolumeAccessLocal:
 							replicaTotalPVCs++

--- a/images/sds-common-scheduler-extender/pkg/scheduler/replicated.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/replicated.go
@@ -191,7 +191,11 @@ func buildReplicaLocations(
 ) map[string][]string {
 	result := make(map[string][]string, len(replicatedPVCs))
 	for _, pvc := range replicatedPVCs {
-		if pvc.Status.Phase != corev1.ClaimBound {
+		// A PVC is bound iff Spec.VolumeName is set. Status.Phase is updated by
+		// kube-controller-manager separately and may lag behind the binding, so
+		// relying on it is racy when a PVC was just bound (or, conversely, when
+		// it was freshly created and the controller has not yet set Pending).
+		if pvc.Spec.VolumeName == "" {
 			continue
 		}
 		nodes, err := getReplicaNodesForBoundPVC(ctx, cl, pvc)
@@ -284,20 +288,25 @@ func filterNodeForReplicatedPVCs(
 			continue
 		}
 
-		if rsc.Spec.Topology == srv.TopologyZonal && pvc.Status.Phase == corev1.ClaimBound {
+		// Use Spec.VolumeName as the source of truth for "bound" vs "pending".
+		// Status.Phase is set by kube-controller-manager in a separate status
+		// update and lags the binding, so a freshly created PVC may still have
+		// Status.Phase == "" when the extender is consulted. See the comment on
+		// extractRequestedSize for the longer rationale.
+		isBound := pvc.Spec.VolumeName != ""
+
+		if rsc.Spec.Topology == srv.TopologyZonal && isBound {
 			log.Debug(fmt.Sprintf("[filterNodeForReplicatedPVCs] TODO: zone filtering for Zonal topology, pvc=%s", pvc.Name))
 		}
 
-		switch pvc.Status.Phase {
-		case corev1.ClaimPending:
+		if !isBound {
 			if requiresLVGCheck(volumeAccess) {
 				ok, reason := checkNodeHasLVGWithSpaceForReplicated(ctx, log, cl, schedulerCache, nodeName, rsp, pvcReq.RequestedSize)
 				if !ok {
 					failReasons = append(failReasons, fmt.Sprintf("PVC %s: %s", pvc.Name, reason))
 				}
 			}
-
-		case corev1.ClaimBound:
+		} else {
 			switch volumeAccess {
 			case srv.VolumeAccessLocal:
 				replicaNodes, err := getReplicaNodesForBoundPVC(ctx, cl, pvc)


### PR DESCRIPTION
## Description

Fixes a race condition in `sds-common-scheduler-extender` that caused `filter` and `prioritize` to return all incoming nodes for a Pod with a freshly-created local PVC, and hardens the filter so the response can never contain a node without a matching `LVMVolumeGroup` for a local PVC.

Concrete changes in `images/sds-common-scheduler-extender/pkg/scheduler/`:

- `func.go` — `extractRequestedSize` now decides "bound vs pending" from `PVC.Spec.VolumeName` instead of `PVC.Status.Phase`. The diagnostic log line keeps printing both fields.
- `replicated.go` — same `Status.Phase` → `Spec.VolumeName` migration in `buildReplicaLocations` and `filterNodeForReplicatedPVCs` (three sites) for consistency.
- `filter.go` — removed the `"No PVC requests found. Return the same nodes"` early-return; control flow now always reaches `filterNodes` → `findMatchedSCLVG`.
- `prioritize.go` — symmetric cleanup (removed the `"return all nodes with 0 score"` early-return); also migrated the bound-PVC check in the scoring path to `Spec.VolumeName`.
- `func_test.go` — added unit and end-to-end regression tests.

No CRD or API changes. No changes to CSI provisioner code. No critical-cluster-component restarts: only the `sds-common-scheduler-extender` Deployment in `d8-sds-node-configurator` is restarted on rollout.

## Why do we need it, and what problem does it solve?

Observed bug: a Pod with a freshly-created local PVC (StorageClass `local`, provisioner `local.csi.storage.deckhouse.io`) stays `Pending` forever, and the PVC keeps emitting `ProvisioningFailed ... error during SelectLVG` events — even though the cluster does have nodes with an `LVMVolumeGroup` matching the StorageClass.

Root cause:

1. The Pod and PVC are created together (single `kubectl apply`).
2. `kube-scheduler` calls the extender ~1 second later. At that moment `PVC.Status.Phase` is still `""` because `kube-controller-manager` has not yet emitted its status update — `Status.Phase` is set in a separate transaction after the PVC is created.
3. `extractRequestedSize` had a `switch pvc.Status.Phase { case ClaimPending: ...; case ClaimBound: ... }` with no default. An empty phase matched nothing, so the PVC was silently dropped from `pvcRequests`.
4. `filter` and `prioritize` then took the "no PVC requests, return all nodes" / "...with 0 score" branch.
5. `kube-scheduler` picked an arbitrary node (`hv-14` in the report) that has no matching LVG. The CSI provisioner, on receiving the PVC with `volume.kubernetes.io/selected-node=hv-14`, has no way to recover — it cannot reschedule the Pod itself — and fails with `error during SelectLVG`.

Two fixes:

- **`Spec.VolumeName` instead of `Status.Phase`.** `Spec.VolumeName` is set in the same transaction as the binding and matches what the upstream `VolumeBinding` scheduler plugin uses. It is immune to the controller-status-update lag.
- **Defense in depth for local PVCs.** Removing the "return all nodes" fallback locks in the invariant: if `managedPVCs` contains at least one local PVC, the `filter` response is always a subset of nodes that have an LVG matching every local PVC's StorageClass — never all nodes. Even if a future regression makes `extractRequestedSize` return an empty map, `filterNodeForLocalPVCs` still rejects any node without a matching LVG.

## What is the expected result?

After this change, with a freshly-created local PVC and Pod:

- `sds-common-scheduler-extender` filter response MUST be empty `nodenames` + populated `FailedNodes` when no node in the request has a matching LVG, and MUST be the strict subset of input nodes that do have a matching LVG otherwise.
- `sds-common-scheduler-extender` filter response for a Pod with local PVCs MUST NOT contain a node without a matching LVG.
- PVC provisioning MUST NOT fail with `error during SelectLVG` for the original reproducer — the scheduler will pick a node where the local CSI provisioner can actually create the volume.
- The previous diagnostic log line `"[extractRequestedSize] PVC <ns>/<name> has status phase: "` is replaced by a more useful form that prints both fields: `"[extractRequestedSize] PVC <ns>/<name> has status phase: \"\", spec.volumeName: \"\""`.

Pre-existing behavior MUST NOT change for:

- Pods with no managed PVCs (filter still passes all input nodes through).
- Pods with a managed PVC whose StorageClass does not exist (PVC is dropped, remaining nodes are passed through unchanged — `TestFilter_MissingSC_PassesAllNodes` still passes).
- Bound PVCs (online expansion still reports `requested - pv.capacity` as the delta).
- All other existing tests in `pkg/scheduler/` pass without modification.

How to reproduce the original bug on `main` and verify the fix: create a Namespace, a PVC (`storageClassName: local`, `accessModes: [ReadWriteOnce]`, `requests.storage: 100Mi`, `volumeMode: Filesystem`), and a Pod that mounts that PVC — all in a single `kubectl apply`.

- Before: the Pod stays `Pending` and the PVC produces repeated `ProvisioningFailed: error during SelectLVG` events.
- After: the Pod is scheduled to a node that has an LVG matching the `local` StorageClass, the PV is provisioned, and the Pod reaches `Running`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.