### PR TITLE
Feat/legacy bd name saver

### DIFF
--- a/images/agent/internal/controller/bd/discoverer.go
+++ b/images/agent/internal/controller/bd/discoverer.go
@@ -674,6 +674,7 @@ func legacyNonConsumableBlockDeviceMatches(
 
 	return candidate.Path != "" &&
 		candidate.Path == blockDevice.Status.Path &&
+		candidate.Type == blockDevice.Status.Type &&
 		candidate.Size.Value() == blockDevice.Status.Size.Value()
 }
 

--- a/images/agent/internal/controller/bd/discoverer.go
+++ b/images/agent/internal/controller/bd/discoverer.go
@@ -144,6 +144,13 @@ func (d *Discoverer) blockDeviceReconcile(ctx context.Context) (bool, error) {
 		if !exist {
 			legacyBlockDevice, found := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
 			if found {
+				d.log.Info(fmt.Sprintf(
+					`[RunBlockDeviceController] found legacy non-consumable BlockDevice, candidate name: "%s", legacy name: "%s", path: "%s"`,
+					candidate.Name, legacyBlockDevice.Name, candidate.Path,
+				))
+				// Adopt the legacy name only for this update path. The candidate
+				// slice keeps the new name, and old non-consumable devices are not
+				// removed by removeDeprecatedAPIDevices.
 				candidate.Name = legacyBlockDevice.Name
 				blockDevice = legacyBlockDevice
 				exist = true
@@ -665,16 +672,29 @@ func legacyNonConsumableBlockDeviceMatches(
 	if candidate.PVUuid != "" && candidate.PVUuid == blockDevice.Status.PVUuid {
 		return true
 	}
-	if candidate.VGUuid != "" && candidate.VGUuid == blockDevice.Status.VGUuid {
-		return true
-	}
 	if candidate.PartUUID != "" && candidate.PartUUID == blockDevice.Status.PartUUID {
 		return true
 	}
 
+	if sameBlockDeviceTypeAndSize(candidate, blockDevice) {
+		if wwn := candidate.GetWWN(); wwn != "" {
+			return wwn == blockDevice.Status.Wwn
+		}
+		if serial := candidate.GetSerial(); serial != "" {
+			return serial == blockDevice.Status.Serial
+		}
+		if blockDevice.Status.Wwn != "" || blockDevice.Status.Serial != "" {
+			return false
+		}
+	}
+
 	return candidate.Path != "" &&
 		candidate.Path == blockDevice.Status.Path &&
-		candidate.Type == blockDevice.Status.Type &&
+		sameBlockDeviceTypeAndSize(candidate, blockDevice)
+}
+
+func sameBlockDeviceTypeAndSize(candidate internal.BlockDeviceCandidate, blockDevice v1alpha1.BlockDevice) bool {
+	return candidate.Type == blockDevice.Status.Type &&
 		candidate.Size.Value() == blockDevice.Status.Size.Value()
 }
 

--- a/images/agent/internal/controller/bd/discoverer.go
+++ b/images/agent/internal/controller/bd/discoverer.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package bd
@@ -141,6 +141,15 @@ func (d *Discoverer) blockDeviceReconcile(ctx context.Context) (bool, error) {
 	// create new API devices
 	for _, candidate := range candidates {
 		blockDevice, exist := apiBlockDevices[candidate.Name]
+		if !exist {
+			legacyBlockDevice, found := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
+			if found {
+				candidate.Name = legacyBlockDevice.Name
+				blockDevice = legacyBlockDevice
+				exist = true
+			}
+		}
+
 		if exist {
 			addToDeleteListIfNotMatched := func(blockDevice v1alpha1.BlockDevice) {
 				if !deviceMatchesSelector(&blockDevice) {
@@ -619,6 +628,53 @@ func shouldDeleteBlockDevice(bd v1alpha1.BlockDevice, actualCandidates map[strin
 func isBlockDeviceDeprecated(blockDevice string, actualCandidates map[string]struct{}) bool {
 	_, ok := actualCandidates[blockDevice]
 	return !ok
+}
+
+func findLegacyNonConsumableBlockDevice(
+	candidate internal.BlockDeviceCandidate,
+	apiBlockDevices map[string]v1alpha1.BlockDevice,
+) (v1alpha1.BlockDevice, bool) {
+	if candidate.Consumable {
+		return v1alpha1.BlockDevice{}, false
+	}
+
+	var matched v1alpha1.BlockDevice
+	found := false
+	for _, blockDevice := range apiBlockDevices {
+		if !legacyNonConsumableBlockDeviceMatches(candidate, blockDevice) {
+			continue
+		}
+		if found {
+			return v1alpha1.BlockDevice{}, false
+		}
+		matched = blockDevice
+		found = true
+	}
+
+	return matched, found
+}
+
+func legacyNonConsumableBlockDeviceMatches(
+	candidate internal.BlockDeviceCandidate,
+	blockDevice v1alpha1.BlockDevice,
+) bool {
+	if blockDevice.Status.NodeName != candidate.NodeName || blockDevice.Status.Consumable {
+		return false
+	}
+
+	if candidate.PVUuid != "" && candidate.PVUuid == blockDevice.Status.PVUuid {
+		return true
+	}
+	if candidate.VGUuid != "" && candidate.VGUuid == blockDevice.Status.VGUuid {
+		return true
+	}
+	if candidate.PartUUID != "" && candidate.PartUUID == blockDevice.Status.PartUUID {
+		return true
+	}
+
+	return candidate.Path != "" &&
+		candidate.Path == blockDevice.Status.Path &&
+		candidate.Size.Value() == blockDevice.Status.Size.Value()
 }
 
 func hasValidSize(size resource.Quantity) (bool, error) {

--- a/images/agent/internal/controller/bd/discoverer_test.go
+++ b/images/agent/internal/controller/bd/discoverer_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package bd
@@ -486,6 +486,58 @@ func TestBlockDeviceCtrl(t *testing.T) {
 		}
 	})
 
+	t.Run("BlockDeviceReconcile", func(t *testing.T) {
+		t.Run("updates_existing_non_consumable_block_device_when_new_hash_name_differs", func(t *testing.T) {
+			ctx := context.Background()
+			d := setupDiscoverer()
+
+			oldCandidate := internal.BlockDeviceCandidate{
+				NodeName:   d.cfg.NodeName,
+				MachineID:  d.cfg.MachineID,
+				Consumable: false,
+				Path:       "/dev/sdz",
+				KName:      "/dev/sdz",
+				Type:       "disk",
+				Serial:     "stable-serial",
+				Wwn:        "stable-wwn",
+				Model:      "legacy-model",
+				HotPlug:    true,
+				Size:       resource.MustParse("2G"),
+			}
+			oldCandidate.Name = createUniqDeviceName(oldCandidate)
+			oldBlockDevice := oldCandidate.AsAPIBlockDevice()
+			assert.NoError(t, d.cl.Create(ctx, &oldBlockDevice))
+
+			currentDevice := internal.Device{
+				Name:    oldCandidate.Path,
+				KName:   oldCandidate.KName,
+				Type:    oldCandidate.Type,
+				Serial:  oldCandidate.Serial,
+				Wwn:     oldCandidate.Wwn,
+				Model:   "current-model",
+				HotPlug: true,
+				Size:    oldCandidate.Size,
+			}
+			currentCandidate := internal.NewBlockDeviceCandidateByDevice(&currentDevice, d.cfg.NodeName, d.cfg.MachineID)
+			currentName := createUniqDeviceName(currentCandidate)
+			assert.NotEqual(t, oldCandidate.Name, currentName)
+
+			d.sdsCache.StoreDevices([]internal.Device{currentDevice}, bytes.Buffer{})
+
+			_, err := d.blockDeviceReconcile(ctx)
+			assert.NoError(t, err)
+
+			var list v1alpha1.BlockDeviceList
+			assert.NoError(t, d.cl.List(ctx, &list))
+			if assert.Len(t, list.Items, 1) {
+				assert.Equal(t, oldCandidate.Name, list.Items[0].Name)
+				assert.Equal(t, currentDevice.Model, list.Items[0].Status.Model)
+				assert.Equal(t, currentDevice.Name, list.Items[0].Status.Path)
+				assert.False(t, list.Items[0].Status.Consumable)
+			}
+		})
+	})
+
 	t.Run("CreateUniqDeviceName", func(t *testing.T) {
 		nodeName := "testNode"
 		can := internal.BlockDeviceCandidate{
@@ -499,6 +551,107 @@ func TestBlockDeviceCtrl(t *testing.T) {
 		deviceName := createUniqDeviceName(can)
 		assert.Equal(t, "dev-", deviceName[0:4], "device name does not start with dev-")
 		assert.Equal(t, len(deviceName[4:]), 40, "device name does not contains sha1 sum")
+	})
+
+	t.Run("FindLegacyNonConsumableBlockDevice", func(t *testing.T) {
+		t.Run("matches_only_non_consumable_block_device_on_same_node", func(t *testing.T) {
+			candidate := internal.BlockDeviceCandidate{
+				NodeName:   "node-a",
+				Consumable: false,
+				Path:       "/dev/sdz",
+				Serial:     "serial",
+				Size:       resource.MustParse("2G"),
+			}
+			apiBlockDevices := map[string]v1alpha1.BlockDevice{
+				"same-node": {
+					ObjectMeta: metav1.ObjectMeta{Name: "same-node"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: false,
+						Path:       candidate.Path,
+						Size:       candidate.Size,
+					},
+				},
+				"other-node": {
+					ObjectMeta: metav1.ObjectMeta{Name: "other-node"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   "node-b",
+						Consumable: false,
+						Path:       candidate.Path,
+						Size:       candidate.Size,
+					},
+				},
+				"consumable": {
+					ObjectMeta: metav1.ObjectMeta{Name: "consumable"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: true,
+						Path:       candidate.Path,
+						Size:       candidate.Size,
+					},
+				},
+			}
+
+			blockDevice, ok := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
+			if assert.True(t, ok) {
+				assert.Equal(t, "same-node", blockDevice.Name)
+			}
+		})
+
+		t.Run("returns_false_for_consumable_candidate", func(t *testing.T) {
+			candidate := internal.BlockDeviceCandidate{
+				NodeName:   "node-a",
+				Consumable: true,
+				Path:       "/dev/sdz",
+				Size:       resource.MustParse("2G"),
+			}
+			apiBlockDevices := map[string]v1alpha1.BlockDevice{
+				"same-node": {
+					ObjectMeta: metav1.ObjectMeta{Name: "same-node"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: false,
+						Path:       candidate.Path,
+						Size:       candidate.Size,
+					},
+				},
+			}
+
+			_, ok := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
+			assert.False(t, ok)
+		})
+
+		t.Run("returns_false_for_ambiguous_matches", func(t *testing.T) {
+			candidate := internal.BlockDeviceCandidate{
+				NodeName:   "node-a",
+				Consumable: false,
+				Path:       "/dev/sdz",
+				Size:       resource.MustParse("2G"),
+			}
+			apiBlockDevices := map[string]v1alpha1.BlockDevice{
+				"first": {
+					ObjectMeta: metav1.ObjectMeta{Name: "first"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: false,
+						Path:       candidate.Path,
+						Size:       candidate.Size,
+					},
+				},
+				"second": {
+					ObjectMeta: metav1.ObjectMeta{Name: "second"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: false,
+						Path:       candidate.Path,
+						Size:       candidate.Size,
+					},
+				},
+			}
+
+			_, ok := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
+			assert.False(t, ok)
+		})
 	})
 
 	t.Run("CheckTag", func(t *testing.T) {

--- a/images/agent/internal/controller/bd/discoverer_test.go
+++ b/images/agent/internal/controller/bd/discoverer_test.go
@@ -621,6 +621,31 @@ func TestBlockDeviceCtrl(t *testing.T) {
 			assert.False(t, ok)
 		})
 
+		t.Run("returns_false_for_path_size_match_with_different_type", func(t *testing.T) {
+			candidate := internal.BlockDeviceCandidate{
+				NodeName:   "node-a",
+				Consumable: false,
+				Path:       "/dev/sdz",
+				Type:       "raid1",
+				Size:       resource.MustParse("2G"),
+			}
+			apiBlockDevices := map[string]v1alpha1.BlockDevice{
+				"same-node": {
+					ObjectMeta: metav1.ObjectMeta{Name: "same-node"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: false,
+						Path:       candidate.Path,
+						Type:       "disk",
+						Size:       candidate.Size,
+					},
+				},
+			}
+
+			_, ok := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
+			assert.False(t, ok)
+		})
+
 		t.Run("returns_false_for_ambiguous_matches", func(t *testing.T) {
 			candidate := internal.BlockDeviceCandidate{
 				NodeName:   "node-a",

--- a/images/agent/internal/controller/bd/discoverer_test.go
+++ b/images/agent/internal/controller/bd/discoverer_test.go
@@ -559,7 +559,7 @@ func TestBlockDeviceCtrl(t *testing.T) {
 				NodeName:   "node-a",
 				Consumable: false,
 				Path:       "/dev/sdz",
-				Serial:     "serial",
+				Type:       "disk",
 				Size:       resource.MustParse("2G"),
 			}
 			apiBlockDevices := map[string]v1alpha1.BlockDevice{
@@ -569,6 +569,7 @@ func TestBlockDeviceCtrl(t *testing.T) {
 						NodeName:   candidate.NodeName,
 						Consumable: false,
 						Path:       candidate.Path,
+						Type:       candidate.Type,
 						Size:       candidate.Size,
 					},
 				},
@@ -578,6 +579,7 @@ func TestBlockDeviceCtrl(t *testing.T) {
 						NodeName:   "node-b",
 						Consumable: false,
 						Path:       candidate.Path,
+						Type:       candidate.Type,
 						Size:       candidate.Size,
 					},
 				},
@@ -587,6 +589,7 @@ func TestBlockDeviceCtrl(t *testing.T) {
 						NodeName:   candidate.NodeName,
 						Consumable: true,
 						Path:       candidate.Path,
+						Type:       candidate.Type,
 						Size:       candidate.Size,
 					},
 				},
@@ -637,6 +640,93 @@ func TestBlockDeviceCtrl(t *testing.T) {
 						Consumable: false,
 						Path:       candidate.Path,
 						Type:       "disk",
+						Size:       candidate.Size,
+					},
+				},
+			}
+
+			_, ok := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
+			assert.False(t, ok)
+		})
+
+		t.Run("matches_by_serial_when_model_change_generates_new_name", func(t *testing.T) {
+			candidate := internal.BlockDeviceCandidate{
+				NodeName:   "node-a",
+				Consumable: false,
+				Path:       "/dev/sdz",
+				Type:       "disk",
+				Serial:     "stable-serial",
+				Model:      "new-model",
+				Size:       resource.MustParse("2G"),
+			}
+			apiBlockDevices := map[string]v1alpha1.BlockDevice{
+				"same-device": {
+					ObjectMeta: metav1.ObjectMeta{Name: "same-device"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: false,
+						Path:       "/dev/legacy-path",
+						Type:       candidate.Type,
+						Serial:     candidate.Serial,
+						Model:      "legacy-model",
+						Size:       candidate.Size,
+					},
+				},
+			}
+
+			blockDevice, ok := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
+			if assert.True(t, ok) {
+				assert.Equal(t, "same-device", blockDevice.Name)
+			}
+		})
+
+		t.Run("returns_false_for_same_vg_uuid_with_different_pv_uuid", func(t *testing.T) {
+			candidate := internal.BlockDeviceCandidate{
+				NodeName:   "node-a",
+				Consumable: false,
+				Path:       "/dev/sdz",
+				Type:       "disk",
+				PVUuid:     "pv-a",
+				VGUuid:     "shared-vg",
+				Size:       resource.MustParse("2G"),
+			}
+			apiBlockDevices := map[string]v1alpha1.BlockDevice{
+				"different-pv": {
+					ObjectMeta: metav1.ObjectMeta{Name: "different-pv"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: false,
+						Path:       "/dev/sdy",
+						Type:       candidate.Type,
+						PVUuid:     "pv-b",
+						VGUuid:     candidate.VGUuid,
+						Size:       candidate.Size,
+					},
+				},
+			}
+
+			_, ok := findLegacyNonConsumableBlockDevice(candidate, apiBlockDevices)
+			assert.False(t, ok)
+		})
+
+		t.Run("returns_false_for_path_type_size_match_with_different_serial", func(t *testing.T) {
+			candidate := internal.BlockDeviceCandidate{
+				NodeName:   "node-a",
+				Consumable: false,
+				Path:       "/dev/sdz",
+				Type:       "disk",
+				Serial:     "candidate-serial",
+				Size:       resource.MustParse("2G"),
+			}
+			apiBlockDevices := map[string]v1alpha1.BlockDevice{
+				"different-device": {
+					ObjectMeta: metav1.ObjectMeta{Name: "different-device"},
+					Status: v1alpha1.BlockDeviceStatus{
+						NodeName:   candidate.NodeName,
+						Consumable: false,
+						Path:       candidate.Path,
+						Type:       candidate.Type,
+						Serial:     "legacy-serial",
 						Size:       candidate.Size,
 					},
 				},


### PR DESCRIPTION
This pull request enhances the block device discovery logic to better handle legacy non-consumable block devices whose unique names may change due to hardware or metadata updates. It introduces a mechanism to match new candidates with existing legacy block devices based on stable attributes (like serial number or WWN), ensuring continuity and preventing unnecessary device recreation. Comprehensive tests have been added to validate these changes and cover various edge cases.

Block device reconciliation improvements:
* Added logic in `blockDeviceReconcile` to detect and adopt legacy non-consumable block devices when a new candidate's generated name differs but stable identifiers match, preventing redundant device removal and recreation.
* Introduced the `findLegacyNonConsumableBlockDevice` function and supporting matching logic (`legacyNonConsumableBlockDeviceMatches`, `sameBlockDeviceTypeAndSize`) to robustly identify legacy non-consumable devices based on node, consumable status, and stable hardware attributes.

Testing enhancements:
* Added a dedicated test suite for `findLegacyNonConsumableBlockDevice`, covering matching by node, consumable status, type, size, serial, ambiguous matches, and edge cases to ensure correct legacy device adoption.
* Added a new test to `BlockDeviceReconcile` to verify that existing non-consumable block devices are updated (not recreated) when only the generated name changes due to hardware property modifications.

General:
* Updated copyright years in `discoverer.go` and `discoverer_test.go`. [[1]](diffhunk://#diff-a8709c961a667ab569b5b9d40eab05f22da36e23d92bb9c520ca0cde7948814cL2-R2) [[2]](diffhunk://#diff-79cad4228611f153baf328f823bab74b2b5dcbb98c8a5567dc75bf5ef951269bL2-R2)