### PR TITLE
E2E Add labels and LVM VG capacity test

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -213,7 +213,7 @@ jobs:
   run_e2e_smoke_tests:
     if: ${{ inputs.run_e2e_smoke_tests == true }}
     name: Run E2E Smoke Tests
-    timeout-minutes: 210
+    timeout-minutes: 240
     runs-on: [self-hosted, regular]
     needs:
       - dev_setup_build
@@ -332,8 +332,8 @@ jobs:
           LOG_LEVEL: ${{ vars.E2E_LOG_LEVEL }}
           # Smoke: all specs with label e2e-tests (excludes stress-test / max-VG ramp).
           E2E_GINKGO_LABEL_FILTER: e2e-tests
-          # BeforeSuite + scheduler + module e2e routinely exceeds 60m on self-hosted CI.
-          E2E_TEST_TIMEOUT: 3h
+          # Ginkgo suite timeout (must be <= go test -timeout below; smoke often exceeds 60m).
+          E2E_TEST_TIMEOUT: 3h30m
         run: |
           mkdir -p "${GOMODCACHE}" "${GOCACHE}"
 
@@ -445,9 +445,11 @@ jobs:
             shopt -u nullglob
           fi
           echo "Ginkgo label filter: ${E2E_GINKGO_LABEL_FILTER} (stress-test specs are skipped in smoke)"
-          E2E_TEST_TIMEOUT="${E2E_TEST_TIMEOUT:-3h}"
-          echo "go test timeout: ${E2E_TEST_TIMEOUT}"
-          go test -v -count=1 -timeout "${E2E_TEST_TIMEOUT}" ./tests/ -run '^TestSdsNodeConfigurator$' \
+          export E2E_TEST_TIMEOUT="${E2E_TEST_TIMEOUT:-3h30m}"
+          # Hardcode go test -timeout: repo/org E2E_TEST_TIMEOUT=60m must not shorten the process alarm.
+          E2E_GO_TEST_TIMEOUT="3h30m"
+          echo "go test -timeout: ${E2E_GO_TEST_TIMEOUT} (Ginkgo suite: ${E2E_TEST_TIMEOUT})"
+          go test -v -count=1 -timeout "${E2E_GO_TEST_TIMEOUT}" ./tests/ -run '^TestSdsNodeConfigurator$' \
             -ginkgo.label-filter="${E2E_GINKGO_LABEL_FILTER}" 2>&1 | tee ../e2e-test-output.log
           TEST_EXIT_CODE=${PIPESTATUS[0]}
           echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -213,6 +213,7 @@ jobs:
   run_e2e_smoke_tests:
     if: ${{ inputs.run_e2e_smoke_tests == true }}
     name: Run E2E Smoke Tests
+    timeout-minutes: 210
     runs-on: [self-hosted, regular]
     needs:
       - dev_setup_build
@@ -329,6 +330,10 @@ jobs:
           E2E_TUNNEL_SSH_JUMP_USER: ${{ secrets.E2E_SSH_JUMP_USER }}
           # Do not set KUBE_CONFIG_PATH here — it is taken from GITHUB_ENV (Setup writes the path to the file from E2E_CLUSTER_KUBECONFIG). Otherwise an empty vars value overwrites the fallback and storage-e2e cannot find kubeconfig when "sudo cat admin.conf" on the master fails.
           LOG_LEVEL: ${{ vars.E2E_LOG_LEVEL }}
+          # Smoke: all specs with label e2e-tests (excludes stress-test / max-VG ramp).
+          E2E_GINKGO_LABEL_FILTER: e2e-tests
+          # BeforeSuite + scheduler + module e2e routinely exceeds 60m on self-hosted CI.
+          E2E_TEST_TIMEOUT: 3h
         run: |
           mkdir -p "${GOMODCACHE}" "${GOCACHE}"
 
@@ -439,7 +444,11 @@ jobs:
             done
             shopt -u nullglob
           fi
-          go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' 2>&1 | tee ../e2e-test-output.log
+          echo "Ginkgo label filter: ${E2E_GINKGO_LABEL_FILTER} (stress-test specs are skipped in smoke)"
+          E2E_TEST_TIMEOUT="${E2E_TEST_TIMEOUT:-3h}"
+          echo "go test timeout: ${E2E_TEST_TIMEOUT}"
+          go test -v -count=1 -timeout "${E2E_TEST_TIMEOUT}" ./tests/ -run '^TestSdsNodeConfigurator$' \
+            -ginkgo.label-filter="${E2E_GINKGO_LABEL_FILTER}" 2>&1 | tee ../e2e-test-output.log
           TEST_EXIT_CODE=${PIPESTATUS[0]}
           echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
           echo "${TEST_EXIT_CODE}" > ../e2e-test-exit-code.txt

--- a/e2e/E2E_USAGE.md
+++ b/e2e/E2E_USAGE.md
@@ -105,6 +105,28 @@ Or run specific test:
 ginkgo -v --progress --focus="Should schedule Pod with local PVC" ./tests/
 ```
 
+### Ginkgo labels (CI / local filter)
+
+Specs are tagged for selective runs:
+
+| Label | Specs |
+|-------|--------|
+| `e2e-tests` | Smoke e2e (scheduler, BlockDevice, LVMVolumeGroup, …) — **default in CI** |
+| `stress-test` | Max independent LVMVolumeGroups per node (`sds_node_configurator_stress_max_vgs_test.go`) |
+
+```bash
+# Smoke only (same as CI default)
+go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=e2e-tests
+
+# Stress only
+go test -v -count=1 -timeout 240m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=stress-test
+
+# Override in CI via env
+export E2E_GINKGO_LABEL_FILTER=stress-test
+```
+
+Focus only: `ginkgo -v --label-filter=stress-test ./tests/`
+
 ### 3. Cluster lock (stale lock)
 
 If a previous run was interrupted (e.g. Ctrl+C) or failed before cleanup, the framework may leave the cluster locked. You will see: `failed to acquire cluster lock: cluster is already locked`.
@@ -167,10 +189,20 @@ storage-e2e checks the Deckhouse `Module/virtualization` once with a short timeo
 | `TEST_CLUSTER_FORCE_LOCK_RELEASE` | No | Set to `true` once to clear a stale lock. |
 | `E2E_VIRTUALIZATION_MODULE_WAIT_TIMEOUT` | No | Max wait for Module `virtualization` Ready before nested cluster create (default ~25m). |
 | `E2E_SKIP_VIRTUALIZATION_MODULE_WAIT` | No | Set to `true` to skip the Module pre-wait (not recommended if you hit Reconciling flakes). |
+| `E2E_GINKGO_LABEL_FILTER` | No | Ginkgo label filter for CI/local (default in workflow: `e2e-tests`). Use `stress-test` for max-VG stress. |
+
+### Stress: maximum VGs per node
+
+Spec **`Stress: maximum independent LVMVolumeGroups per node`** (`sds_node_configurator_stress_max_vgs_test.go`), label **`stress-test`** (excluded from CI smoke; smoke uses **`e2e-tests`**). LVM2 has no fixed VG count limit; the test ramps **one VirtualDisk → one BlockDevice → one LVMVolumeGroup (one VG)** per slot on a single node in batches and prints an empirical report (`Ready` count, on-node `vgs`/`pvs` totals).
+
+Optional tuning: `E2E_STRESS_MAX_VG_TARGET` (default 30), `E2E_STRESS_MAX_VG_BATCH_SIZE`, `E2E_STRESS_MAX_VG_DISK_SIZE`, `E2E_STRESS_MAX_VG_STRICT`, `E2E_STRESS_MAX_VG_MIN_READY`.
+
+Focus or label: `ginkgo -v --label-filter=stress-test ./tests/`
 
 ---
 
 ## See also
 
 - [README.md](README.md) — test scenarios, debugging, troubleshooting.
-- Local runs: `ginkgo -v --progress ./tests/` or `go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$'` (same as CI).
+- Local smoke (same as CI): `make -C e2e test-go` or `go test ... -ginkgo.label-filter=e2e-tests`
+- Full package including stress: `go test ... -ginkgo.label-filter='e2e-tests || stress-test'` or `-ginkgo.label-filter=stress-test` for stress only

--- a/e2e/E2E_USAGE.md
+++ b/e2e/E2E_USAGE.md
@@ -116,7 +116,7 @@ Specs are tagged for selective runs:
 
 ```bash
 # Smoke only (same as CI default)
-go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=e2e-tests
+go test -v -count=1 -timeout 3h ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=e2e-tests
 
 # Stress only
 go test -v -count=1 -timeout 240m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=stress-test
@@ -190,6 +190,7 @@ storage-e2e checks the Deckhouse `Module/virtualization` once with a short timeo
 | `E2E_VIRTUALIZATION_MODULE_WAIT_TIMEOUT` | No | Max wait for Module `virtualization` Ready before nested cluster create (default ~25m). |
 | `E2E_SKIP_VIRTUALIZATION_MODULE_WAIT` | No | Set to `true` to skip the Module pre-wait (not recommended if you hit Reconciling flakes). |
 | `E2E_GINKGO_LABEL_FILTER` | No | Ginkgo label filter for CI/local (default in workflow: `e2e-tests`). Use `stress-test` for max-VG stress. |
+| `E2E_TEST_TIMEOUT` | No | `go test -timeout` and Ginkgo suite timeout (CI default `3h`, local default `90m`). Example: `2h30m`. |
 
 ### Stress: maximum VGs per node
 

--- a/e2e/E2E_USAGE.md
+++ b/e2e/E2E_USAGE.md
@@ -118,7 +118,7 @@ Without `-ginkgo.label-filter`, `TestSdsNodeConfigurator` applies label filter `
 
 ```bash
 # Smoke only (same as CI default)
-go test -v -count=1 -timeout 3h ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=e2e-tests
+go test -v -count=1 -timeout 3h30m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=e2e-tests
 
 # Stress only
 go test -v -count=1 -timeout 240m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=stress-test
@@ -192,7 +192,7 @@ storage-e2e checks the Deckhouse `Module/virtualization` once with a short timeo
 | `E2E_VIRTUALIZATION_MODULE_WAIT_TIMEOUT` | No | Max wait for Module `virtualization` Ready before nested cluster create (default ~25m). |
 | `E2E_SKIP_VIRTUALIZATION_MODULE_WAIT` | No | Set to `true` to skip the Module pre-wait (not recommended if you hit Reconciling flakes). |
 | `E2E_GINKGO_LABEL_FILTER` | No | Ginkgo label filter for CI/local (default in workflow: `e2e-tests`). Use `stress-test` for max-VG stress. |
-| `E2E_TEST_TIMEOUT` | No | `go test -timeout` and Ginkgo suite timeout (CI default `3h`, local default `90m`). Example: `2h30m`. |
+| `E2E_TEST_TIMEOUT` | No | Ginkgo suite timeout only on CI (default `3h30m`). CI workflow uses a **fixed** `go test -timeout 3h30m` so org/repo vars cannot shorten it to `60m`. Local default `90m`. |
 
 ### Stress: maximum VGs per node
 

--- a/e2e/E2E_USAGE.md
+++ b/e2e/E2E_USAGE.md
@@ -95,14 +95,14 @@ From the repo root:
 source e2e/config/test_exports_storage_e2e
 cd e2e
 go mod tidy
-ginkgo -v --progress ./tests/
+ginkgo -v --progress --label-filter=e2e-tests ./tests/
 ```
 
 Or run specific test:
 
 ```bash
 # Ginkgo focus on a spec name; CI runs: go test ./tests/ -run '^TestSdsNodeConfigurator$'
-ginkgo -v --progress --focus="Should schedule Pod with local PVC" ./tests/
+ginkgo -v --progress --label-filter=e2e-tests --focus="Should schedule Pod with local PVC" ./tests/
 ```
 
 ### Ginkgo labels (CI / local filter)
@@ -111,8 +111,10 @@ Specs are tagged for selective runs:
 
 | Label | Specs |
 |-------|--------|
-| `e2e-tests` | Smoke e2e (scheduler, BlockDevice, LVMVolumeGroup, …) — **default in CI** |
-| `stress-test` | Max independent LVMVolumeGroups per node (`sds_node_configurator_stress_max_vgs_test.go`) |
+| `e2e-tests` | Smoke e2e (scheduler, BlockDevice, LVMVolumeGroup, …) — **default** (suite, CI, `make test`) |
+| `stress-test` | Max independent LVMVolumeGroups per node — **not run by default** |
+
+Without `-ginkgo.label-filter`, `TestSdsNodeConfigurator` applies label filter `e2e-tests` automatically. Stress runs only with `make test-stress`, `-ginkgo.label-filter=stress-test`, or `E2E_GINKGO_LABEL_FILTER=stress-test`. Full package: `E2E_GINKGO_LABEL_FILTER='e2e-tests || stress-test'` or `E2E_GINKGO_LABEL_FILTER=all`.
 
 ```bash
 # Smoke only (same as CI default)
@@ -136,7 +138,7 @@ To release the lock once (only when no other run is using the cluster):
 ```bash
 export TEST_CLUSTER_FORCE_LOCK_RELEASE='true'
 source e2e/config/test_exports_storage_e2e
-cd e2e && ginkgo -v --progress ./tests/
+cd e2e && ginkgo -v --progress --label-filter=e2e-tests ./tests/
 ```
 
 For `alwaysUseExisting`, this suite retries once after clearing a stale lock: first it tries deleting ConfigMap `default/e2e-cluster-lock` via `KUBE_CONFIG_PATH` (works when the API URL is reachable directly). If that fails (common when `server` is `https://127.0.0.1:…` and no tunnel is running yet), it opens the same SSH + port-forward as the test connect and releases the lock. Disable with `E2E_NO_CLUSTER_LOCK_RETRY=true` (e.g. shared cluster).
@@ -196,7 +198,7 @@ storage-e2e checks the Deckhouse `Module/virtualization` once with a short timeo
 
 Spec **`Stress: maximum independent LVMVolumeGroups per node`** (`sds_node_configurator_stress_max_vgs_test.go`), label **`stress-test`** (excluded from CI smoke; smoke uses **`e2e-tests`**). LVM2 has no fixed VG count limit; the test ramps **one VirtualDisk → one BlockDevice → one LVMVolumeGroup (one VG)** per slot on a single node in batches and prints an empirical report (`Ready` count, on-node `vgs`/`pvs` totals).
 
-Optional tuning: `E2E_STRESS_MAX_VG_TARGET` (default 30), `E2E_STRESS_MAX_VG_BATCH_SIZE`, `E2E_STRESS_MAX_VG_DISK_SIZE`, `E2E_STRESS_MAX_VG_STRICT`, `E2E_STRESS_MAX_VG_MIN_READY`.
+Optional tuning: `E2E_STRESS_MAX_VG_TARGET` (default 15), `E2E_STRESS_MAX_VM_BLOCK_DEVICES` (default 15; Deckhouse virt allows 16 block devices per VM), `E2E_STRESS_MAX_VG_BATCH_SIZE`, `E2E_STRESS_MAX_VG_DISK_SIZE`, `E2E_STRESS_MAX_VG_STRICT`, `E2E_STRESS_MAX_VG_MIN_READY`. The ramp stops gracefully when the VM attachment limit is hit.
 
 Focus or label: `ginkgo -v --label-filter=stress-test ./tests/`
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -44,6 +44,7 @@ cleanup: ## Delete Job and RBAC
 # CI smoke uses label e2e-tests (everything except max-VG stress). Override: make test-go GINKGO_LABEL_FILTER=stress-test
 GINKGO_LABEL_FILTER ?= e2e-tests
 E2E_TEST_TIMEOUT ?= 90m
+# CI workflow uses go test -timeout 3h30m regardless of this var.
 
 .PHONY: test
 test: ## Run E2E smoke (label e2e-tests, без max-VG stress) — как CI

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -41,14 +41,22 @@ cleanup: ## Delete Job and RBAC
 	kubectl delete -f manifests/rbac.yaml --ignore-not-found
 
 # === Local run ===
+# CI smoke uses label e2e-tests (everything except max-VG stress). Override: make test-go GINKGO_LABEL_FILTER=stress-test
+GINKGO_LABEL_FILTER ?= e2e-tests
 
 .PHONY: test
-test: ## Run full E2E suite (TestSdsNodeConfigurator — все Ginkgo-спеки в пакете)
-	go test -v -count=1 -timeout 60m ./tests/
+test: ## Run E2E smoke (label e2e-tests, без max-VG stress) — как CI
+	$(MAKE) test-go
 
 .PHONY: test-go
-test-go: ## Как в CI smoke: только TestSdsNodeConfigurator (Common Scheduler, затем Sds Node Configurator)
-	go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$$'
+test-go: ## Как в CI smoke: TestSdsNodeConfigurator + -ginkgo.label-filter=e2e-tests
+	go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$$' \
+		-ginkgo.label-filter="$(GINKGO_LABEL_FILTER)"
+
+.PHONY: test-stress
+test-stress: ## Только max-VG stress (label stress-test)
+	go test -v -count=1 -timeout 240m ./tests/ -run '^TestSdsNodeConfigurator$$' \
+		-ginkgo.label-filter=stress-test
 
 .PHONY: test-focus
 test-focus: ## Run by test name (make test-focus FOCUS="TestSdsNodeConfigurator")

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -65,7 +65,8 @@ test-focus: ## Run by test name (make test-focus FOCUS="TestSdsNodeConfigurator"
 		echo "Error: specify FOCUS=<test name>"; \
 		exit 1; \
 	fi
-	go test -v -count=1 -timeout 60m ./tests/ -run "$(FOCUS)"
+	go test -v -count=1 -timeout 60m ./tests/ -run "$(FOCUS)" \
+		-ginkgo.label-filter="$(GINKGO_LABEL_FILTER)"
 
 .PHONY: install-ginkgo
 install-ginkgo: ## Install Ginkgo CLI

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -43,6 +43,7 @@ cleanup: ## Delete Job and RBAC
 # === Local run ===
 # CI smoke uses label e2e-tests (everything except max-VG stress). Override: make test-go GINKGO_LABEL_FILTER=stress-test
 GINKGO_LABEL_FILTER ?= e2e-tests
+E2E_TEST_TIMEOUT ?= 90m
 
 .PHONY: test
 test: ## Run E2E smoke (label e2e-tests, без max-VG stress) — как CI
@@ -50,7 +51,7 @@ test: ## Run E2E smoke (label e2e-tests, без max-VG stress) — как CI
 
 .PHONY: test-go
 test-go: ## Как в CI smoke: TestSdsNodeConfigurator + -ginkgo.label-filter=e2e-tests
-	go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$$' \
+	go test -v -count=1 -timeout "$(E2E_TEST_TIMEOUT)" ./tests/ -run '^TestSdsNodeConfigurator$$' \
 		-ginkgo.label-filter="$(GINKGO_LABEL_FILTER)"
 
 .PHONY: test-stress

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -29,6 +29,7 @@ e2e/
     ├── sds_node_configurator_suite_test.go  # TestSdsNodeConfigurator, BeforeSuite/AfterSuite (storage-e2e)
     ├── e2e_cluster_lock_test.go  # lock retry / очистка lock для alwaysUseExisting
     ├── sds_node_configurator_test.go  # один корневой Ordered: Common Scheduler Extender, затем Sds Node Configurator; хелперы
+    ├── sds_node_configurator_stress_max_vgs_test.go  # stress: макс. число VG на одной ноде
     └── cluster_config.yml     # вложенный кластер (storage-e2e)
 ```
 
@@ -97,6 +98,10 @@ ginkgo -v --progress --focus="Should schedule Pod with local PVC" ./tests/
 
 - **BlockDevice discovery**: появление диска; корректные `status.nodeName`, `status.path`, `status.size`, `consumable`.
 - **LVMVolumeGroup**: создание на основе BlockDevice, статус и capacity.
+
+### Stress: максимум VG на одной ноде
+
+Spec в `sds_node_configurator_stress_max_vgs_test.go`, Ginkgo-лейбл **`stress-test`** (остальные e2e — **`e2e-tests`**). CI smoke по умолчанию: `-ginkgo.label-filter=e2e-tests`. Подробнее — [E2E_USAGE.md](E2E_USAGE.md).
 
 ### Common Scheduler Extender
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -78,8 +78,8 @@ go test -v -count=1 -timeout 3h ./tests/ -run '^TestSdsNodeConfigurator$' -ginkg
 Альтернатива через [Ginkgo CLI](https://github.com/onsi/ginkgo):
 
 ```bash
-ginkgo -v --progress ./tests/
-ginkgo -v --progress --focus="Should schedule Pod with local PVC" ./tests/
+ginkgo -v --progress --label-filter=e2e-tests ./tests/
+ginkgo -v --progress --label-filter=e2e-tests --focus="Should schedule Pod with local PVC" ./tests/
 ```
 
 ## Тестовые сценарии

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -72,7 +72,7 @@ make test-focus FOCUS="TestSdsNodeConfigurator"
 Один вход, как в CI по label `e2e-smoke-test`: `TestSdsNodeConfigurator` — сначала **Common Scheduler Extender**, затем **Sds Node Configurator** (вложенные `Describe(..., Ordered)` в одном файле `sds_node_configurator_test.go`, внешний `Describe` тоже `Ordered`).
 
 ```bash
-go test -v -count=1 -timeout 60m ./tests/ -run '^TestSdsNodeConfigurator$'
+go test -v -count=1 -timeout 3h ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=e2e-tests
 ```
 
 Альтернатива через [Ginkgo CLI](https://github.com/onsi/ginkgo):

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -72,7 +72,7 @@ make test-focus FOCUS="TestSdsNodeConfigurator"
 Один вход, как в CI по label `e2e-smoke-test`: `TestSdsNodeConfigurator` — сначала **Common Scheduler Extender**, затем **Sds Node Configurator** (вложенные `Describe(..., Ordered)` в одном файле `sds_node_configurator_test.go`, внешний `Describe` тоже `Ordered`).
 
 ```bash
-go test -v -count=1 -timeout 3h ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=e2e-tests
+go test -v -count=1 -timeout 3h30m ./tests/ -run '^TestSdsNodeConfigurator$' -ginkgo.label-filter=e2e-tests
 ```
 
 Альтернатива через [Ginkgo CLI](https://github.com/onsi/ginkgo):

--- a/e2e/manifests/job.yaml
+++ b/e2e/manifests/job.yaml
@@ -14,6 +14,8 @@ spec:
         - name: e2e-tests
           image: ${E2E_IMAGE}
           env:
+            - name: E2E_GINKGO_LABEL_FILTER
+              value: "e2e-tests"
             - name: TEST_CLUSTER_CREATE_MODE
               value: "alwaysUseExisting"
             - name: TEST_CLUSTER_NAMESPACE

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -36,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Block device stability with explicit lifecycle stages", Ordered, func() {
+var _ = Describe("Block device stability with explicit lifecycle stages", Label("e2e-tests"), Ordered, func() {
 	var (
 		ctx       context.Context
 		res       *cluster.TestClusterResources
@@ -73,13 +74,23 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Ordere
 			targetVM = vm
 			break
 		}
+		Expect(targetVM).NotTo(BeEmpty(), "need a non-bootstrap VM for block device stability test")
 
-		By("Attaching a virtual disk to the target VM")
+		ns := conf.TestCluster.Namespace
+		// Fixed names from older runs / interrupted AfterAll — detach best-effort before create.
+		for _, legacy := range []struct{ disk, att string }{
+			{"block-device-stable-readable", "block-device-stable-readable-attachment"},
+		} {
+			_ = kubernetes.DetachAndDeleteVirtualDisk(ctx, res.BaseKubeconfig, ns, legacy.att, legacy.disk)
+		}
+
+		diskName := fmt.Sprintf("e2e-bd-stable-%d", time.Now().Unix())
+		By("Attaching a virtual disk to the target VM: " + diskName)
 		attachResult, attachErr := kubernetes.AttachVirtualDiskToVM(ctx, res.BaseKubeconfig,
 			kubernetes.VirtualDiskAttachmentConfig{
 				VMName:           targetVM,
-				Namespace:        conf.TestCluster.Namespace,
-				DiskName:         "block-device-stable-readable",
+				Namespace:        ns,
+				DiskName:         diskName,
 				DiskSize:         "5Gi",
 				StorageClassName: conf.TestCluster.StorageClass,
 			})

--- a/e2e/tests/netlink_discovery_test.go
+++ b/e2e/tests/netlink_discovery_test.go
@@ -47,7 +47,7 @@ const (
 	netlinkChangeEventLogPattern = `(?i)\[HandleEvent\].*udev event.*action=change`
 )
 
-var _ = Describe("BlockDevice netlink discovery", Ordered, ContinueOnFailure, func() {
+var _ = Describe("BlockDevice netlink discovery", Label("e2e-tests"), Ordered, ContinueOnFailure, func() {
 	var (
 		testClusterResources *cluster.TestClusterResources
 		k8sClient            client.Client

--- a/e2e/tests/sds_node_configurator_helpers_cleanup_scheduler_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_cleanup_scheduler_test.go
@@ -197,42 +197,58 @@ func e2eForceDeleteLocalStorageClass(ctx context.Context, dynClient dynamic.Inte
 	}
 	obj.SetFinalizers(nil)
 	if _, err := dynClient.Resource(localStorageClassGVR).Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
-		GinkgoWriter.Printf("force delete LSC %s: update finalizers: %v\n", name, err)
+		GinkgoWriter.Printf("force delete LSC %s: clear finalizers: %v\n", name, err)
 	}
-	_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, name, metav1.DeleteOptions{})
+	propagation := metav1.DeletePropagationForeground
+	_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, name, metav1.DeleteOptions{
+		PropagationPolicy: &propagation,
+	})
 }
 
 // ensureE2ELocalStorageClassAbsent deletes e2e-local-sc (and matching StorageClass) and waits until gone.
 // Needed when a prior run left LocalStorageClass in Terminating ("already exists" on recreate).
-func ensureE2ELocalStorageClassAbsent(ctx context.Context, kubeconfig *rest.Config, k8sCl client.Client, name string) {
+func ensureE2ELocalStorageClassAbsent(ctx context.Context, kubeconfig *rest.Config, k8sCl client.Client, name string) error {
 	dynClient, err := dynamic.NewForConfig(kubeconfig)
 	if err != nil {
-		GinkgoWriter.Printf("ensure LSC absent: dynamic client: %v\n", err)
-		return
+		return fmt.Errorf("dynamic client: %w", err)
 	}
 
-	if _, err := dynClient.Resource(localStorageClassGVR).Get(ctx, name, metav1.GetOptions{}); err == nil {
-		GinkgoWriter.Printf("Deleting LocalStorageClass %s before recreate\n", name)
-		_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, name, metav1.DeleteOptions{})
+	propagation := metav1.DeletePropagationForeground
+	deleteOpts := metav1.DeleteOptions{PropagationPolicy: &propagation}
+
+	obj, getErr := dynClient.Resource(localStorageClassGVR).Get(ctx, name, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(getErr):
+		// gone
+	case getErr != nil:
+		return fmt.Errorf("get LocalStorageClass %s: %w", name, getErr)
+	default:
+		if obj.GetDeletionTimestamp() == nil {
+			GinkgoWriter.Printf("Deleting LocalStorageClass %s before recreate\n", name)
+			_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, name, deleteOpts)
+		} else {
+			GinkgoWriter.Printf("Waiting for LocalStorageClass %s to finish deleting\n", name)
+		}
 	}
-	if err := waitForLocalStorageClassDeleted(ctx, dynClient, name, 3*time.Minute); err != nil {
-		GinkgoWriter.Printf("ensure LSC absent: %v; force deleting\n", err)
+
+	if err := waitForLocalStorageClassDeleted(ctx, dynClient, name, 5*time.Minute); err != nil {
+		GinkgoWriter.Printf("ensure LSC absent: %v; force deleting %s\n", err, name)
 		e2eForceDeleteLocalStorageClass(ctx, dynClient, name)
-		_ = waitForLocalStorageClassDeleted(ctx, dynClient, name, time.Minute)
+		if err2 := waitForLocalStorageClassDeleted(ctx, dynClient, name, 2*time.Minute); err2 != nil {
+			return fmt.Errorf("LocalStorageClass %s still present after force delete: %w", name, err2)
+		}
 	}
 
-	if k8sCl == nil {
-		return
+	if k8sCl != nil {
+		var sc storagev1.StorageClass
+		if err := k8sCl.Get(ctx, client.ObjectKey{Name: name}, &sc); err == nil {
+			GinkgoWriter.Printf("Deleting leftover StorageClass %s\n", name)
+			_ = client.IgnoreNotFound(k8sCl.Delete(ctx, &sc))
+		} else if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("get StorageClass %s: %w", name, err)
+		}
 	}
-	var sc storagev1.StorageClass
-	if err := k8sCl.Get(ctx, client.ObjectKey{Name: name}, &sc); apierrors.IsNotFound(err) {
-		return
-	} else if err != nil {
-		GinkgoWriter.Printf("ensure LSC absent: get StorageClass %s: %v\n", name, err)
-		return
-	}
-	GinkgoWriter.Printf("Deleting leftover StorageClass %s\n", name)
-	_ = client.IgnoreNotFound(k8sCl.Delete(ctx, &sc))
+	return nil
 }
 
 func cleanupE2ELocalStorageClasses(ctx context.Context, kubeconfig *rest.Config) {

--- a/e2e/tests/sds_node_configurator_helpers_cleanup_scheduler_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_cleanup_scheduler_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -168,6 +169,72 @@ func ensureSchedulerE2EK8sClient(resources *cluster.TestClusterResources, k8s *c
 	cleanupE2EPVCs(ctx, *k8s)
 }
 
+func waitForLocalStorageClassDeleted(ctx context.Context, dynClient dynamic.Interface, name string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_, err := dynClient.Resource(localStorageClassGVR).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for LocalStorageClass %s to be deleted", name)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func e2eForceDeleteLocalStorageClass(ctx context.Context, dynClient dynamic.Interface, name string) {
+	obj, err := dynClient.Resource(localStorageClassGVR).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		GinkgoWriter.Printf("force delete LSC %s: get: %v\n", name, err)
+		return
+	}
+	obj.SetFinalizers(nil)
+	if _, err := dynClient.Resource(localStorageClassGVR).Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+		GinkgoWriter.Printf("force delete LSC %s: update finalizers: %v\n", name, err)
+	}
+	_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+// ensureE2ELocalStorageClassAbsent deletes e2e-local-sc (and matching StorageClass) and waits until gone.
+// Needed when a prior run left LocalStorageClass in Terminating ("already exists" on recreate).
+func ensureE2ELocalStorageClassAbsent(ctx context.Context, kubeconfig *rest.Config, k8sCl client.Client, name string) {
+	dynClient, err := dynamic.NewForConfig(kubeconfig)
+	if err != nil {
+		GinkgoWriter.Printf("ensure LSC absent: dynamic client: %v\n", err)
+		return
+	}
+
+	if _, err := dynClient.Resource(localStorageClassGVR).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		GinkgoWriter.Printf("Deleting LocalStorageClass %s before recreate\n", name)
+		_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, name, metav1.DeleteOptions{})
+	}
+	if err := waitForLocalStorageClassDeleted(ctx, dynClient, name, 3*time.Minute); err != nil {
+		GinkgoWriter.Printf("ensure LSC absent: %v; force deleting\n", err)
+		e2eForceDeleteLocalStorageClass(ctx, dynClient, name)
+		_ = waitForLocalStorageClassDeleted(ctx, dynClient, name, time.Minute)
+	}
+
+	if k8sCl == nil {
+		return
+	}
+	var sc storagev1.StorageClass
+	if err := k8sCl.Get(ctx, client.ObjectKey{Name: name}, &sc); apierrors.IsNotFound(err) {
+		return
+	} else if err != nil {
+		GinkgoWriter.Printf("ensure LSC absent: get StorageClass %s: %v\n", name, err)
+		return
+	}
+	GinkgoWriter.Printf("Deleting leftover StorageClass %s\n", name)
+	_ = client.IgnoreNotFound(k8sCl.Delete(ctx, &sc))
+}
+
 func cleanupE2ELocalStorageClasses(ctx context.Context, kubeconfig *rest.Config) {
 	dynClient, err := dynamic.NewForConfig(kubeconfig)
 	if err != nil {
@@ -181,9 +248,16 @@ func cleanupE2ELocalStorageClasses(ctx context.Context, kubeconfig *rest.Config)
 	}
 
 	for _, item := range lscList.Items {
-		if strings.HasPrefix(item.GetName(), "e2e-") {
-			GinkgoWriter.Printf("Deleting LocalStorageClass %s\n", item.GetName())
-			_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, item.GetName(), metav1.DeleteOptions{})
+		if !strings.HasPrefix(item.GetName(), "e2e-") {
+			continue
+		}
+		name := item.GetName()
+		GinkgoWriter.Printf("Deleting LocalStorageClass %s\n", name)
+		_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, name, metav1.DeleteOptions{})
+		if err := waitForLocalStorageClassDeleted(ctx, dynClient, name, 3*time.Minute); err != nil {
+			GinkgoWriter.Printf("  %v; force deleting\n", err)
+			e2eForceDeleteLocalStorageClass(ctx, dynClient, name)
+			_ = waitForLocalStorageClassDeleted(ctx, dynClient, name, time.Minute)
 		}
 	}
 }

--- a/e2e/tests/sds_node_configurator_helpers_cleanup_scheduler_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_cleanup_scheduler_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -774,8 +775,16 @@ func countE2EPVCsDefault(ctx context.Context, cl client.Client) int {
 	return n
 }
 
-// countE2ERelatedPVs returns PVs still present for e2e local volumes (same StorageClass as scheduler tests).
-// PVC objects can be gone while PV is still Terminating — CSI must detach before LVMLogicalVolume can be removed safely.
+func isE2ERelatedPV(pv *corev1.PersistentVolume) bool {
+	if pv.Spec.StorageClassName == e2eLocalStorageClassName {
+		return true
+	}
+	if ref := pv.Spec.ClaimRef; ref != nil && ref.Namespace == metav1.NamespaceDefault &&
+		strings.HasPrefix(ref.Name, e2ePVCPrefix) {
+		return true
+	}
+	return false
+}
 
 // countE2ERelatedPVs returns PVs still present for e2e local volumes (same StorageClass as scheduler tests).
 // PVC objects can be gone while PV is still Terminating — CSI must detach before LVMLogicalVolume can be removed safely.
@@ -787,17 +796,83 @@ func countE2ERelatedPVs(ctx context.Context, cl client.Client) int {
 	}
 	n := 0
 	for i := range list.Items {
-		pv := &list.Items[i]
-		if pv.Spec.StorageClassName == e2eLocalStorageClassName {
-			n++
-			continue
-		}
-		if ref := pv.Spec.ClaimRef; ref != nil && ref.Namespace == metav1.NamespaceDefault &&
-			strings.HasPrefix(ref.Name, e2ePVCPrefix) {
+		if isE2ERelatedPV(&list.Items[i]) {
 			n++
 		}
 	}
 	return n
+}
+
+func e2eSchedulerPVDeleteTimeoutDuration() time.Duration {
+	if os.Getenv("CI") != "" {
+		return 40 * time.Minute
+	}
+	return e2eSchedulerPVDeleteTimeout
+}
+
+func logSampleStuckE2EPVs(ctx context.Context, cl client.Client, max int) {
+	var list corev1.PersistentVolumeList
+	if err := cl.List(ctx, &list); err != nil {
+		return
+	}
+	logged := 0
+	for i := range list.Items {
+		pv := &list.Items[i]
+		if !isE2ERelatedPV(pv) {
+			continue
+		}
+		deletingFor := "—"
+		if pv.DeletionTimestamp != nil {
+			deletingFor = time.Since(pv.DeletionTimestamp.Time).Round(time.Second).String()
+		}
+		GinkgoWriter.Printf("  e2e PV %s phase=%s claim=%s deletingFor=%s finalizers=%v\n",
+			pv.Name, pv.Status.Phase, pv.Spec.ClaimRef, deletingFor, pv.Finalizers)
+		logged++
+		if logged >= max {
+			break
+		}
+	}
+}
+
+// forceFinalizeStuckE2EPVs issues Delete on lingering PVs and strips finalizers when CSI delete stalls.
+func forceFinalizeStuckE2EPVs(ctx context.Context, cl client.Client) int {
+	var list corev1.PersistentVolumeList
+	if err := cl.List(ctx, &list); err != nil {
+		GinkgoWriter.Printf("list e2e PVs for force finalize: %v\n", err)
+		return 0
+	}
+	finalized := 0
+	for i := range list.Items {
+		pv := &list.Items[i]
+		if !isE2ERelatedPV(pv) {
+			continue
+		}
+		if pv.DeletionTimestamp == nil {
+			if err := cl.Delete(ctx, pv); err != nil && !apierrors.IsNotFound(err) {
+				GinkgoWriter.Printf("delete PV %s: %v\n", pv.Name, err)
+			}
+			continue
+		}
+		var fresh corev1.PersistentVolume
+		if err := cl.Get(ctx, client.ObjectKeyFromObject(pv), &fresh); err != nil {
+			if !apierrors.IsNotFound(err) {
+				GinkgoWriter.Printf("get PV %s for force finalize: %v\n", pv.Name, err)
+			}
+			continue
+		}
+		if len(fresh.Finalizers) == 0 {
+			continue
+		}
+		fresh.Finalizers = nil
+		if err := cl.Update(ctx, &fresh); err != nil && !apierrors.IsNotFound(err) {
+			GinkgoWriter.Printf("strip finalizers on PV %s: %v\n", fresh.Name, err)
+			continue
+		}
+		deletingFor := time.Since(fresh.DeletionTimestamp.Time).Round(time.Second)
+		GinkgoWriter.Printf("Force-finalized stuck PV %s (phase=%s, deletingFor=%s)\n", fresh.Name, fresh.Status.Phase, deletingFor)
+		finalized++
+	}
+	return finalized
 }
 
 // cleanupE2EPodsAndPVCsWithWait deletes e2e Pods first and waits until they are gone before deleting PVCs.
@@ -811,9 +886,15 @@ func cleanupE2EPodsAndPVCsWithWait(ctx context.Context, cl client.Client, podPha
 
 	cleanupE2EPVCs(ctx, cl)
 	pvDeadline := time.Now().Add(pvPhaseTimeout)
+	lastPVCount := -1
+	lastPVProgress := time.Now()
+	lastPVDetailLog := time.Time{}
 	for time.Now().Before(pvDeadline) {
 		if countE2EPodsDefault(ctx, cl) > 0 {
 			cleanupE2EPods(ctx, cl)
+		}
+		if countE2EPVCsDefault(ctx, cl) > 0 {
+			cleanupE2EPVCs(ctx, cl)
 		}
 		podCount := countE2EPodsDefault(ctx, cl)
 		pvcCount := countE2EPVCsDefault(ctx, cl)
@@ -822,8 +903,28 @@ func cleanupE2EPodsAndPVCsWithWait(ctx context.Context, cl client.Client, podPha
 			GinkgoWriter.Println("All e2e Pods, PVCs, and related PVs deleted")
 			return
 		}
-		GinkgoWriter.Printf("Waiting for cleanup: %d pods, %d PVCs, %d PVs remaining\n", podCount, pvcCount, pvCount)
+		if pvCount < lastPVCount {
+			lastPVProgress = time.Now()
+		}
+		lastPVCount = pvCount
+		if pvCount > 0 && time.Since(lastPVProgress) >= 3*time.Minute {
+			if forceFinalizeStuckE2EPVs(ctx, cl) > 0 {
+				lastPVProgress = time.Now()
+			}
+		}
+		if pvCount > 0 && time.Since(lastPVDetailLog) >= e2ePodCleanupLogStuckInterval {
+			GinkgoWriter.Printf("Waiting for cleanup: %d pods, %d PVCs, %d PVs remaining (sample PVs):\n", podCount, pvcCount, pvCount)
+			logSampleStuckE2EPVs(ctx, cl, 5)
+			lastPVDetailLog = time.Now()
+		} else {
+			GinkgoWriter.Printf("Waiting for cleanup: %d pods, %d PVCs, %d PVs remaining\n", podCount, pvcCount, pvCount)
+		}
 		time.Sleep(5 * time.Second)
+	}
+	if n := countE2ERelatedPVs(ctx, cl); n > 0 {
+		GinkgoWriter.Printf("PV cleanup deadline reached with %d e2e PVs left; forcing removal\n", n)
+		forceFinalizeStuckE2EPVs(ctx, cl)
+		logSampleStuckE2EPVs(ctx, cl, 10)
 	}
 	GinkgoWriter.Println("Warning: some e2e Pods/PVCs/PVs may still exist after cleanup timeout")
 }
@@ -910,7 +1011,7 @@ func schedulerVolumeSizesForConsolidatedFill(currentAvailable, maxPerLVG, prefer
 // or LVMVolumeGroup teardown hits "Delete used LVs first" and PV can stay Released with no PVC.
 // Pods/PVCs are deleted without stripping finalizers; wait for PVs before LLV so CSI does not race with LVMLogicalVolume deletion.
 func schedulerCleanupWorkloadBeforeNextFill(ctx context.Context, cl client.Client) {
-	cleanupE2EPodsAndPVCsWithWait(ctx, cl, e2eSchedulerPodCleanupTimeout, e2eSchedulerPVDeleteTimeout)
+	cleanupE2EPodsAndPVCsWithWait(ctx, cl, e2eSchedulerPodCleanupTimeout, e2eSchedulerPVDeleteTimeoutDuration())
 	// If cleanupE2EPodsAndPVCsWithWait hit its deadline, PVs can remain Released while CSI waits for detach/delete.
 	// Deleting LVMLogicalVolume CRs in that window makes the provisioner error (LLV not found) and leaves PV stuck.
 	n := countE2ERelatedPVs(ctx, cl)

--- a/e2e/tests/sds_node_configurator_helpers_core_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_core_test.go
@@ -153,6 +153,10 @@ const (
 	e2eSuitePodPVCleanupPodTimeout = 2 * time.Minute
 	e2eSuitePodPVCleanupPVTimeout  = 15 * time.Minute
 
+	// Full smoke suite (BeforeSuite cluster + scheduler + module e2e) exceeds 60m on CI; override via E2E_TEST_TIMEOUT.
+	e2eTestTimeoutDefaultLocal = 90 * time.Minute
+	e2eTestTimeoutDefaultCI    = 3 * time.Hour
+
 	// Guest VM name prefix for dhctl/bootstrap (Deckhouse test clusters). Do not attach data disks here — not a worker.
 	e2eBootstrapGuestVMPrefix = "bootstrap-node-"
 )
@@ -248,6 +252,19 @@ func e2eConfigRegistryDockerCfg() string {
 }
 
 func e2eConfigTestClusterCreateMode() string { return os.Getenv("TEST_CLUSTER_CREATE_MODE") }
+
+// e2eTestSuiteTimeout is the Ginkgo suite / go test -timeout budget for TestSdsNodeConfigurator.
+func e2eTestSuiteTimeout() time.Duration {
+	if v := strings.TrimSpace(os.Getenv("E2E_TEST_TIMEOUT")); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	if os.Getenv("CI") != "" {
+		return e2eTestTimeoutDefaultCI
+	}
+	return e2eTestTimeoutDefaultLocal
+}
 
 // Stress e2e: many independent LVMVolumeGroups (1 PV = 1 VG) on one node.
 const (

--- a/e2e/tests/sds_node_configurator_helpers_core_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_core_test.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -247,6 +248,74 @@ func e2eConfigRegistryDockerCfg() string {
 }
 
 func e2eConfigTestClusterCreateMode() string { return os.Getenv("TEST_CLUSTER_CREATE_MODE") }
+
+// Stress e2e: many independent LVMVolumeGroups (1 PV = 1 VG) on one node.
+const (
+	e2eStressMaxVGTargetEnv       = "E2E_STRESS_MAX_VG_TARGET"
+	e2eStressMaxVGDiskSizeEnv     = "E2E_STRESS_MAX_VG_DISK_SIZE"
+	e2eStressMaxVGBatchSizeEnv    = "E2E_STRESS_MAX_VG_BATCH_SIZE"
+	e2eStressMaxVGStrictEnv       = "E2E_STRESS_MAX_VG_STRICT"
+	e2eStressMaxVGMinReadyEnv     = "E2E_STRESS_MAX_VG_MIN_READY"
+	e2eStressMaxVGDefaultTarget   = 30
+	e2eStressMaxVGDefaultBatch    = 5
+	e2eStressMaxVGDefaultDiskSize = "1Gi"
+	e2eStressMaxVGNamePrefix      = "e2e-stress-vg-"
+	e2eStressMaxLVGNamePrefix     = "e2e-lvg-stress-"
+)
+
+func e2eStressMaxVGTarget() int {
+	return e2eEnvIntPositive(e2eStressMaxVGTargetEnv, e2eStressMaxVGDefaultTarget)
+}
+
+func e2eStressMaxVGBatchSize() int {
+	b := e2eEnvIntPositive(e2eStressMaxVGBatchSizeEnv, e2eStressMaxVGDefaultBatch)
+	if t := e2eStressMaxVGTarget(); b > t {
+		return t
+	}
+	return b
+}
+
+func e2eStressMaxVGDiskSize() string {
+	if v := strings.TrimSpace(os.Getenv(e2eStressMaxVGDiskSizeEnv)); v != "" {
+		return v
+	}
+	return e2eStressMaxVGDefaultDiskSize
+}
+
+func e2eStressMaxVGStrict() bool { return e2eEnvBool(e2eStressMaxVGStrictEnv) }
+
+func e2eStressMaxVGMinReady(target int) int {
+	if v := strings.TrimSpace(os.Getenv(e2eStressMaxVGMinReadyEnv)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	if e2eStressMaxVGStrict() {
+		return target
+	}
+	return 1
+}
+
+func e2eEnvBool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func e2eEnvIntPositive(name string, defaultVal int) int {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return defaultVal
+	}
+	return n
+}
 
 // e2eNestedTestCluster is the single nested cluster for a full suite run (both Ordered Describes).
 // Common Scheduler Extender registers it after CreateOrConnect; AfterSuite runs e2eCleanupNestedTestClusterAfterSuite.

--- a/e2e/tests/sds_node_configurator_helpers_core_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_core_test.go
@@ -157,7 +157,8 @@ const (
 	// Full smoke suite (BeforeSuite cluster + scheduler + module e2e) exceeds 60m on CI.
 	e2eTestTimeoutDefaultLocal = 90 * time.Minute
 	e2eTestTimeoutDefaultCI    = 3*time.Hour + 30*time.Minute
-	e2eMinCIGoTestTimeout      = e2eTestTimeoutDefaultCI // go test -timeout must be >= this on CI (see TestSdsNodeConfigurator)
+	e2eMinCIGoTestTimeout       = e2eTestTimeoutDefaultCI // go test -timeout must be ~this on CI (see TestSdsNodeConfigurator)
+	e2eCIGoTestTimeoutDetectMin = 2 * time.Hour           // fail only below this (catches 60m org defaults, not 3h30m−ε)
 
 	// Guest VM name prefix for dhctl/bootstrap (Deckhouse test clusters). Do not attach data disks here — not a worker.
 	e2eBootstrapGuestVMPrefix = "bootstrap-node-"
@@ -290,9 +291,10 @@ func e2eAssertCIGoTestTimeout(t *testing.T) {
 		return
 	}
 	remaining := time.Until(deadline)
-	if remaining < e2eMinCIGoTestTimeout {
+	// go test sets deadline slightly below -timeout (startup); Round for stable log output.
+	if remaining.Round(time.Second) < e2eCIGoTestTimeoutDetectMin {
 		t.Fatalf("go test -timeout too short for CI smoke (%v remaining, need >= %v). "+
-			"Use go test -timeout 3h30m (workflow must not pass a shorter E2E_TEST_TIMEOUT to the -timeout flag).",
+			"Use go test -timeout 3h30m (workflow must not pass a shorter value to the -timeout flag).",
 			remaining.Round(time.Second), e2eMinCIGoTestTimeout)
 	}
 }

--- a/e2e/tests/sds_node_configurator_helpers_core_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_core_test.go
@@ -253,6 +253,27 @@ func e2eConfigRegistryDockerCfg() string {
 
 func e2eConfigTestClusterCreateMode() string { return os.Getenv("TEST_CLUSTER_CREATE_MODE") }
 
+// Ginkgo label filters (see sds_node_configurator_suite_test.go).
+const (
+	e2eGinkgoLabelE2ETests   = "e2e-tests"
+	e2eGinkgoLabelStressTest = "stress-test"
+	e2eGinkgoLabelFilterEnv  = "E2E_GINKGO_LABEL_FILTER"
+)
+
+// e2eGinkgoLabelFilter is applied when go test is run without -ginkgo.label-filter.
+// Default smoke excludes stress-test; set E2E_GINKGO_LABEL_FILTER=all to run every spec.
+func e2eGinkgoLabelFilter() string {
+	v := strings.TrimSpace(os.Getenv(e2eGinkgoLabelFilterEnv))
+	switch strings.ToLower(v) {
+	case "", "default", "smoke":
+		return e2eGinkgoLabelE2ETests
+	case "all", "*", "!", "none":
+		return ""
+	default:
+		return v
+	}
+}
+
 // e2eTestSuiteTimeout is the Ginkgo suite / go test -timeout budget for TestSdsNodeConfigurator.
 func e2eTestSuiteTimeout() time.Duration {
 	if v := strings.TrimSpace(os.Getenv("E2E_TEST_TIMEOUT")); v != "" {
@@ -272,16 +293,27 @@ const (
 	e2eStressMaxVGDiskSizeEnv     = "E2E_STRESS_MAX_VG_DISK_SIZE"
 	e2eStressMaxVGBatchSizeEnv    = "E2E_STRESS_MAX_VG_BATCH_SIZE"
 	e2eStressMaxVGStrictEnv       = "E2E_STRESS_MAX_VG_STRICT"
-	e2eStressMaxVGMinReadyEnv     = "E2E_STRESS_MAX_VG_MIN_READY"
-	e2eStressMaxVGDefaultTarget   = 30
+	e2eStressMaxVGMinReadyEnv          = "E2E_STRESS_MAX_VG_MIN_READY"
+	e2eStressMaxVMBlockDevicesEnv      = "E2E_STRESS_MAX_VM_BLOCK_DEVICES"
+	e2eStressMaxVGDefaultTarget        = 15
+	e2eStressMaxVMBlockDevicesDefault  = 15 // Deckhouse virt: max 16 VMBDAs per VM; reserve one for boot/system disks
 	e2eStressMaxVGDefaultBatch    = 5
 	e2eStressMaxVGDefaultDiskSize = "1Gi"
 	e2eStressMaxVGNamePrefix      = "e2e-stress-vg-"
 	e2eStressMaxLVGNamePrefix     = "e2e-lvg-stress-"
 )
 
+func e2eStressMaxVMBlockDevices() int {
+	return e2eEnvIntPositive(e2eStressMaxVMBlockDevicesEnv, e2eStressMaxVMBlockDevicesDefault)
+}
+
 func e2eStressMaxVGTarget() int {
-	return e2eEnvIntPositive(e2eStressMaxVGTargetEnv, e2eStressMaxVGDefaultTarget)
+	target := e2eEnvIntPositive(e2eStressMaxVGTargetEnv, e2eStressMaxVGDefaultTarget)
+	maxVM := e2eStressMaxVMBlockDevices()
+	if target > maxVM {
+		return maxVM
+	}
+	return target
 }
 
 func e2eStressMaxVGBatchSize() int {

--- a/e2e/tests/sds_node_configurator_helpers_core_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_core_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -153,9 +154,10 @@ const (
 	e2eSuitePodPVCleanupPodTimeout = 2 * time.Minute
 	e2eSuitePodPVCleanupPVTimeout  = 15 * time.Minute
 
-	// Full smoke suite (BeforeSuite cluster + scheduler + module e2e) exceeds 60m on CI; override via E2E_TEST_TIMEOUT.
+	// Full smoke suite (BeforeSuite cluster + scheduler + module e2e) exceeds 60m on CI.
 	e2eTestTimeoutDefaultLocal = 90 * time.Minute
-	e2eTestTimeoutDefaultCI    = 3 * time.Hour
+	e2eTestTimeoutDefaultCI    = 3*time.Hour + 30*time.Minute
+	e2eMinCIGoTestTimeout      = e2eTestTimeoutDefaultCI // go test -timeout must be >= this on CI (see TestSdsNodeConfigurator)
 
 	// Guest VM name prefix for dhctl/bootstrap (Deckhouse test clusters). Do not attach data disks here — not a worker.
 	e2eBootstrapGuestVMPrefix = "bootstrap-node-"
@@ -275,16 +277,44 @@ func e2eGinkgoLabelFilter() string {
 }
 
 // e2eTestSuiteTimeout is the Ginkgo suite / go test -timeout budget for TestSdsNodeConfigurator.
+// e2eAssertCIGoTestTimeout fails fast when CI runs go test with -timeout 60m (default org setting).
+// Ginkgo suite timeout cannot extend the go test process alarm — both must be >= e2eMinCIGoTestTimeout.
+func e2eAssertCIGoTestTimeout(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CI") == "" {
+		return
+	}
+	deadline, ok := t.Deadline()
+	if !ok {
+		t.Logf("CI: go test deadline unknown; invoke with -timeout at least %v", e2eMinCIGoTestTimeout)
+		return
+	}
+	remaining := time.Until(deadline)
+	if remaining < e2eMinCIGoTestTimeout {
+		t.Fatalf("go test -timeout too short for CI smoke (%v remaining, need >= %v). "+
+			"Use go test -timeout 3h30m (workflow must not pass a shorter E2E_TEST_TIMEOUT to the -timeout flag).",
+			remaining.Round(time.Second), e2eMinCIGoTestTimeout)
+	}
+}
+
 func e2eTestSuiteTimeout() time.Duration {
+	var d time.Duration
 	if v := strings.TrimSpace(os.Getenv("E2E_TEST_TIMEOUT")); v != "" {
-		if d, err := time.ParseDuration(v); err == nil && d > 0 {
-			return d
+		if parsed, err := time.ParseDuration(v); err == nil && parsed > 0 {
+			d = parsed
 		}
 	}
-	if os.Getenv("CI") != "" {
-		return e2eTestTimeoutDefaultCI
+	if d == 0 {
+		if os.Getenv("CI") != "" {
+			d = e2eTestTimeoutDefaultCI
+		} else {
+			d = e2eTestTimeoutDefaultLocal
+		}
 	}
-	return e2eTestTimeoutDefaultLocal
+	if os.Getenv("CI") != "" && d < e2eMinCIGoTestTimeout {
+		return e2eMinCIGoTestTimeout
+	}
+	return d
 }
 
 // Stress e2e: many independent LVMVolumeGroups (1 PV = 1 VG) on one node.

--- a/e2e/tests/sds_node_configurator_helpers_discovery_ssh_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_discovery_ssh_test.go
@@ -150,6 +150,34 @@ func e2eExecOnTestClusterNodeSSH(ctx context.Context, testKubeconfig *rest.Confi
 	return out, nil
 }
 
+// e2eCountVGsOnNode returns the number of volume groups visible to vgs on the node (all VGs).
+func e2eCountVGsOnNode(ctx context.Context, testKubeconfig *rest.Config, nodeName, sshUser string) (int, string, error) {
+	cmd := `vgs -o vg_name --noheadings 2>/dev/null | sed '/^$/d' | wc -l`
+	out, err := e2eExecOnTestClusterNodeSSH(ctx, testKubeconfig, nodeName, sshUser, cmd)
+	if err != nil {
+		return 0, out, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, out, fmt.Errorf("parse vg count %q: %w", strings.TrimSpace(out), err)
+	}
+	return n, out, nil
+}
+
+// e2eCountPVsOnNode returns the number of physical volumes visible to pvs on the node (all PVs).
+func e2eCountPVsOnNode(ctx context.Context, testKubeconfig *rest.Config, nodeName, sshUser string) (int, string, error) {
+	cmd := `pvs -o pv_name --noheadings 2>/dev/null | sed '/^$/d' | wc -l`
+	out, err := e2eExecOnTestClusterNodeSSH(ctx, testKubeconfig, nodeName, sshUser, cmd)
+	if err != nil {
+		return 0, out, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, out, fmt.Errorf("parse pv count %q: %w", strings.TrimSpace(out), err)
+	}
+	return n, out, nil
+}
+
 // e2eCountPVsInVGOnNode returns how many PVs belong to vgName according to pvs on the node.
 func e2eCountPVsInVGOnNode(ctx context.Context, testKubeconfig *rest.Config, nodeName, sshUser, vgName string) (int, string, error) {
 	quotedVG := strconv.Quote(vgName)

--- a/e2e/tests/sds_node_configurator_helpers_virtualization_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_virtualization_test.go
@@ -692,6 +692,16 @@ func e2eAttachVirtualDiskToVM(ctx context.Context, baseKubeconfig *rest.Config, 
 	}, nil
 }
 
+// e2eVirtVMBlockDeviceLimitReached reports Deckhouse virtualization admission denying
+// another VirtualMachineBlockDeviceAttachment because the VM already has the maximum count.
+func e2eVirtVMBlockDeviceLimitReached(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "limit reached") && strings.Contains(msg, "maximum")
+}
+
 func attachVirtualDiskWithRetry(ctx context.Context, baseKubeconfig *rest.Config, config kubernetes.VirtualDiskAttachmentConfig, maxRetries int, retryInterval time.Duration) (*kubernetes.VirtualDiskAttachmentResult, error) {
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -700,6 +710,9 @@ func attachVirtualDiskWithRetry(ctx context.Context, baseKubeconfig *rest.Config
 			return att, nil
 		}
 		lastErr = err
+		if e2eVirtVMBlockDeviceLimitReached(err) {
+			break
+		}
 		if attempt < maxRetries {
 			time.Sleep(retryInterval)
 		}

--- a/e2e/tests/sds_node_configurator_stress_max_vgs_test.go
+++ b/e2e/tests/sds_node_configurator_stress_max_vgs_test.go
@@ -61,12 +61,20 @@ func e2eStressBatchReadyTimeout(batchLen int) time.Duration {
 	return t
 }
 
-func e2eStressPrintReport(nodeName string, target, ready, batchSize int, strict bool, slots []stressVGSlot, vgCount, pvCount int) {
+func e2eStressPrintReport(nodeName string, target, ready, batchSize int, strict, stoppedEarly, virtLimitReached bool, slots []stressVGSlot, vgCount, pvCount int) {
 	GinkgoWriter.Printf("\n========== Stress: max independent VGs per node — report ==========\n")
 	GinkgoWriter.Printf("  node: %s\n", nodeName)
-	GinkgoWriter.Printf("  target LVMVolumeGroups: %d (batch size %d)\n", target, batchSize)
+	GinkgoWriter.Printf("  target LVMVolumeGroups: %d (batch size %d; capped by E2E_STRESS_MAX_VM_BLOCK_DEVICES=%d)\n",
+		target, batchSize, e2eStressMaxVMBlockDevices())
 	GinkgoWriter.Printf("  Ready LVMVolumeGroups: %d\n", ready)
 	GinkgoWriter.Printf("  strict mode (all target must be Ready): %v\n", strict)
+	if stoppedEarly {
+		if virtLimitReached {
+			GinkgoWriter.Println("  stopped early: Deckhouse virtualization VM block-device limit (16 attachments per VM).")
+		} else {
+			GinkgoWriter.Println("  stopped early: batch LVMVolumeGroup Ready timeout or no further attach progress.")
+		}
+	}
 	GinkgoWriter.Printf("  on-node vgs count (all VGs): %d\n", vgCount)
 	GinkgoWriter.Printf("  on-node pvs count (all PVs): %d\n", pvCount)
 	for _, s := range slots {
@@ -80,8 +88,9 @@ func e2eStressPrintReport(nodeName string, target, ready, batchSize int, strict 
 		GinkgoWriter.Printf("  [%02d] disk=%s lvg=%s vg=%s bd=%s phase=%s\n",
 			s.index, s.diskName, s.lvgName, s.vgName, stressBDName(s), phase)
 	}
-	GinkgoWriter.Println("  LVM2 has no documented hard cap on VG count; practical limits depend on metadata size,")
-	GinkgoWriter.Println("  udev/device-mapper, and agent/controller throughput. Use this report as an empirical ceiling.")
+	GinkgoWriter.Println("  LVM2 has no documented hard cap on VG count; on a single VM the Deckhouse virt controller")
+	GinkgoWriter.Println("  caps block-device attachments at 16 (leave headroom for boot disks — default stress target 15).")
+	GinkgoWriter.Println("  Beyond that, practical limits depend on metadata size, udev, and agent throughput.")
 	GinkgoWriter.Println("====================================================================\n")
 }
 
@@ -135,7 +144,8 @@ func e2eMarkStressSlotsReady(ctx context.Context, cl client.Client, slots []stre
 	return n
 }
 
-var _ = Describe("Stress: maximum independent LVMVolumeGroups per node", Label("stress-test"), Ordered, func() {
+// Label stress-test: excluded from default smoke (suite label filter e2e-tests). Run via make test-stress or E2E_GINKGO_LABEL_FILTER=stress-test.
+var _ = Describe("Stress: maximum independent LVMVolumeGroups per node", Label(e2eGinkgoLabelStressTest), Ordered, func() {
 	var (
 		e2eCtx      context.Context
 		res         *cluster.TestClusterResources
@@ -211,8 +221,10 @@ var _ = Describe("Stress: maximum independent LVMVolumeGroups per node", Label("
 		readyTotal := 0
 		batchNum := 0
 		stoppedEarly := false
+		virtLimitReached := false
 
-		By(fmt.Sprintf("Stress ramp: target=%d batch=%d diskSize=%s VM=%q", target, batchSize, diskSize, targetVM))
+		By(fmt.Sprintf("Stress ramp: target=%d batch=%d diskSize=%s VM=%q (max VM block devices=%d)",
+			target, batchSize, diskSize, targetVM, e2eStressMaxVMBlockDevices()))
 
 		for batchStart := 0; batchStart < target && !stoppedEarly; batchStart += batchSize {
 			batchEnd := batchStart + batchSize
@@ -234,15 +246,30 @@ var _ = Describe("Stress: maximum independent LVMVolumeGroups per node", Label("
 				slots = append(slots, slot)
 			}
 
+			batchEndAttached := batchEnd
 			for i := batchStart; i < batchEnd; i++ {
 				att, err := attachVirtualDiskWithRetry(e2eCtx, res.BaseKubeconfig, kubernetes.VirtualDiskAttachmentConfig{
 					VMName: targetVM, Namespace: ns, DiskName: slots[i].diskName,
 					DiskSize: diskSize, StorageClassName: storageClass,
 				}, e2eVirtualDiskAttachMaxRetries, e2eVirtualDiskAttachRetryInterval)
+				if e2eVirtVMBlockDeviceLimitReached(err) {
+					GinkgoWriter.Printf("    VM %q block-device attachment limit reached at disk %s — stopping ramp (%d Ready so far)\n",
+						targetVM, slots[i].diskName, readyTotal)
+					stoppedEarly = true
+					virtLimitReached = true
+					slots = slots[:i]
+					batchEndAttached = i
+					break
+				}
 				Expect(err).NotTo(HaveOccurred(), "attach disk %s", slots[i].diskName)
 				slots[i].att = att
 				attachments = append(attachments, att)
 			}
+			if batchEndAttached == batchStart {
+				break
+			}
+			batchEnd = batchEndAttached
+			curBatch = batchEnd - batchStart
 
 			for i := batchStart; i < batchEnd; i++ {
 				attachCtx, cancel := context.WithTimeout(e2eCtx, e2eVirtualDiskAttachWaitTimeout)
@@ -308,6 +335,9 @@ var _ = Describe("Stress: maximum independent LVMVolumeGroups per node", Label("
 					GinkgoWriter.Printf("    batch %d OK: cumulative Ready=%d; on-node vgs=%d pvs=%d\n", batchNum, readyTotal, vgN, pvN)
 				}
 			}
+			if virtLimitReached {
+				break
+			}
 		}
 
 		vmSSH := e2eConfigVMSSHUser()
@@ -320,7 +350,7 @@ var _ = Describe("Stress: maximum independent LVMVolumeGroups per node", Label("
 			GinkgoWriter.Printf("    pvs count on node failed: %v (output %q)\n", errPV, pvOut)
 		}
 
-		e2eStressPrintReport(nodeName, target, readyTotal, batchSize, strict, slots, vgCount, pvCount)
+		e2eStressPrintReport(nodeName, target, readyTotal, batchSize, strict, stoppedEarly, virtLimitReached, slots, vgCount, pvCount)
 
 		if strict {
 			Expect(readyTotal).To(Equal(target),

--- a/e2e/tests/sds_node_configurator_stress_max_vgs_test.go
+++ b/e2e/tests/sds_node_configurator_stress_max_vgs_test.go
@@ -1,0 +1,350 @@
+/*
+	Copyright 2026 Flant JSC
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
+	"github.com/deckhouse/storage-e2e/pkg/cluster"
+	"github.com/deckhouse/storage-e2e/pkg/kubernetes"
+)
+
+// stressVGSlot is one independent VG (one VirtualDisk → BlockDevice → LVMVolumeGroup) on a single node.
+type stressVGSlot struct {
+	index    int
+	diskName string
+	att      *kubernetes.VirtualDiskAttachmentResult
+	bd       *v1alpha1.BlockDevice
+	meta     string
+	lvgName  string
+	vgName   string
+	ready    bool
+}
+
+// e2eStressBatchReadyTimeout scales with batch size: many concurrent LVM ops on one node need headroom.
+func e2eStressBatchReadyTimeout(batchLen int) time.Duration {
+	if batchLen <= 0 {
+		return e2eLVMVolumeGroupReadyTimeout
+	}
+	t := time.Duration(batchLen) * 4 * time.Minute
+	if t < e2eLVMVolumeGroupReadyTimeout {
+		return e2eLVMVolumeGroupReadyTimeout
+	}
+	const maxBatch = 3 * time.Hour
+	if t > maxBatch {
+		return maxBatch
+	}
+	return t
+}
+
+func e2eStressPrintReport(nodeName string, target, ready, batchSize int, strict bool, slots []stressVGSlot, vgCount, pvCount int) {
+	GinkgoWriter.Printf("\n========== Stress: max independent VGs per node — report ==========\n")
+	GinkgoWriter.Printf("  node: %s\n", nodeName)
+	GinkgoWriter.Printf("  target LVMVolumeGroups: %d (batch size %d)\n", target, batchSize)
+	GinkgoWriter.Printf("  Ready LVMVolumeGroups: %d\n", ready)
+	GinkgoWriter.Printf("  strict mode (all target must be Ready): %v\n", strict)
+	GinkgoWriter.Printf("  on-node vgs count (all VGs): %d\n", vgCount)
+	GinkgoWriter.Printf("  on-node pvs count (all PVs): %d\n", pvCount)
+	for _, s := range slots {
+		phase := "<not created>"
+		if s.lvgName != "" {
+			phase = "Pending/missing"
+		}
+		if s.ready {
+			phase = "Ready"
+		}
+		GinkgoWriter.Printf("  [%02d] disk=%s lvg=%s vg=%s bd=%s phase=%s\n",
+			s.index, s.diskName, s.lvgName, s.vgName, stressBDName(s), phase)
+	}
+	GinkgoWriter.Println("  LVM2 has no documented hard cap on VG count; practical limits depend on metadata size,")
+	GinkgoWriter.Println("  udev/device-mapper, and agent/controller throughput. Use this report as an empirical ceiling.")
+	GinkgoWriter.Println("====================================================================\n")
+}
+
+func stressBDName(s stressVGSlot) string {
+	if s.bd == nil {
+		return "-"
+	}
+	return s.bd.Name
+}
+
+// e2eWaitStressLVGBatchReady polls until every LVMVolumeGroup in [from,to) is Ready or timeout expires.
+// Returns false on timeout (probe mode stops the ramp without failing the spec).
+func e2eWaitStressLVGBatchReady(ctx context.Context, cl client.Client, slots []stressVGSlot, from, to int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	poll := 15 * time.Second
+	for {
+		allReady := true
+		for i := from; i < to; i++ {
+			var cur v1alpha1.LVMVolumeGroup
+			if err := cl.Get(ctx, client.ObjectKey{Name: slots[i].lvgName}, &cur); err != nil {
+				allReady = false
+				break
+			}
+			if cur.Status.Phase != v1alpha1.PhaseReady {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(poll)
+	}
+}
+
+func e2eMarkStressSlotsReady(ctx context.Context, cl client.Client, slots []stressVGSlot, from, to int) int {
+	n := 0
+	for i := from; i < to; i++ {
+		var cur v1alpha1.LVMVolumeGroup
+		if err := cl.Get(ctx, client.ObjectKey{Name: slots[i].lvgName}, &cur); err != nil {
+			continue
+		}
+		if cur.Status.Phase == v1alpha1.PhaseReady {
+			slots[i].ready = true
+			n++
+		}
+	}
+	return n
+}
+
+var _ = Describe("Stress: maximum independent LVMVolumeGroups per node", Label("stress-test"), Ordered, func() {
+	var (
+		e2eCtx      context.Context
+		res         *cluster.TestClusterResources
+		k8sClient   client.Client
+		stressRunID string
+		stressOnce  sync.Once
+		slots       []stressVGSlot
+		nodeName    string
+		attachments []*kubernetes.VirtualDiskAttachmentResult
+	)
+
+	BeforeAll(func() {
+		e2eCtx = context.Background()
+		res = e2eNestedTestClusterOrNil()
+		Expect(res).NotTo(BeNil(), "nested test cluster must exist (BeforeSuite)")
+		Expect(res.BaseKubeconfig).NotTo(BeNil(), "stress test requires nested virtualization (base cluster kubeconfig)")
+		ensureE2EK8sClient(res, &k8sClient, e2eCtx)
+		stressRunID = fmt.Sprintf("%d", time.Now().Unix())
+	})
+
+	BeforeEach(func() {
+		stressOnce.Do(func() {
+			prepCtx, prepCancel := context.WithTimeout(context.Background(), e2eClusterCleanupTimeout)
+			defer prepCancel()
+			By("Stress max-VGs: cleanup before test")
+			cleanupE2EPodsAndPVCsWithWait(prepCtx, k8sClient, e2eSuitePodPVCleanupPodTimeout, e2eSuitePodPVCleanupPVTimeout)
+			cleanupE2ELVMLogicalVolumes(prepCtx, k8sClient)
+			cleanupE2ELVMVolumeGroups(prepCtx, k8sClient)
+			cleanupE2ELocalStorageClasses(prepCtx, res.Kubeconfig)
+			cleanupE2EVirtualDisks(prepCtx, res.BaseKubeconfig, e2eConfigNamespace(), e2eSuiteVirtualDiskPrefix)
+			forceDeleteAllNonConsumableBlockDevices(prepCtx, k8sClient, 2*time.Minute)
+			forceDeleteAllBlockDevices(prepCtx, k8sClient, 3*time.Minute)
+		})
+	})
+
+	AfterEach(func() {
+		if res == nil || res.BaseKubeconfig == nil {
+			return
+		}
+		ns := e2eConfigNamespace()
+		for _, att := range attachments {
+			if att == nil {
+				continue
+			}
+			_ = kubernetes.DetachAndDeleteVirtualDisk(e2eCtx, res.BaseKubeconfig, ns, att.AttachmentName, att.DiskName)
+		}
+		attachments = nil
+		for i := len(slots) - 1; i >= 0; i-- {
+			if slots[i].lvgName == "" {
+				continue
+			}
+			_ = client.IgnoreNotFound(k8sClient.Delete(e2eCtx, &v1alpha1.LVMVolumeGroup{ObjectMeta: metav1.ObjectMeta{Name: slots[i].lvgName}}))
+		}
+	})
+
+	It("Should ramp independent LVMVolumeGroups on one node until target or first failing batch", func() {
+		target := e2eStressMaxVGTarget()
+		batchSize := e2eStressMaxVGBatchSize()
+		diskSize := e2eStressMaxVGDiskSize()
+		strict := e2eStressMaxVGStrict()
+		minReady := e2eStressMaxVGMinReady(target)
+
+		ns := e2eConfigNamespace()
+		storageClass := e2eConfigStorageClass()
+		Expect(storageClass).NotTo(BeEmpty())
+
+		clusterVMs := e2eListClusterVMNames(e2eCtx, res, ns)
+		Expect(clusterVMs).NotTo(BeEmpty())
+		targetVM := clusterVMs[0]
+		nodeSafe := ""
+
+		slots = make([]stressVGSlot, 0, target)
+		readyTotal := 0
+		batchNum := 0
+		stoppedEarly := false
+
+		By(fmt.Sprintf("Stress ramp: target=%d batch=%d diskSize=%s VM=%q", target, batchSize, diskSize, targetVM))
+
+		for batchStart := 0; batchStart < target && !stoppedEarly; batchStart += batchSize {
+			batchEnd := batchStart + batchSize
+			if batchEnd > target {
+				batchEnd = target
+			}
+			curBatch := batchEnd - batchStart
+			batchNum++
+
+			By(fmt.Sprintf("Batch %d: disks/LVGs [%d..%d) (%d slots)", batchNum, batchStart, batchEnd, curBatch))
+
+			for i := batchStart; i < batchEnd; i++ {
+				idx := i + 1
+				slot := stressVGSlot{
+					index:    idx,
+					diskName: fmt.Sprintf("%sd%d-%s", e2eStressMaxVGNamePrefix, idx, stressRunID),
+					vgName:   fmt.Sprintf("e2e-vg-stress-%d-%s", idx, stressRunID),
+				}
+				slots = append(slots, slot)
+			}
+
+			for i := batchStart; i < batchEnd; i++ {
+				att, err := attachVirtualDiskWithRetry(e2eCtx, res.BaseKubeconfig, kubernetes.VirtualDiskAttachmentConfig{
+					VMName: targetVM, Namespace: ns, DiskName: slots[i].diskName,
+					DiskSize: diskSize, StorageClassName: storageClass,
+				}, e2eVirtualDiskAttachMaxRetries, e2eVirtualDiskAttachRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "attach disk %s", slots[i].diskName)
+				slots[i].att = att
+				attachments = append(attachments, att)
+			}
+
+			for i := batchStart; i < batchEnd; i++ {
+				attachCtx, cancel := context.WithTimeout(e2eCtx, e2eVirtualDiskAttachWaitTimeout)
+				Expect(kubernetes.WaitForVirtualDiskAttached(attachCtx, res.BaseKubeconfig, ns, slots[i].att.AttachmentName, 10*time.Second)).To(Succeed())
+				cancel()
+			}
+
+			metaSeen := make(map[string]struct{})
+			for i := batchStart; i < batchEnd; i++ {
+				bd := e2eWaitConsumableBlockDeviceForVirtualDisk(e2eCtx, res.BaseKubeconfig, k8sClient, ns,
+					slots[i].att.DiskName, slots[i].att.AttachmentName, targetVM)
+				slots[i].bd = bd
+				if nodeName == "" {
+					nodeName = bd.Status.NodeName
+					nodeSafe = strings.ReplaceAll(strings.ReplaceAll(nodeName, ".", "-"), "_", "-")
+				} else {
+					Expect(bd.Status.NodeName).To(Equal(nodeName), "all BlockDevices must be on the same node")
+				}
+				meta := bd.Labels["kubernetes.io/metadata.name"]
+				if meta == "" {
+					meta = bd.Name
+				}
+				Expect(metaSeen).NotTo(HaveKey(meta), "duplicate BlockDevice selector meta %q", meta)
+				metaSeen[meta] = struct{}{}
+				slots[i].meta = meta
+				slots[i].lvgName = fmt.Sprintf("%s%d-%s-%s", e2eStressMaxLVGNamePrefix, slots[i].index, stressRunID, nodeSafe)
+			}
+
+			for i := batchStart; i < batchEnd; i++ {
+				lvg := &v1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{Name: slots[i].lvgName},
+					Spec: v1alpha1.LVMVolumeGroupSpec{
+						ActualVGNameOnTheNode: slots[i].vgName,
+						BlockDeviceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/hostname":      nodeName,
+								"kubernetes.io/metadata.name": slots[i].meta,
+							},
+						},
+						Type:  "Local",
+						Local: v1alpha1.LVMVolumeGroupLocalSpec{NodeName: nodeName},
+					},
+				}
+				Expect(k8sClient.Create(e2eCtx, lvg)).To(Succeed(),
+					"create LVMVolumeGroup %s (batch %d)", slots[i].lvgName, batchNum)
+			}
+
+			batchTimeout := e2eStressBatchReadyTimeout(curBatch)
+			if !e2eWaitStressLVGBatchReady(e2eCtx, k8sClient, slots, batchStart, batchEnd, batchTimeout) {
+				GinkgoWriter.Printf("    batch %d: not all LVMVolumeGroups Ready within %v — stopping ramp\n", batchNum, batchTimeout)
+				stoppedEarly = true
+				readyTotal += e2eMarkStressSlotsReady(e2eCtx, k8sClient, slots, batchStart, batchEnd)
+				break
+			}
+			for i := batchStart; i < batchEnd; i++ {
+				slots[i].ready = true
+			}
+			readyTotal += curBatch
+
+			vmSSH := e2eConfigVMSSHUser()
+			if vgN, _, err := e2eCountVGsOnNode(e2eCtx, res.Kubeconfig, nodeName, vmSSH); err == nil {
+				if pvN, _, errPV := e2eCountPVsOnNode(e2eCtx, res.Kubeconfig, nodeName, vmSSH); errPV == nil {
+					GinkgoWriter.Printf("    batch %d OK: cumulative Ready=%d; on-node vgs=%d pvs=%d\n", batchNum, readyTotal, vgN, pvN)
+				}
+			}
+		}
+
+		vmSSH := e2eConfigVMSSHUser()
+		vgCount, vgOut, errVG := e2eCountVGsOnNode(e2eCtx, res.Kubeconfig, nodeName, vmSSH)
+		if errVG != nil {
+			GinkgoWriter.Printf("    vgs count on node failed: %v (output %q)\n", errVG, vgOut)
+		}
+		pvCount, pvOut, errPV := e2eCountPVsOnNode(e2eCtx, res.Kubeconfig, nodeName, vmSSH)
+		if errPV != nil {
+			GinkgoWriter.Printf("    pvs count on node failed: %v (output %q)\n", errPV, pvOut)
+		}
+
+		e2eStressPrintReport(nodeName, target, readyTotal, batchSize, strict, slots, vgCount, pvCount)
+
+		if strict {
+			Expect(readyTotal).To(Equal(target),
+				"strict mode: expected %d Ready LVMVolumeGroups on %s; got %d (stopped early=%v)",
+				target, nodeName, readyTotal, stoppedEarly)
+		} else {
+			Expect(readyTotal).To(BeNumerically(">=", minReady),
+				"probe mode: expected at least %d Ready LVMVolumeGroups; got %d (target %d, stopped early=%v)",
+				minReady, readyTotal, target, stoppedEarly)
+		}
+
+		if readyTotal > 0 {
+			vgsCmd := "vgs -o vg_name --noheadings 2>/dev/null || sudo -n vgs -o vg_name --noheadings 2>/dev/null"
+			outVgs, errVgs := e2eExecOnTestClusterNodeSSH(e2eCtx, res.Kubeconfig, nodeName, vmSSH, vgsCmd)
+			Expect(errVgs).NotTo(HaveOccurred())
+			for i := range slots {
+				if !slots[i].ready {
+					continue
+				}
+				Expect(e2eVgNameListedInVgsOutput(outVgs, slots[i].vgName)).To(BeTrue(),
+					"vgs should list stress VG %q", slots[i].vgName)
+			}
+		}
+
+		By(fmt.Sprintf("✓ Stress ramp finished: %d/%d LVMVolumeGroups Ready on node %s", readyTotal, target, nodeName))
+	})
+})

--- a/e2e/tests/sds_node_configurator_suite_test.go
+++ b/e2e/tests/sds_node_configurator_suite_test.go
@@ -61,10 +61,13 @@ var _ = AfterSuite(func() {
 func TestSdsNodeConfigurator(t *testing.T) {
 	RegisterFailHandler(Fail)
 	suiteConfig, reporterConfig := GinkgoConfiguration()
+	suiteTimeout := e2eTestSuiteTimeout()
+	suiteConfig.Timeout = suiteTimeout
 	if os.Getenv("CI") != "" {
 		suiteConfig.FailFast = true
 	}
 	reporterConfig.Verbose = true
 	reporterConfig.ShowNodeEvents = false
+	t.Logf("E2E suite timeout: %v (override with E2E_TEST_TIMEOUT)", suiteTimeout)
 	RunSpecs(t, "Sds Node Configurator Suite", suiteConfig, reporterConfig)
 }

--- a/e2e/tests/sds_node_configurator_suite_test.go
+++ b/e2e/tests/sds_node_configurator_suite_test.go
@@ -60,6 +60,8 @@ var _ = AfterSuite(func() {
 })
 
 func TestSdsNodeConfigurator(t *testing.T) {
+	e2eAssertCIGoTestTimeout(t)
+
 	RegisterFailHandler(Fail)
 	suiteConfig, reporterConfig := GinkgoConfiguration()
 	suiteTimeout := e2eTestSuiteTimeout()

--- a/e2e/tests/sds_node_configurator_suite_test.go
+++ b/e2e/tests/sds_node_configurator_suite_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,11 +64,19 @@ func TestSdsNodeConfigurator(t *testing.T) {
 	suiteConfig, reporterConfig := GinkgoConfiguration()
 	suiteTimeout := e2eTestSuiteTimeout()
 	suiteConfig.Timeout = suiteTimeout
+	if suiteConfig.LabelFilter == "" {
+		suiteConfig.LabelFilter = e2eGinkgoLabelFilter()
+	}
 	if os.Getenv("CI") != "" {
 		suiteConfig.FailFast = true
 	}
 	reporterConfig.Verbose = true
 	reporterConfig.ShowNodeEvents = false
 	t.Logf("E2E suite timeout: %v (override with E2E_TEST_TIMEOUT)", suiteTimeout)
+	if f := strings.TrimSpace(suiteConfig.LabelFilter); f != "" {
+		t.Logf("Ginkgo label filter: %q (stress-test excluded unless filter includes it; override: -ginkgo.label-filter or E2E_GINKGO_LABEL_FILTER)", f)
+	} else {
+		t.Logf("Ginkgo label filter: (none) — all specs including stress-test (set E2E_GINKGO_LABEL_FILTER=all explicitly)")
+	}
 	RunSpecs(t, "Sds Node Configurator Suite", suiteConfig, reporterConfig)
 }

--- a/e2e/tests/sds_node_configurator_test.go
+++ b/e2e/tests/sds_node_configurator_test.go
@@ -2245,10 +2245,17 @@ var _ = Describe("sds-node-configurator module e2e", Label("e2e-tests"), Ordered
 				ensureE2EK8sClient(testClusterResources, &k8sClient, e2eCtx)
 				Expect(testClusterResources.BaseKubeconfig).NotTo(BeNil(), "requires nested virtualization")
 				thinPoolRestoreRunID := fmt.Sprintf("%d", time.Now().Unix())
+				diskName := fmt.Sprintf("%s-%s", e2eThinPoolRestoreDiskName, thinPoolRestoreRunID)
 
 				ns := e2eConfigNamespace()
 				storageClass := e2eConfigStorageClass()
 				Expect(storageClass).NotTo(BeEmpty())
+				if testClusterResources.BaseKubeconfig != nil {
+					_ = kubernetes.DetachAndDeleteVirtualDisk(e2eCtx, testClusterResources.BaseKubeconfig, ns,
+						diskName+"-attachment", diskName)
+					_ = kubernetes.DetachAndDeleteVirtualDisk(e2eCtx, testClusterResources.BaseKubeconfig, ns,
+						e2eThinPoolRestoreDiskName+"-attachment", e2eThinPoolRestoreDiskName)
+				}
 				clusterVMs := e2eListClusterVMNames(e2eCtx, testClusterResources, ns)
 				targetVM := clusterVMs[rand.Intn(len(clusterVMs))]
 				vmSSH := e2eConfigVMSSHUser()
@@ -2261,7 +2268,7 @@ var _ = Describe("sds-node-configurator module e2e", Label("e2e-tests"), Ordered
 
 				By("Step 1: attach VirtualDisk and create LVMVolumeGroup with thin-pool")
 				att, err := attachVirtualDiskWithRetry(e2eCtx, testClusterResources.BaseKubeconfig, kubernetes.VirtualDiskAttachmentConfig{
-					VMName: targetVM, Namespace: ns, DiskName: e2eThinPoolRestoreDiskName,
+					VMName: targetVM, Namespace: ns, DiskName: diskName,
 					DiskSize: e2eThinPoolRestoreDiskSize, StorageClassName: storageClass,
 				}, e2eVirtualDiskAttachMaxRetries, e2eVirtualDiskAttachRetryInterval)
 				Expect(err).NotTo(HaveOccurred())

--- a/e2e/tests/sds_node_configurator_test.go
+++ b/e2e/tests/sds_node_configurator_test.go
@@ -156,6 +156,9 @@ var _ = Describe("sds-node-configurator module e2e", Label("e2e-tests"), Ordered
 				By("Cleaning up existing e2e LVMVolumeGroups (to release LVM signatures)")
 				cleanupE2ELVMVolumeGroups(e2eCtx, k8sClient)
 
+				By("Ensuring no leftover LocalStorageClass from a previous run")
+				Expect(ensureE2ELocalStorageClassAbsent(e2eCtx, testClusterResources.Kubeconfig, k8sClient, e2eLocalStorageClassName)).To(Succeed())
+
 				if testClusterResources.BaseKubeconfig != nil {
 					By("Cleaning up e2e VirtualDisks and attachments before tests")
 					cleanupE2EVirtualDisks(e2eCtx, testClusterResources.BaseKubeconfig, ns, e2eVirtualDiskPrefix)
@@ -469,11 +472,6 @@ var _ = Describe("sds-node-configurator module e2e", Label("e2e-tests"), Ordered
 					lvgNames[i] = lvg.Name
 				}
 
-				By(fmt.Sprintf("Ensuring LocalStorageClass %s is absent before create", e2eLocalStorageClassName))
-				ensureE2ELocalStorageClassAbsent(e2eCtx, testClusterResources.Kubeconfig, k8sClient, e2eLocalStorageClassName)
-
-				By(fmt.Sprintf("Creating LocalStorageClass %s with LVMVolumeGroups: %v", e2eLocalStorageClassName, lvgNames))
-
 				lvmVolumeGroups := make([]interface{}, len(lvgNames))
 				for i, lvgName := range lvgNames {
 					lvmVolumeGroups[i] = map[string]interface{}{
@@ -499,8 +497,12 @@ var _ = Describe("sds-node-configurator module e2e", Label("e2e-tests"), Ordered
 					},
 				}
 
-				_, err = dynamicClient.Resource(localStorageClassGVR).Create(e2eCtx, lsc, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred(), "create LocalStorageClass")
+				By(fmt.Sprintf("Creating LocalStorageClass %s with LVMVolumeGroups: %v", e2eLocalStorageClassName, lvgNames))
+				Eventually(func(g Gomega) {
+					g.Expect(ensureE2ELocalStorageClassAbsent(e2eCtx, testClusterResources.Kubeconfig, k8sClient, e2eLocalStorageClassName)).To(Succeed())
+					_, createErr := dynamicClient.Resource(localStorageClassGVR).Create(e2eCtx, lsc.DeepCopy(), metav1.CreateOptions{})
+					g.Expect(createErr).NotTo(HaveOccurred(), "create LocalStorageClass")
+				}, 5*time.Minute, 10*time.Second).Should(Succeed(), "create LocalStorageClass after prior e2e-local-sc is fully removed")
 
 				By("Waiting for LocalStorageClass to reach Created phase (up to 3 minutes)")
 				Eventually(func(g Gomega) {

--- a/e2e/tests/sds_node_configurator_test.go
+++ b/e2e/tests/sds_node_configurator_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/deckhouse/storage-e2e/pkg/kubernetes"
 )
 
-var _ = Describe("sds-node-configurator module e2e", Ordered, func() {
+var _ = Describe("sds-node-configurator module e2e", Label("e2e-tests"), Ordered, func() {
 
 	Describe("Common Scheduler Extender", Ordered, func() {
 		var (
@@ -468,6 +468,9 @@ var _ = Describe("sds-node-configurator module e2e", Ordered, func() {
 				for i, lvg := range createdLVGs {
 					lvgNames[i] = lvg.Name
 				}
+
+				By(fmt.Sprintf("Ensuring LocalStorageClass %s is absent before create", e2eLocalStorageClassName))
+				ensureE2ELocalStorageClassAbsent(e2eCtx, testClusterResources.Kubeconfig, k8sClient, e2eLocalStorageClassName)
 
 				By(fmt.Sprintf("Creating LocalStorageClass %s with LVMVolumeGroups: %v", e2eLocalStorageClassName, lvgNames))
 


### PR DESCRIPTION
Signed-off-by: Nikolay Demchuk <nikolay.demchuk@flant.com>

## Description
This PR extends product e2e: Ginkgo labels (`e2e-tests` / `stress-test`), an optional max–LVMVolumeGroup-per-node stress ramp, CI smoke filtering and a fixed `go test -timeout 3h30m`, plus hardening of scheduler cleanup, virtualization attach, and flaky specs (block-device-stable, `e2e-local-sc`).

## Why do we need it, and what problem does it solve?
Smoke CI was failing on a 60-minute `go test` panic during long scheduler fill/cleanup, stress specs ran in the default suite, and several e2e paths hit Deckhouse limits (16 VM block devices) or resource leaks (stuck PVs/PVCs, duplicate CR names).

## What is the expected result?
PR CI runs only `e2e-tests` within ~3h30m without stress; stress runs via `make test-stress` or `E2E_GINKGO_LABEL_FILTER=stress-test`; scheduler and module scenarios complete or fail with explicit assertions instead of a process timeout panic.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.