### PR TITLE
E2E Add LVG/BD stability test 

### DIFF
--- a/e2e/tests/e2e_cluster_lock_test.go
+++ b/e2e/tests/e2e_cluster_lock_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
 	"github.com/deckhouse/storage-e2e/pkg/cluster"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,27 +86,15 @@ func e2eTryDeleteClusterLockViaKubeconfig(ctx context.Context) error {
 // e2eForceReleaseClusterLockViaSSH opens the same SSH + API tunnel as UseExistingCluster (step 1) and deletes the lock ConfigMap.
 // Use when KUBE_CONFIG_PATH uses 127.0.0.1 and nothing is listening until storage-e2e establishes the tunnel.
 func e2eForceReleaseClusterLockViaSSH(ctx context.Context) error {
-	e2eCfg := cfg.Load()
-
 	tmpDir, err := os.MkdirTemp("", "e2e-lock-release-kube-*")
 	if err != nil {
 		return err
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	var opts cluster.ConnectClusterOptions
-
-	if e2eCfg.SSH.Jump.Host != "" {
-		opts = cluster.ConnectClusterOptions{
-			SSHUser: e2eCfg.SSH.Jump.User, SSHHost: e2eCfg.SSH.Jump.Host, SSHKeyPath: e2eCfg.SSH.Jump.PrivateKeyPath,
-			UseJumpHost: true, TargetUser: e2eCfg.SSH.User, TargetHost: e2eCfg.SSH.Host, TargetKeyPath: e2eCfg.SSH.PrivateKey,
-			KubeconfigOutputDir: tmpDir,
-		}
-	} else {
-		opts = cluster.ConnectClusterOptions{
-			SSHUser: e2eCfg.SSH.User, SSHHost: e2eCfg.SSH.Host, SSHKeyPath: e2eCfg.SSH.PrivateKey,
-			UseJumpHost: false, KubeconfigOutputDir: tmpDir,
-		}
+	opts, err := e2eBaseClusterConnectOptions(tmpDir)
+	if err != nil {
+		return fmt.Errorf("base cluster SSH options: %w", err)
 	}
 
 	res, err := cluster.ConnectToCluster(ctx, opts)

--- a/e2e/tests/sds_node_configurator_helpers_cleanup_scheduler_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_cleanup_scheduler_test.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -142,6 +143,144 @@ func isPodReady(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// e2eManagedStorageSnapshot captures BlockDevice/LVMVolumeGroup identity and status on a node
+// before controller restart; used to assert no recreate/delete churn after the pod comes back.
+type e2eManagedStorageSnapshot struct {
+	NodeName               string
+	BlockDeviceNamesOnNode map[string]types.UID
+	BlockDeviceName        string
+	BlockDeviceUID         types.UID
+	BlockDeviceStatus      e2eBlockDeviceStatusSnapshot
+	LVMVolumeGroupName     string
+	LVMVolumeGroupUID      types.UID
+	LVMVolumeGroupStatus   e2eLVMVolumeGroupStatusSnapshot
+}
+
+type e2eBlockDeviceStatusSnapshot struct {
+	Path                  string
+	Size                  string
+	Consumable            bool
+	PVUuid                string
+	LVMVolumeGroupName    string
+	ActualVGNameOnTheNode string
+}
+
+type e2eLVMVolumeGroupStatusSnapshot struct {
+	Phase              string
+	VGSize             string
+	VGFree             string
+	ThinPoolNamesReady map[string]bool
+}
+
+func e2eBlockDevicesOnNode(ctx context.Context, cl client.Client, nodeName string) (map[string]types.UID, error) {
+	var list v1alpha1.BlockDeviceList
+	if err := cl.List(ctx, &list, &client.ListOptions{}); err != nil {
+		return nil, err
+	}
+	out := make(map[string]types.UID)
+	for i := range list.Items {
+		bd := &list.Items[i]
+		if bd.Status.NodeName != nodeName || bd.DeletionTimestamp != nil {
+			continue
+		}
+		out[bd.Name] = bd.UID
+	}
+	return out, nil
+}
+
+func e2eTakeManagedStorageSnapshot(ctx context.Context, cl client.Client, nodeName, blockDeviceName, lvgName string) (e2eManagedStorageSnapshot, error) {
+	bdsOnNode, err := e2eBlockDevicesOnNode(ctx, cl, nodeName)
+	if err != nil {
+		return e2eManagedStorageSnapshot{}, err
+	}
+
+	var bd v1alpha1.BlockDevice
+	if err := cl.Get(ctx, client.ObjectKey{Name: blockDeviceName}, &bd); err != nil {
+		return e2eManagedStorageSnapshot{}, err
+	}
+
+	var lvg v1alpha1.LVMVolumeGroup
+	if err := cl.Get(ctx, client.ObjectKey{Name: lvgName}, &lvg); err != nil {
+		return e2eManagedStorageSnapshot{}, err
+	}
+
+	thinReady := make(map[string]bool, len(lvg.Status.ThinPools))
+	for i := range lvg.Status.ThinPools {
+		tp := lvg.Status.ThinPools[i]
+		thinReady[tp.Name] = tp.Ready
+	}
+
+	return e2eManagedStorageSnapshot{
+		NodeName:               nodeName,
+		BlockDeviceNamesOnNode: bdsOnNode,
+		BlockDeviceName:        bd.Name,
+		BlockDeviceUID:         bd.UID,
+		BlockDeviceStatus: e2eBlockDeviceStatusSnapshot{
+			Path:                  bd.Status.Path,
+			Size:                  bd.Status.Size.String(),
+			Consumable:            bd.Status.Consumable,
+			PVUuid:                bd.Status.PVUuid,
+			LVMVolumeGroupName:    bd.Status.LVMVolumeGroupName,
+			ActualVGNameOnTheNode: bd.Status.ActualVGNameOnTheNode,
+		},
+		LVMVolumeGroupName:   lvg.Name,
+		LVMVolumeGroupUID:    lvg.UID,
+		LVMVolumeGroupStatus: e2eLVMVolumeGroupStatusSnapshot{
+			Phase:              lvg.Status.Phase,
+			VGSize:             lvg.Status.VGSize.String(),
+			VGFree:             lvg.Status.VGFree.String(),
+			ThinPoolNamesReady: thinReady,
+		},
+	}, nil
+}
+
+func e2eExpectManagedStorageStableAfterRestart(ctx context.Context, cl client.Client, before e2eManagedStorageSnapshot) {
+	Eventually(func(g Gomega) {
+		afterBDs, err := e2eBlockDevicesOnNode(ctx, cl, before.NodeName)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(afterBDs).To(Equal(before.BlockDeviceNamesOnNode),
+			"BlockDevice set on node %s must not change (no unexpected create/delete)", before.NodeName)
+
+		var bd v1alpha1.BlockDevice
+		g.Expect(cl.Get(ctx, client.ObjectKey{Name: before.BlockDeviceName}, &bd)).To(Succeed())
+		g.Expect(bd.UID).To(Equal(before.BlockDeviceUID), "BlockDevice %s must not be recreated", before.BlockDeviceName)
+		g.Expect(bd.DeletionTimestamp).To(BeNil())
+		g.Expect(bd.Status.Path).To(Equal(before.BlockDeviceStatus.Path))
+		g.Expect(bd.Status.Size.String()).To(Equal(before.BlockDeviceStatus.Size))
+		g.Expect(bd.Status.Consumable).To(Equal(before.BlockDeviceStatus.Consumable))
+		g.Expect(bd.Status.PVUuid).To(Equal(before.BlockDeviceStatus.PVUuid))
+		g.Expect(bd.Status.LVMVolumeGroupName).To(Equal(before.BlockDeviceStatus.LVMVolumeGroupName))
+		g.Expect(bd.Status.ActualVGNameOnTheNode).To(Equal(before.BlockDeviceStatus.ActualVGNameOnTheNode))
+
+		var lvg v1alpha1.LVMVolumeGroup
+		g.Expect(cl.Get(ctx, client.ObjectKey{Name: before.LVMVolumeGroupName}, &lvg)).To(Succeed())
+		g.Expect(lvg.UID).To(Equal(before.LVMVolumeGroupUID), "LVMVolumeGroup %s must not be recreated", before.LVMVolumeGroupName)
+		g.Expect(lvg.DeletionTimestamp).To(BeNil())
+		g.Expect(lvg.Status.Phase).To(Equal(v1alpha1.PhaseReady), "LVMVolumeGroup phase should converge to Ready")
+		g.Expect(lvg.Status.VGSize.String()).To(Equal(before.LVMVolumeGroupStatus.VGSize))
+		g.Expect(lvg.Status.VGFree.String()).To(Equal(before.LVMVolumeGroupStatus.VGFree))
+
+		g.Expect(len(lvg.Status.ThinPools)).To(Equal(len(before.LVMVolumeGroupStatus.ThinPoolNamesReady)),
+			"thin-pool count must stay the same")
+		for name, wasReady := range before.LVMVolumeGroupStatus.ThinPoolNamesReady {
+			var found *v1alpha1.LVMVolumeGroupThinPoolStatus
+			for i := range lvg.Status.ThinPools {
+				if lvg.Status.ThinPools[i].Name == name {
+					found = &lvg.Status.ThinPools[i]
+					break
+				}
+			}
+			g.Expect(found).NotTo(BeNil(), "thin-pool %q missing from status after restart", name)
+			g.Expect(found.Ready).To(Equal(wasReady), "thin-pool %q Ready flag changed unexpectedly", name)
+		}
+
+		for _, c := range lvg.Status.Conditions {
+			g.Expect(c.Status).NotTo(Equal(metav1.ConditionFalse),
+				"condition %s has status False after restart: reason=%s message=%s", c.Type, c.Reason, c.Message)
+		}
+	}, e2eLVMVolumeGroupReadyTimeout, 8*time.Second).Should(Succeed())
 }
 
 // e2eClusterStateJSONPath returns the path to storage-e2e cluster-state.json for this test file

--- a/e2e/tests/sds_node_configurator_helpers_cluster_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_cluster_test.go
@@ -41,6 +41,51 @@ import (
 	"github.com/deckhouse/storage-e2e/pkg/cluster"
 )
 
+// e2eBaseClusterConnectOptions builds storage-e2e ConnectClusterOptions for the base (virtualization) cluster.
+// Resolves SSH_PRIVATE_KEY (path or base64 PEM) and mirrors storage-e2e jump-host key fallbacks.
+func e2eBaseClusterConnectOptions(kubeconfigDir string) (cluster.ConnectClusterOptions, error) {
+	c := e2ecfg.Load()
+	sshKeyPath, err := e2eGetSSHPrivateKeyPath()
+	if err != nil {
+		return cluster.ConnectClusterOptions{}, err
+	}
+	sshUser := strings.TrimSpace(c.SSH.User)
+	sshHost := strings.TrimSpace(c.SSH.Host)
+	if sshUser == "" || sshHost == "" {
+		return cluster.ConnectClusterOptions{}, fmt.Errorf("SSH_USER and SSH_HOST must be set for base cluster connect")
+	}
+
+	jumpHost := strings.TrimSpace(c.SSH.Jump.Host)
+	if jumpHost != "" {
+		jumpUser := strings.TrimSpace(c.SSH.Jump.User)
+		if jumpUser == "" {
+			jumpUser = sshUser
+		}
+		jumpKeyPath := strings.TrimSpace(c.SSH.Jump.PrivateKeyPath)
+		if jumpKeyPath == "" {
+			jumpKeyPath = sshKeyPath
+		}
+		return cluster.ConnectClusterOptions{
+			SSHUser:             jumpUser,
+			SSHHost:             jumpHost,
+			SSHKeyPath:          jumpKeyPath,
+			UseJumpHost:         true,
+			TargetUser:          sshUser,
+			TargetHost:          sshHost,
+			TargetKeyPath:       sshKeyPath,
+			KubeconfigOutputDir: kubeconfigDir,
+		}, nil
+	}
+
+	return cluster.ConnectClusterOptions{
+		SSHUser:             sshUser,
+		SSHHost:             sshHost,
+		SSHKeyPath:          sshKeyPath,
+		UseJumpHost:         false,
+		KubeconfigOutputDir: kubeconfigDir,
+	}, nil
+}
+
 // clusterResumeState mirrors storage-e2e cluster-state.json (namespace after VMs are created).
 // e2eSuiteSharedStorageCleanup removes e2e VirtualDisks, PVCs/Pods, LocalStorageClasses, LVMLogicalVolumes, and LVMVolumeGroups
 // after both Common Scheduler and Sds Node Configurator Describes complete.
@@ -220,7 +265,6 @@ func e2eSyncCleanupBaseClusterNamespace(ctx context.Context, clusterStatePath st
 			GinkgoWriter.Printf("    ⚠️  cleanup: read %s: %v\n", clusterStatePath, readErr)
 		}
 	}
-	cfg := e2ecfg.Load()
 	if ns == "" {
 		ns = e2eConfigNamespace()
 		GinkgoWriter.Printf("    ▶️  cleanup: namespace from TEST_CLUSTER_NAMESPACE=%q\n", ns)
@@ -228,19 +272,10 @@ func e2eSyncCleanupBaseClusterNamespace(ctx context.Context, clusterStatePath st
 		GinkgoWriter.Printf("    ▶️  cleanup: namespace from cluster-state.json: %q\n", ns)
 	}
 
-	var opts cluster.ConnectClusterOptions
-	if cfg.SSH.Jump.Host != "" {
-		opts = cluster.ConnectClusterOptions{
-			SSHUser: cfg.SSH.User, SSHHost: cfg.SSH.Jump.Host, SSHKeyPath: cfg.SSH.Jump.PrivateKeyPath,
-			UseJumpHost: true, TargetUser: cfg.SSH.User, TargetHost: cfg.SSH.Host, TargetKeyPath: cfg.SSH.PrivateKey,
-			KubeconfigOutputDir: kubeconfigDir,
-		}
-	} else {
-		opts = cluster.ConnectClusterOptions{
-			SSHUser: cfg.SSH.User, SSHHost: cfg.SSH.Host, SSHKeyPath: cfg.SSH.PrivateKey,
-			UseJumpHost:         false,
-			KubeconfigOutputDir: kubeconfigDir,
-		}
+	opts, optsErr := e2eBaseClusterConnectOptions(kubeconfigDir)
+	if optsErr != nil {
+		GinkgoWriter.Printf("    ⚠️  cleanup: base cluster SSH options: %v\n", optsErr)
+		return
 	}
 
 	baseRes, err := cluster.ConnectToCluster(ctx, opts)

--- a/e2e/tests/sds_node_configurator_helpers_virtualization_test.go
+++ b/e2e/tests/sds_node_configurator_helpers_virtualization_test.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
 	virtv1alpha2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -472,8 +471,6 @@ func waitForVirtualizationModuleReadyIfNeeded(ctx context.Context) error {
 		return nil
 	}
 
-	e2eCfg := cfg.Load()
-
 	kubeconfigDir, err := e2eTestTempDirFromStack()
 	if err != nil {
 		return err
@@ -482,19 +479,9 @@ func waitForVirtualizationModuleReadyIfNeeded(ctx context.Context) error {
 		return fmt.Errorf("mkdir kubeconfig dir for virtualization pre-wait: %w", err)
 	}
 
-	var opts cluster.ConnectClusterOptions
-
-	if e2eCfg.SSH.Jump.Host != "" {
-		opts = cluster.ConnectClusterOptions{
-			SSHUser: e2eCfg.SSH.Jump.User, SSHHost: e2eCfg.SSH.Jump.Host, SSHKeyPath: e2eCfg.SSH.Jump.PrivateKeyPath,
-			UseJumpHost: true, TargetUser: e2eCfg.SSH.User, TargetHost: e2eCfg.SSH.Host, TargetKeyPath: e2eCfg.SSH.PrivateKey,
-			KubeconfigOutputDir: kubeconfigDir,
-		}
-	} else {
-		opts = cluster.ConnectClusterOptions{
-			SSHUser: e2eCfg.SSH.User, SSHHost: e2eCfg.SSH.Host, SSHKeyPath: e2eCfg.SSH.PrivateKey,
-			UseJumpHost: false, KubeconfigOutputDir: kubeconfigDir,
-		}
+	opts, err := e2eBaseClusterConnectOptions(kubeconfigDir)
+	if err != nil {
+		return fmt.Errorf("base cluster SSH options: %w", err)
 	}
 
 	GinkgoWriter.Printf("    🔌 Connecting to base cluster (SSH) for virtualization Module pre-wait...\n")

--- a/e2e/tests/sds_node_configurator_test.go
+++ b/e2e/tests/sds_node_configurator_test.go
@@ -2759,6 +2759,109 @@ sudo -n vgchange "$VG" --addtag storage.deckhouse.io/enabled=true 2>&1
 			})
 		})
 
+		Context("Controller pod restart preserves managed VG and BlockDevice state", func() {
+			const (
+				e2eRestartStateDiskName = "e2e-restart-state-disk"
+				e2eRestartStateDiskSize = "2Gi"
+			)
+
+			var (
+				restartStateAttachment *kubernetes.VirtualDiskAttachmentResult
+				restartStateRunID      string
+			)
+
+			AfterEach(func() {
+				if restartStateAttachment == nil || testClusterResources == nil || testClusterResources.BaseKubeconfig == nil {
+					return
+				}
+				ns := e2eConfigNamespace()
+				By("Cleaning up restart-state test VirtualDisk and attachment")
+				_ = kubernetes.DetachAndDeleteVirtualDisk(e2eCtx, testClusterResources.BaseKubeconfig, ns,
+					restartStateAttachment.AttachmentName, restartStateAttachment.DiskName)
+				restartStateAttachment = nil
+			})
+
+			It("Should preserve managed VG and BlockDevice state after controller pod restart", func() {
+				ensureE2EK8sClient(testClusterResources, &k8sClient, e2eCtx)
+				By("Сценарий: управляемые VG и BlockDevice → перезапуск pod контроллера → без лишних create/delete, статусы сходятся")
+
+				Expect(testClusterResources.BaseKubeconfig).NotTo(BeNil(), "restart-state test requires nested virtualization (base cluster)")
+				ns := e2eConfigNamespace()
+				storageClass := e2eConfigStorageClass()
+				Expect(storageClass).NotTo(BeEmpty(), "TEST_CLUSTER_STORAGE_CLASS is required for VirtualDisk")
+
+				restartStateRunID = fmt.Sprintf("%d", time.Now().Unix())
+				clusterVMs := e2eListClusterVMNames(e2eCtx, testClusterResources, ns)
+				targetVM := clusterVMs[rand.Intn(len(clusterVMs))]
+
+				By("Step 1: attach disk and wait for consumable BlockDevice")
+				var attachErr error
+				restartStateAttachment, attachErr = attachVirtualDiskWithRetry(e2eCtx, testClusterResources.BaseKubeconfig, kubernetes.VirtualDiskAttachmentConfig{
+					VMName:           targetVM,
+					Namespace:        ns,
+					DiskName:         e2eRestartStateDiskName,
+					DiskSize:         e2eRestartStateDiskSize,
+					StorageClassName: storageClass,
+				}, e2eVirtualDiskAttachMaxRetries, e2eVirtualDiskAttachRetryInterval)
+				Expect(attachErr).NotTo(HaveOccurred())
+
+				attachCtx, cancel := context.WithTimeout(e2eCtx, e2eVirtualDiskAttachWaitTimeout)
+				defer cancel()
+				Expect(kubernetes.WaitForVirtualDiskAttached(attachCtx, testClusterResources.BaseKubeconfig, ns,
+					restartStateAttachment.AttachmentName, 10*time.Second)).To(Succeed())
+
+				targetBD := e2eWaitConsumableBlockDeviceForVirtualDisk(e2eCtx, testClusterResources.BaseKubeconfig, k8sClient, ns,
+					restartStateAttachment.DiskName, restartStateAttachment.AttachmentName, targetVM)
+				nodeName := targetBD.Status.NodeName
+				bdMetaName := targetBD.Labels["kubernetes.io/metadata.name"]
+				if bdMetaName == "" {
+					bdMetaName = targetBD.Name
+				}
+
+				By("Step 1 (continued): create managed LVMVolumeGroup and wait for Ready")
+				vgName := "e2e-vg-restart-" + restartStateRunID
+				thinPoolName := "e2e-thin-pool-restart"
+				lvgName := "e2e-lvg-restart-" + restartStateRunID + "-" + strings.ReplaceAll(strings.ReplaceAll(nodeName, ".", "-"), "_", "-")
+				lvg := &v1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{Name: lvgName},
+					Spec: v1alpha1.LVMVolumeGroupSpec{
+						ActualVGNameOnTheNode: vgName,
+						BlockDeviceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/hostname":      nodeName,
+								"kubernetes.io/metadata.name": bdMetaName,
+							},
+						},
+						ThinPools: []v1alpha1.LVMVolumeGroupThinPoolSpec{
+							{Name: thinPoolName, Size: "60%", AllocationLimit: "100%"},
+						},
+						Type:  "Local",
+						Local: v1alpha1.LVMVolumeGroupLocalSpec{NodeName: nodeName},
+					},
+				}
+				Expect(k8sClient.Create(e2eCtx, lvg)).To(Succeed())
+				defer func() { _ = k8sClient.Delete(e2eCtx, lvg) }()
+
+				Eventually(func(g Gomega) {
+					var cur v1alpha1.LVMVolumeGroup
+					g.Expect(k8sClient.Get(e2eCtx, client.ObjectKey{Name: lvgName}, &cur)).To(Succeed())
+					g.Expect(cur.Status.Phase).To(Equal(v1alpha1.PhaseReady), "managed LVMVolumeGroup must be Ready before restart; phase=%s", cur.Status.Phase)
+				}, e2eLVMVolumeGroupReadyTimeout, 10*time.Second).Should(Succeed())
+
+				By("Step 2: snapshot BlockDevice/LVMVolumeGroup identity and status on the node")
+				snapshot, snapErr := e2eTakeManagedStorageSnapshot(e2eCtx, k8sClient, nodeName, targetBD.Name, lvgName)
+				Expect(snapErr).NotTo(HaveOccurred())
+				GinkgoWriter.Printf("    snapshot: %d BlockDevice(s) on node %s; BD=%s LVG=%s phase=%s\n",
+					len(snapshot.BlockDeviceNamesOnNode), nodeName, snapshot.BlockDeviceName, snapshot.LVMVolumeGroupName, snapshot.LVMVolumeGroupStatus.Phase)
+
+				By("Step 3: restart sds-node-configurator controller pod on the node")
+				restartSDSNodeConfiguratorAgentOnNode(e2eCtx, k8sClient, nodeName)
+
+				By("Step 4: verify no recreate/delete churn and statuses converge after controller is back")
+				e2eExpectManagedStorageStableAfterRestart(e2eCtx, k8sClient, snapshot)
+				By("✓ Managed VG and BlockDevice unchanged after controller pod restart")
+			})
+		})
 
 		Context("LVMVolumeGroup validation (disk not usable)", func() {
 			const (


### PR DESCRIPTION
Signed-off-by: Nikolay Demchuk <nikolay.demchuk@flant.com>

## Description

Add an e2e scenario that checks managed `LVMVolumeGroup` and `BlockDevice` stability after restarting the `sds-node-configurator` pod on the node, plus shared `e2eBaseClusterConnectOptions` so base-cluster SSH (cleanup, lock release, virtualization pre-wait) resolves keys like storage-e2e.

## Why do we need it, and what problem does it solve?

We need coverage for the case where a controller pod restarts while VG and BD already exist, to ensure there is no recreate/delete churn and statuses converge; the SSH helper fixes failed post-bootstrap cleanup when `SSH_JUMP_KEY_PATH` is unset but `SSH_PRIVATE_KEY` is set.

## What is the expected result?

After the test attaches a disk, waits for a Ready managed LVG, restarts the controller pod on that node, the same BD/LVG UIDs and node BD set remain, LVG returns to `Ready` without `False` conditions, and `ginkgo --focus="Should preserve managed VG and BlockDevice state after controller pod restart"` passes on a nested cluster.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.