### PR TITLE
feat(agent): schedule sds-node-configurator agent on sds-elastic data nodes

### DIFF
--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -69,6 +69,11 @@ spec:
                     operator: In
                     values:
                       - ""
+              - matchExpressions:
+                  - key: storage.deckhouse.io/sds-elastic-node
+                    operator: In
+                    values:
+                      - ""
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
         - name: {{ .Chart.Name }}-module-registry


### PR DESCRIPTION
## Description

Adds a third `nodeSelectorTerm` to the sds-node-configurator agent DaemonSet so it is scheduled on Nodes that carry the `storage.deckhouse.io/sds-elastic-node=""` label, mirroring the existing terms for `storage.deckhouse.io/sds-replicated-volume-node` and `storage.deckhouse.io/sds-local-volume-node`.

```diff
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: storage.deckhouse.io/sds-replicated-volume-node
                    operator: In
                    values:
                      - ""
              - matchExpressions:
                  - key: storage.deckhouse.io/sds-local-volume-node
                    operator: In
                    values:
                      - ""
+             - matchExpressions:
+                 - key: storage.deckhouse.io/sds-elastic-node
+                   operator: In
+                   values:
+                     - ""
```

`nodeSelectorTerms` are OR-ed at scheduling time, so the agent still lands on every Node where at least one of the three storage modules has marked the Node as data-eligible; sds-replicated-volume and sds-local-volume behaviour is unchanged.

This is a chart-only change (single DaemonSet manifest); no Go code, no RBAC, no CRDs are affected. Critical cluster components (control-plane, Prometheus, ingress, etc.) are NOT impacted - only the existing sds-node-configurator DaemonSet may now schedule on additional Nodes (those labelled by sds-elastic) and stop being scheduled on Nodes that lose all three labels.

## Why do we need it, and what problem does it solve?

[`deckhouse/sds-elastic#32`](https://github.com/deckhouse/sds-elastic/pull/32) introduces `settings.dataNodes.nodeSelector` and an in-controller reconciler that maintains the `storage.deckhouse.io/sds-elastic-node=""` label on Nodes that match it. That label is meant to be consumed exactly the same way the existing `sds-replicated-volume-node` / `sds-local-volume-node` labels are:

- sds-node-configurator agent runs on data-eligible Nodes and exposes `BlockDevice` / `LVMVolumeGroup` CRs;
- downstream (Ceph OSD bootstrap, LVG-backed local PVs, sds-elastic ElasticCluster reconcilers) relies on those CRs to know which Nodes can host data.

Without this PR, an sds-elastic data Node that is not also tagged as an sds-replicated-volume or sds-local-volume data Node would not run the sds-node-configurator agent, and sds-elastic would not be able to discover its block devices / LVM topology.

## What is the expected result?

After this change is rolled out together with `deckhouse/sds-elastic#32`:

- On Nodes that match `settings.dataNodes.nodeSelector` of `sds-elastic`, the sds-elastic-controller adds `storage.deckhouse.io/sds-elastic-node=""`; sds-node-configurator's DaemonSet then schedules its agent Pod on those Nodes and emits `BlockDevice` / `LVMVolumeGroup` resources.
- On Nodes that previously hosted the agent only because of `sds-replicated-volume-node` or `sds-local-volume-node`, the agent continues to run unchanged - existing labels still match the first two `nodeSelectorTerms`.
- Nodes that carry NONE of the three labels (the default behaviour for clusters without any of these modules' data-nodes settings) do not run the agent, matching previous behaviour.

How to verify on a live cluster:

1. Install / upgrade `sds-node-configurator` from this PR alongside `sds-elastic#32`.
2. Set `settings.dataNodes.nodeSelector` in the sds-elastic ModuleConfig to match a node that does NOT carry `sds-replicated-volume-node` or `sds-local-volume-node`.
3. Observe `kubectl get nodes -l storage.deckhouse.io/sds-elastic-node=""` lists the expected Node.
4. Observe `kubectl -n d8-sds-node-configurator get pods -l app=sds-node-configurator -o wide` now includes a Pod scheduled on that Node.
5. Observe `kubectl get blockdevices.storage.deckhouse.io` includes the entries for that Node.
6. Clearing `settings.dataNodes.nodeSelector` (or making it not match the Node) removes the label and evicts the agent Pod from that Node on the next DaemonSet reconcile.

## Checklist

- [x] The code is covered by unit tests. (No new Go code; the change is a single chart manifest. Existing chart-rendering / e2e DaemonSet coverage exercises the affinity block.)
- [ ] e2e tests passed. (Pending CI; the change does not modify the DaemonSet's pod-spec, only adds a third OR-ed `nodeSelectorTerm`, so existing e2e on sds-replicated-volume / sds-local-volume Nodes is unaffected.)
- [x] Documentation updated according to the changes. (The label contract is documented module-side in [`deckhouse/sds-elastic#32`](https://github.com/deckhouse/sds-elastic/pull/32), under `docs/USAGE.{md,ru.md}` "Selecting Data Nodes / Выбор data-узлов".)
- [ ] Changes were tested in the Kubernetes cluster manually. (To be done on the dev cluster jointly with `deckhouse/sds-elastic#32`.)