### PR TITLE
fix(agent): validate BlockDevice selector only for In operator

### DIFF
--- a/images/agent/internal/controller/lvg/reconciler.go
+++ b/images/agent/internal/controller/lvg/reconciler.go
@@ -1472,7 +1472,7 @@ func validateSpecBlockDevices(lvg *v1alpha1.LVMVolumeGroup, blockDevices map[str
 	}
 
 	for _, me := range lvg.Spec.BlockDeviceSelector.MatchExpressions {
-		if me.Key == internal.MetadataNameLabelKey {
+		if me.Key == internal.MetadataNameLabelKey && me.Operator == v1.LabelSelectorOpIn {
 			if len(me.Values) != len(blockDevices) {
 				missedBds := make([]string, 0, len(me.Values))
 				for _, bdName := range me.Values {

--- a/images/agent/internal/controller/lvg/reconciler_test.go
+++ b/images/agent/internal/controller/lvg/reconciler_test.go
@@ -816,6 +816,42 @@ func TestLVMVolumeGroupWatcherCtrl(t *testing.T) {
 			assert.Equal(t, "none of specified BlockDevices were found", reason)
 		})
 
+		t.Run("validation_passes_with_exists_operator_on_metadata_name", func(t *testing.T) {
+			const (
+				nodeName = "nodeName"
+			)
+			lvg := &v1alpha1.LVMVolumeGroup{
+				Spec: v1alpha1.LVMVolumeGroupSpec{
+					Local: v1alpha1.LVMVolumeGroupLocalSpec{
+						NodeName: nodeName,
+					},
+					BlockDeviceSelector: &v1.LabelSelector{
+						MatchExpressions: []v1.LabelSelectorRequirement{
+							{
+								Key:      internal.MetadataNameLabelKey,
+								Operator: v1.LabelSelectorOpExists,
+							},
+						},
+					},
+				},
+			}
+
+			bds := map[string]v1alpha1.BlockDevice{
+				"first": {
+					ObjectMeta: v1.ObjectMeta{
+						Name: "first",
+					},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName: nodeName,
+					},
+				},
+			}
+
+			valid, reason := validateSpecBlockDevices(lvg, bds)
+			assert.True(t, valid)
+			assert.Empty(t, reason)
+		})
+
 		t.Run("validation_fails_due_to_some_blockdevice_were_not_found", func(t *testing.T) {
 			const (
 				nodeName = "nodeName"


### PR DESCRIPTION
## Description

Fix `validateSpecBlockDevices` to only apply the explicit name-count check when the `matchExpression` operator is `In`. Previously the check triggered for any operator (`Exists`, `DoesNotExist`, `NotIn`) on the `kubernetes.io/metadata.name` key, causing a false validation failure.

## Why do we need it, and what problem does it solve?

When an `LVMVolumeGroup` uses `blockDeviceSelector` with `matchExpressions` `{key: kubernetes.io/metadata.name, operator: Exists}`, the LVG validation always fails with `"unable to find specified BlockDevices: "` even though BlockDevices are correctly found by the Kubernetes label selector.

Root cause: `validateSpecBlockDevices` compares `len(me.Values)` (0 for `Exists`) against `len(blockDevices)` (>= 1), enters the error branch, iterates an empty `Values` slice, and returns an empty error list.

## What is the expected result?

- `LVMVolumeGroup` with `blockDeviceSelector` using `Exists` / `DoesNotExist` / `NotIn` operators on `kubernetes.io/metadata.name` passes validation and proceeds to VG configuration.
- Existing behavior for `In` operator is unchanged.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.