### PR TITLE
fix(agent): unblock pod startup and add LVM command timeouts

### DIFF
--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	goruntime "runtime"
+	"syscall"
 
 	v1 "k8s.io/api/core/v1"
 	sv1 "k8s.io/api/storage/v1"
@@ -59,7 +61,19 @@ var (
 )
 
 func main() {
-	ctx := context.Background()
+	// Keep main minimal so that `defer cancel()` from signal.NotifyContext
+	// (set up in run) is honored even on startup failures. Doing os.Exit
+	// next to a defer in the same function would skip the deferred cleanup
+	// (gocritic: exitAfterDefer).
+	os.Exit(run())
+}
+
+func run() int {
+	// Cancel ctx on SIGTERM/SIGINT so the controller-runtime manager (and
+	// any nsenter-backed LVM commands launched via exec.CommandContext)
+	// terminate gracefully instead of being killed mid-flight.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
 
 	cfgParams, err := config.NewConfig()
 	if err != nil {
@@ -69,7 +83,7 @@ func main() {
 	log, err := logger.NewLogger(cfgParams.Loglevel)
 	if err != nil {
 		fmt.Printf("unable to create NewLogger, err: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	log.Info(fmt.Sprintf("[main] Go Version:%s ", goruntime.Version()))
@@ -97,7 +111,7 @@ func main() {
 		err := f(scheme)
 		if err != nil {
 			log.Error(err, "[main] unable to add scheme to func")
-			os.Exit(1)
+			return 1
 		}
 	}
 	log.Info("[main] successfully read scheme CR")
@@ -112,23 +126,36 @@ func main() {
 	mgr, err := manager.New(kConfig, managerOpts)
 	if err != nil {
 		log.Error(err, "[main] unable to manager.New")
-		os.Exit(1)
+		return 1
 	}
 	log.Info("[main] successfully created kubernetes manager")
 
 	metrics := monitoring.GetMetrics(cfgParams.NodeName)
 	commands := utils.NewCommands()
 
-	log.Info("[main] ReTag starts")
-	if err := commands.ReTag(ctx, log, metrics, bd.DiscovererName); err != nil {
-		log.Error(err, "[main] unable to run ReTag")
-	}
+	// Run ReTag and VG activation only after the manager has started its
+	// HTTP servers (including health probes). These nsenter-backed LVM
+	// operations may take longer than the liveness probe failure window,
+	// so executing them synchronously before mgr.Start() makes kubelet
+	// SIGTERM the container with exit code 143 (no error in logs).
+	// The runnable also receives a cancellable context, so a graceful
+	// shutdown can interrupt long-running LVM commands.
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		log.Info("[main] ReTag starts")
+		if err := commands.ReTag(ctx, log, metrics, bd.DiscovererName, cfgParams.CmdDeadlineDuration); err != nil {
+			log.Error(err, "[main] unable to run ReTag")
+		}
 
-	log.Info("[main] ActivateVGs starts")
-	if err := utils.ActivateAllManagedVGs(ctx, log, commands, metrics); err != nil {
-		log.Error(err, "[main] unable to activate managed VGs")
+		log.Info("[main] ActivateVGs starts")
+		if err := utils.ActivateAllManagedVGs(ctx, log, commands, metrics, cfgParams.CmdDeadlineDuration); err != nil {
+			log.Error(err, "[main] unable to activate managed VGs")
+		}
+		log.Info("[main] ActivateVGs completed")
+		return nil
+	})); err != nil {
+		log.Error(err, "[main] unable to add startup tasks runnable")
+		return 1
 	}
-	log.Info("[main] ActivateVGs completed")
 
 	sdsCache := cache.New()
 
@@ -149,7 +176,7 @@ func main() {
 	)
 	if err != nil {
 		log.Error(err, "[main] unable to controller.RunBlockDeviceController")
-		os.Exit(1)
+		return 1
 	}
 
 	rediscoverLVGs, err := controller.AddDiscoverer(
@@ -169,7 +196,7 @@ func main() {
 	)
 	if err != nil {
 		log.Error(err, "[main] unable to controller.RunLVMVolumeGroupDiscoverController")
-		os.Exit(1)
+		return 1
 	}
 
 	err = controller.AddReconciler(
@@ -188,7 +215,7 @@ func main() {
 	)
 	if err != nil {
 		log.Error(err, "[main] unable to run BlockDeviceFilter controller")
-		os.Exit(1)
+		return 1
 	}
 
 	err = controller.AddReconciler(
@@ -209,7 +236,7 @@ func main() {
 	)
 	if err != nil {
 		log.Error(err, "[main] unable to controller.RunLVMVolumeGroupWatcherController")
-		os.Exit(1)
+		return 1
 	}
 
 	go func() {
@@ -246,7 +273,7 @@ func main() {
 	)
 	if err != nil {
 		log.Error(err, "[main] unable to controller.RunLVMVolumeGroupWatcherController")
-		os.Exit(1)
+		return 1
 	}
 
 	err = controller.AddReconciler(
@@ -266,28 +293,29 @@ func main() {
 	)
 	if err != nil {
 		log.Error(err, "[main] unable to controller.RunLVMLogicalVolumeExtenderWatcherController")
-		os.Exit(1)
+		return 1
 	}
 
 	addLLVSReconciler(mgr, log, metrics, sdsCache, commands, cfgParams)
 
 	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		log.Error(err, "[main] unable to mgr.AddHealthzCheck")
-		os.Exit(1)
+		return 1
 	}
 	log.Info("[main] successfully AddHealthzCheck")
 
 	if err = mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		log.Error(err, "[main] unable to mgr.AddReadyzCheck")
-		os.Exit(1)
+		return 1
 	}
 	log.Info("[main] successfully AddReadyzCheck")
 
 	err = mgr.Start(ctx)
 	if err != nil {
 		log.Error(err, "[main] unable to mgr.Start")
-		os.Exit(1)
+		return 1
 	}
 
 	log.Info("[main] successfully starts the manager")
+	return 0
 }

--- a/images/agent/internal/controller/lvg/reconciler.go
+++ b/images/agent/internal/controller/lvg/reconciler.go
@@ -1356,7 +1356,7 @@ func (r *Reconciler) updateVGTagIfNeeded(
 		}
 
 		start := time.Now()
-		cmd, err := r.commands.VGChangeDelTag(vg.VGName, fmt.Sprintf("%s=%s", internal.LVMVolumeGroupTag, tagName))
+		cmd, err := r.commands.VGChangeDelTag(ctx, vg.VGName, fmt.Sprintf("%s=%s", internal.LVMVolumeGroupTag, tagName))
 		r.metrics.UtilsCommandsDuration(ReconcilerName, "vgchange").Observe(r.metrics.GetEstimatedTimeInSeconds(start))
 		r.metrics.UtilsCommandsExecutionCount(ReconcilerName, "vgchange").Inc()
 		r.log.Debug(fmt.Sprintf("[UpdateVGTagIfNeeded] exec cmd: %s", cmd))
@@ -1367,7 +1367,7 @@ func (r *Reconciler) updateVGTagIfNeeded(
 		}
 
 		start = time.Now()
-		cmd, err = r.commands.VGChangeAddTag(vg.VGName, fmt.Sprintf("%s=%s", internal.LVMVolumeGroupTag, lvg.Name))
+		cmd, err = r.commands.VGChangeAddTag(ctx, vg.VGName, fmt.Sprintf("%s=%s", internal.LVMVolumeGroupTag, lvg.Name))
 		r.metrics.UtilsCommandsDuration(ReconcilerName, "vgchange").Observe(r.metrics.GetEstimatedTimeInSeconds(start))
 		r.metrics.UtilsCommandsExecutionCount(ReconcilerName, "vgchange").Inc()
 		r.log.Debug(fmt.Sprintf("[UpdateVGTagIfNeeded] exec cmd: %s", cmd))

--- a/images/agent/internal/mock_utils/commands.go
+++ b/images/agent/internal/mock_utils/commands.go
@@ -13,6 +13,7 @@ import (
 	bytes "bytes"
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	internal "github.com/deckhouse/sds-node-configurator/images/agent/internal"
 	logger "github.com/deckhouse/sds-node-configurator/images/agent/internal/logger"
@@ -359,18 +360,18 @@ func (mr *MockCommandsMockRecorder) LVActivate(ctx, vgName, lvName any) *gomock.
 }
 
 // LVChangeDelTag mocks base method.
-func (m *MockCommands) LVChangeDelTag(lv internal.LVData, tag string) (string, error) {
+func (m *MockCommands) LVChangeDelTag(ctx context.Context, lv internal.LVData, tag string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LVChangeDelTag", lv, tag)
+	ret := m.ctrl.Call(m, "LVChangeDelTag", ctx, lv, tag)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LVChangeDelTag indicates an expected call of LVChangeDelTag.
-func (mr *MockCommandsMockRecorder) LVChangeDelTag(lv, tag any) *gomock.Call {
+func (mr *MockCommandsMockRecorder) LVChangeDelTag(ctx, lv, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LVChangeDelTag", reflect.TypeOf((*MockCommands)(nil).LVChangeDelTag), lv, tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LVChangeDelTag", reflect.TypeOf((*MockCommands)(nil).LVChangeDelTag), ctx, lv, tag)
 }
 
 // PVScan mocks base method.
@@ -389,17 +390,17 @@ func (mr *MockCommandsMockRecorder) PVScan(ctx any) *gomock.Call {
 }
 
 // ReTag mocks base method.
-func (m *MockCommands) ReTag(ctx context.Context, log logger.Logger, metrics *monitoring.Metrics, ctrlName string) error {
+func (m *MockCommands) ReTag(ctx context.Context, log logger.Logger, metrics *monitoring.Metrics, ctrlName string, cmdTimeout time.Duration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReTag", ctx, log, metrics, ctrlName)
+	ret := m.ctrl.Call(m, "ReTag", ctx, log, metrics, ctrlName, cmdTimeout)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReTag indicates an expected call of ReTag.
-func (mr *MockCommandsMockRecorder) ReTag(ctx, log, metrics, ctrlName any) *gomock.Call {
+func (mr *MockCommandsMockRecorder) ReTag(ctx, log, metrics, ctrlName, cmdTimeout any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReTag", reflect.TypeOf((*MockCommands)(nil).ReTag), ctx, log, metrics, ctrlName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReTag", reflect.TypeOf((*MockCommands)(nil).ReTag), ctx, log, metrics, ctrlName, cmdTimeout)
 }
 
 // RemoveLV mocks base method.
@@ -493,33 +494,33 @@ func (mr *MockCommandsMockRecorder) VGActivate(ctx, vgName, shared any) *gomock.
 }
 
 // VGChangeAddTag mocks base method.
-func (m *MockCommands) VGChangeAddTag(vGName, tag string) (string, error) {
+func (m *MockCommands) VGChangeAddTag(ctx context.Context, vGName, tag string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VGChangeAddTag", vGName, tag)
+	ret := m.ctrl.Call(m, "VGChangeAddTag", ctx, vGName, tag)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // VGChangeAddTag indicates an expected call of VGChangeAddTag.
-func (mr *MockCommandsMockRecorder) VGChangeAddTag(vGName, tag any) *gomock.Call {
+func (mr *MockCommandsMockRecorder) VGChangeAddTag(ctx, vGName, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VGChangeAddTag", reflect.TypeOf((*MockCommands)(nil).VGChangeAddTag), vGName, tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VGChangeAddTag", reflect.TypeOf((*MockCommands)(nil).VGChangeAddTag), ctx, vGName, tag)
 }
 
 // VGChangeDelTag mocks base method.
-func (m *MockCommands) VGChangeDelTag(vGName, tag string) (string, error) {
+func (m *MockCommands) VGChangeDelTag(ctx context.Context, vGName, tag string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VGChangeDelTag", vGName, tag)
+	ret := m.ctrl.Call(m, "VGChangeDelTag", ctx, vGName, tag)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // VGChangeDelTag indicates an expected call of VGChangeDelTag.
-func (mr *MockCommandsMockRecorder) VGChangeDelTag(vGName, tag any) *gomock.Call {
+func (mr *MockCommandsMockRecorder) VGChangeDelTag(ctx, vGName, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VGChangeDelTag", reflect.TypeOf((*MockCommands)(nil).VGChangeDelTag), vGName, tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VGChangeDelTag", reflect.TypeOf((*MockCommands)(nil).VGChangeDelTag), ctx, vGName, tag)
 }
 
 // VGScan mocks base method.

--- a/images/agent/internal/scanner/scanner.go
+++ b/images/agent/internal/scanner/scanner.go
@@ -237,7 +237,7 @@ func (s *scanner) fillTheCache(ctx context.Context, log logger.Logger, cache *ca
 		return err
 	}
 
-	if activated := utils.EnsureVGActivation(ctx, log, s.commands, metrics, vgs, lvs); activated {
+	if activated := utils.EnsureVGActivation(ctx, log, s.commands, metrics, vgs, lvs, cfg.CmdDeadlineDuration); activated {
 		log.Info("[fillTheCache] LVs were activated, re-scanning LVs and VGs")
 		now = time.Now()
 		lvs, lvsErr, err = s.scanLVs(ctx, log, cfg)

--- a/images/agent/internal/utils/activation.go
+++ b/images/agent/internal/utils/activation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal"
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal/logger"
@@ -61,22 +62,45 @@ func FilterVGsByTag(vgs []internal.VGData, tags []string) []internal.VGData {
 	return filtered
 }
 
-func ActivateAllManagedVGs(ctx context.Context, log logger.Logger, commands Commands, metrics *monitoring.Metrics) error {
+// runWithTimeout invokes fn under a child context with the given timeout, so a
+// stuck nsenter-backed LVM command does not block the caller indefinitely.
+// A non-positive timeout disables the deadline and is treated as "no timeout".
+func runWithTimeout[T any](ctx context.Context, timeout time.Duration, fn func(context.Context) (T, error)) (T, error) {
+	if timeout <= 0 {
+		return fn(ctx)
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return fn(ctx)
+}
+
+func ActivateAllManagedVGs(ctx context.Context, log logger.Logger, commands Commands, metrics *monitoring.Metrics, cmdTimeout time.Duration) error {
 	log.Info("[ActivateVGs] refreshing LVM metadata cache")
-	if cmd, err := commands.PVScan(ctx); err != nil {
+	if cmd, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+		return commands.PVScan(ctx)
+	}); err != nil {
 		log.Warning(fmt.Sprintf("[ActivateVGs] pvscan --cache failed (cmd: %s): %v", cmd, err))
 	}
-	if cmd, err := commands.VGScan(ctx); err != nil {
+	if cmd, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+		return commands.VGScan(ctx)
+	}); err != nil {
 		log.Warning(fmt.Sprintf("[ActivateVGs] vgscan --cache failed (cmd: %s): %v", cmd, err))
 	}
 
-	vgs, cmdStr, _, err := commands.GetAllVGs(ctx)
-	log.Debug(fmt.Sprintf("[ActivateVGs] exec cmd: %s", cmdStr))
+	type vgsResult struct {
+		data   []internal.VGData
+		cmdStr string
+	}
+	res, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (vgsResult, error) {
+		data, cmdStr, _, err := commands.GetAllVGs(ctx)
+		return vgsResult{data: data, cmdStr: cmdStr}, err
+	})
+	log.Debug(fmt.Sprintf("[ActivateVGs] exec cmd: %s", res.cmdStr))
 	if err != nil {
 		return fmt.Errorf("unable to get VGs: %w", err)
 	}
 
-	managedVGs := FilterVGsByTag(vgs, internal.LVMTags)
+	managedVGs := FilterVGsByTag(res.data, internal.LVMTags)
 	if len(managedVGs) == 0 {
 		log.Info("[ActivateVGs] no managed VGs found, nothing to activate")
 		return nil
@@ -87,7 +111,9 @@ func ActivateAllManagedVGs(ctx context.Context, log logger.Logger, commands Comm
 	var activationErrors []error
 	for _, vg := range managedVGs {
 		shared := vg.VGShared != ""
-		cmd, err := commands.VGActivate(ctx, vg.VGName, shared)
+		cmd, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+			return commands.VGActivate(ctx, vg.VGName, shared)
+		})
 		if err != nil {
 			log.Error(err, fmt.Sprintf("[ActivateVGs] failed to activate VG %s (shared=%t, cmd: %s)", vg.VGName, shared, cmd))
 			metrics.UtilsCommandsErrorsCount(activationControllerName, "vgchange").Inc()
@@ -113,6 +139,7 @@ func EnsureVGActivation(
 	metrics *monitoring.Metrics,
 	vgs []internal.VGData,
 	lvs []internal.LVData,
+	cmdTimeout time.Duration,
 ) bool {
 	managedVGs := FilterVGsByTag(vgs, internal.LVMTags)
 	if len(managedVGs) == 0 {
@@ -149,7 +176,9 @@ func EnsureVGActivation(
 	activated := false
 	for _, vg := range vgsToActivate {
 		shared := vg.VGShared != ""
-		cmd, err := commands.VGActivate(ctx, vg.VGName, shared)
+		cmd, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+			return commands.VGActivate(ctx, vg.VGName, shared)
+		})
 		if err != nil {
 			log.Error(err, fmt.Sprintf("[EnsureActivation] failed to activate VG %s (cmd: %s)", vg.VGName, cmd))
 			metrics.UtilsCommandsErrorsCount(activationControllerName, "vgchange").Inc()

--- a/images/agent/internal/utils/commands.go
+++ b/images/agent/internal/utils/commands.go
@@ -60,15 +60,15 @@ type Commands interface {
 	RemoveVG(vgName string) (string, error)
 	RemovePV(pvNames []string) (string, error)
 	RemoveLV(vgName, lvName string) (string, error)
-	VGChangeAddTag(vGName, tag string) (string, error)
-	VGChangeDelTag(vGName, tag string) (string, error)
-	LVChangeDelTag(lv internal.LVData, tag string) (string, error)
+	VGChangeAddTag(ctx context.Context, vGName, tag string) (string, error)
+	VGChangeDelTag(ctx context.Context, vGName, tag string) (string, error)
+	LVChangeDelTag(ctx context.Context, lv internal.LVData, tag string) (string, error)
 	VGActivate(ctx context.Context, vgName string, shared bool) (string, error)
 	LVActivate(ctx context.Context, vgName, lvName string) (string, error)
 	VGScan(ctx context.Context) (string, error)
 	PVScan(ctx context.Context) (string, error)
 	UnmarshalDevices(out []byte) ([]internal.Device, error)
-	ReTag(ctx context.Context, log logger.Logger, metrics *monitoring.Metrics, ctrlName string) error
+	ReTag(ctx context.Context, log logger.Logger, metrics *monitoring.Metrics, ctrlName string, cmdTimeout time.Duration) error
 }
 
 type commands struct {
@@ -498,11 +498,11 @@ func (commands) RemoveLV(vgName, lvName string) (string, error) {
 	return cmd.String(), nil
 }
 
-func (commands) VGChangeAddTag(vGName, tag string) (string, error) {
+func (commands) VGChangeAddTag(ctx context.Context, vGName, tag string) (string, error) {
 	var outs, stdErr bytes.Buffer
 	args := []string{"vgchange", vGName, "--addtag", tag}
 	extendedArgs := lvmStaticExtendedArgs(args)
-	cmd := exec.Command(internal.NSENTERCmd, extendedArgs...)
+	cmd := exec.CommandContext(ctx, internal.NSENTERCmd, extendedArgs...)
 	cmd.Stdout = &outs
 	cmd.Stderr = &stdErr
 
@@ -512,11 +512,11 @@ func (commands) VGChangeAddTag(vGName, tag string) (string, error) {
 	return cmd.String(), nil
 }
 
-func (commands) VGChangeDelTag(vGName, tag string) (string, error) {
+func (commands) VGChangeDelTag(ctx context.Context, vGName, tag string) (string, error) {
 	var outs, stdErr bytes.Buffer
 	args := []string{"vgchange", vGName, "--deltag", tag}
 	extendedArgs := lvmStaticExtendedArgs(args)
-	cmd := exec.Command(internal.NSENTERCmd, extendedArgs...)
+	cmd := exec.CommandContext(ctx, internal.NSENTERCmd, extendedArgs...)
 	cmd.Stdout = &outs
 	cmd.Stderr = &stdErr
 
@@ -526,12 +526,12 @@ func (commands) VGChangeDelTag(vGName, tag string) (string, error) {
 	return cmd.String(), nil
 }
 
-func (commands) LVChangeDelTag(lv internal.LVData, tag string) (string, error) {
+func (commands) LVChangeDelTag(ctx context.Context, lv internal.LVData, tag string) (string, error) {
 	tmpStr := filepath.Join("/dev/%s/%s", lv.VGName, lv.LVName)
 	var outs, stdErr bytes.Buffer
 	args := []string{"lvchange", tmpStr, "--deltag", tag}
 	extendedArgs := lvmStaticExtendedArgs(args)
-	cmd := exec.Command(internal.NSENTERCmd, extendedArgs...)
+	cmd := exec.CommandContext(ctx, internal.NSENTERCmd, extendedArgs...)
 	cmd.Stdout = &outs
 	cmd.Stderr = &stdErr
 
@@ -611,21 +611,33 @@ func (commands) UnmarshalDevices(out []byte) ([]internal.Device, error) {
 	return devices.BlockDevices, nil
 }
 
-func (c *commands) ReTag(ctx context.Context, log logger.Logger, metrics *monitoring.Metrics, ctrlName string) error {
+// ReTag walks managed LVs/VGs and replaces the legacy linstor tag with the
+// current LVMTag. Each underlying LVM command is executed with its own
+// timeout (derived from CMD_DEADLINE_DURATION) and the caller's context, so a
+// stuck nsenter-backed command cannot block the agent indefinitely and a
+// SIGTERM from kubelet propagates immediately to the child process.
+func (c *commands) ReTag(ctx context.Context, log logger.Logger, metrics *monitoring.Metrics, ctrlName string, cmdTimeout time.Duration) error {
 	// thin pool
 	log.Debug("[ReTag] start re-tagging LV")
 	start := time.Now()
-	lvs, cmdStr, _, err := c.GetAllLVs(ctx)
+	type lvsResult struct {
+		data   []internal.LVData
+		cmdStr string
+	}
+	lvsRes, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (lvsResult, error) {
+		data, cmdStr, _, err := c.GetAllLVs(ctx)
+		return lvsResult{data: data, cmdStr: cmdStr}, err
+	})
 	metrics.UtilsCommandsDuration(ctrlName, "lvs").Observe(metrics.GetEstimatedTimeInSeconds(start))
 	metrics.UtilsCommandsExecutionCount(ctrlName, "lvs").Inc()
-	log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", cmdStr))
+	log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", lvsRes.cmdStr))
 	if err != nil {
 		metrics.UtilsCommandsErrorsCount(ctrlName, "lvs").Inc()
 		log.Error(err, "[ReTag] unable to GetAllLVs")
 		return err
 	}
 
-	for _, lv := range lvs {
+	for _, lv := range lvsRes.data {
 		tags := strings.Split(lv.LvTags, ",")
 		for _, tag := range tags {
 			if strings.Contains(tag, internal.LVMTags[0]) {
@@ -634,7 +646,9 @@ func (c *commands) ReTag(ctx context.Context, log logger.Logger, metrics *monito
 
 			if strings.Contains(tag, internal.LVMTags[1]) {
 				start = time.Now()
-				cmdStr, err = c.LVChangeDelTag(lv, tag)
+				cmdStr, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+					return c.LVChangeDelTag(ctx, lv, tag)
+				})
 				metrics.UtilsCommandsDuration(ctrlName, "lvchange").Observe(metrics.GetEstimatedTimeInSeconds(start))
 				metrics.UtilsCommandsExecutionCount(ctrlName, "lvchange").Inc()
 				log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", cmdStr))
@@ -645,7 +659,9 @@ func (c *commands) ReTag(ctx context.Context, log logger.Logger, metrics *monito
 				}
 
 				start = time.Now()
-				cmdStr, err = c.VGChangeAddTag(lv.VGName, internal.LVMTags[0])
+				cmdStr, err = runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+					return c.VGChangeAddTag(ctx, lv.VGName, internal.LVMTags[0])
+				})
 				metrics.UtilsCommandsDuration(ctrlName, "vgchange").Observe(metrics.GetEstimatedTimeInSeconds(start))
 				metrics.UtilsCommandsExecutionCount(ctrlName, "vgchange").Inc()
 				log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", cmdStr))
@@ -661,17 +677,24 @@ func (c *commands) ReTag(ctx context.Context, log logger.Logger, metrics *monito
 
 	log.Debug("[ReTag] start re-tagging LVM")
 	start = time.Now()
-	vgs, cmdStr, _, err := c.GetAllVGs(ctx)
+	type vgsResult struct {
+		data   []internal.VGData
+		cmdStr string
+	}
+	vgsRes, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (vgsResult, error) {
+		data, cmdStr, _, err := c.GetAllVGs(ctx)
+		return vgsResult{data: data, cmdStr: cmdStr}, err
+	})
 	metrics.UtilsCommandsDuration(ctrlName, "vgs").Observe(metrics.GetEstimatedTimeInSeconds(start))
 	metrics.UtilsCommandsExecutionCount(ctrlName, "vgs").Inc()
-	log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", cmdStr))
+	log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", vgsRes.cmdStr))
 	if err != nil {
-		metrics.UtilsCommandsErrorsCount(ctrlName, cmdStr).Inc()
+		metrics.UtilsCommandsErrorsCount(ctrlName, vgsRes.cmdStr).Inc()
 		log.Error(err, "[ReTag] unable to GetAllVGs")
 		return err
 	}
 
-	for _, vg := range vgs {
+	for _, vg := range vgsRes.data {
 		tags := strings.Split(vg.VGTags, ",")
 		for _, tag := range tags {
 			if strings.Contains(tag, internal.LVMTags[0]) {
@@ -680,7 +703,9 @@ func (c *commands) ReTag(ctx context.Context, log logger.Logger, metrics *monito
 
 			if strings.Contains(tag, internal.LVMTags[1]) {
 				start = time.Now()
-				cmdStr, err = c.VGChangeDelTag(vg.VGName, tag)
+				cmdStr, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+					return c.VGChangeDelTag(ctx, vg.VGName, tag)
+				})
 				metrics.UtilsCommandsDuration(ctrlName, "vgchange").Observe(metrics.GetEstimatedTimeInSeconds(start))
 				metrics.UtilsCommandsExecutionCount(ctrlName, "vgchange").Inc()
 				log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", cmdStr))
@@ -691,7 +716,9 @@ func (c *commands) ReTag(ctx context.Context, log logger.Logger, metrics *monito
 				}
 
 				start = time.Now()
-				cmdStr, err = c.VGChangeAddTag(vg.VGName, internal.LVMTags[0])
+				cmdStr, err = runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+					return c.VGChangeAddTag(ctx, vg.VGName, internal.LVMTags[0])
+				})
 				metrics.UtilsCommandsDuration(ctrlName, "vgchange").Observe(metrics.GetEstimatedTimeInSeconds(start))
 				metrics.UtilsCommandsExecutionCount(ctrlName, "vgchange").Inc()
 				log.Debug(fmt.Sprintf("[ReTag] exec cmd: %s", cmdStr))

--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -158,6 +158,18 @@ spec:
       - name: sds-node-configurator-agent
         image: {{ include "helm_lib_module_image" (list . "agent") }}
         imagePullPolicy: IfNotPresent
+        # startupProbe must succeed before liveness/readiness start.
+        # The agent runs LVM operations (pvscan/vgscan/vgchange) via
+        # nsenter on the host and they may take a long time on nodes
+        # with many devices, so we allow up to ~5 minutes here.
+        startupProbe:
+          httpGet:
+            path: /healthz
+            host: 127.0.0.1
+            port: 4228
+            scheme: HTTP
+          periodSeconds: 2
+          failureThreshold: 150
         readinessProbe:
           httpGet:
             path: /readyz


### PR DESCRIPTION
## Description

The `sds-node-configurator-agent` container was being killed with exit code 143 (SIGTERM) shortly after pod start, with no error message in logs (last log line stuck at `[ActivateVGs] refreshing LVM metadata cache`). Root cause: `commands.ReTag` and `utils.ActivateAllManagedVGs` were executed **synchronously** before `mgr.Start(ctx)`, but the manager's health-probe HTTP server (`/healthz`, `/readyz` on `127.0.0.1:4228`) is started only inside `mgr.Start()`. With `livenessProbe.periodSeconds: 1`, `failureThreshold: 3`, no `initialDelaySeconds` and no `startupProbe`, kubelet got `connection refused` and SIGTERMed the container within ~3 seconds. On nodes where `pvscan --cache` / `vgscan --cache` / `vgchange -ay` are slow, the container never reached `mgr.Start()`. Regression introduced by #200 (commit `b27abd8`).

This PR contains 4 logically connected fixes:

- **Startup race fix (`images/agent/cmd/main.go`).** Move `ReTag` and `ActivateAllManagedVGs` into a `manager.RunnableFunc` registered via `mgr.Add()`. Controller-runtime starts HTTP servers (including health probes) before any leader-election runnable, so the probe endpoints are up before LVM work begins. Switch the agent's root context to `signal.NotifyContext(... SIGINT, SIGTERM)` so kubelet SIGTERM cancels the manager and every `exec.CommandContext`-backed LVM child process instead of leaving them hanging until SIGKILL.

- **Safety net (`templates/agent/daemonset.yaml`).** Add a `startupProbe` (`periodSeconds: 2`, `failureThreshold: 150` ≈ 5 minutes) so even on very slow nodes the container is not killed by liveness while LVM initialization is in progress.

- **Per-command timeouts (`images/agent/internal/utils/activation.go`, `commands.go`, `scanner/scanner.go`).** Introduce a `runWithTimeout` generic helper and thread `CmdDeadlineDuration` (env `CMD_DEADLINE_DURATION`, default 30s — already in `config.Config`) into `ActivateAllManagedVGs`, `EnsureVGActivation`, and `ReTag`. Each LVM call (`pvscan`/`vgscan`/`vgs`/`lvs`/`vgchange`/`lvchange`) now runs under its own deadlined child context. Same pattern that scanner.go already uses for `GetBlockDevices`/`GetAllPVs`/`GetAllVGs`/`GetAllLVs`.

- **Context-aware tag commands (`images/agent/internal/utils/commands.go`, `controller/lvg/reconciler.go`, regenerated `mock_utils/commands.go`).** `VGChangeAddTag`, `VGChangeDelTag`, `LVChangeDelTag` now accept `context.Context` and use `exec.CommandContext`, so SIGTERM / per-command timeout actually cancels the underlying nsenter+lvm process. Update the only external caller (`updateVGTagIfNeeded` in lvg reconciler) to pass through its `ctx`. Mock regenerated via the existing `go:generate` directive.

## Why do we need it, and what problem does it solve?

After upgrading to a release that contains #200, agent pods on nodes with non-trivial LVM topology fall into `CrashLoopBackOff` with exit code 143. While the agent is down on a node:
- no LVM events for that node are processed;
- `LVMVolumeGroup` / `BlockDevice` state for the node is not maintained;
- existing volumes keep working, but new `LVMLogicalVolume` / `LVMVolumeGroup` operations on the affected node stall.

Reported in the field on a cluster where `[main] ReTag starts` → `[main] ActivateVGs starts` took 3.3s on its own and then the container was killed mid-`pvscan --cache`:

```
I0605 04:23:53.000230  412655 main.go:122] \"INFO [main] ReTag starts\"
I0605 04:23:56.334605  412655 main.go:127] \"INFO [main] ActivateVGs starts\"
I0605 04:23:56.334668  412655 activation.go:65] \"INFO [ActivateVGs] refreshing LVM metadata cache\"
<container killed, exit code 143, no further logs>
```

## What is the expected result?

- `sds-node-configurator-agent` pod becomes `Ready` even on nodes where the initial LVM scan + VG activation takes tens of seconds (up to ~5 min with the new startupProbe).
- A SIGTERM from kubelet (rolling update, eviction, node drain) terminates the agent gracefully within `terminationGracePeriodSeconds`; no orphan nsenter+lvm processes left in the host PID namespace.
- A stuck `pvscan` / `vgscan` / `vgchange` / `lvchange` is interrupted within `CMD_DEADLINE_DURATION` (30s by default) with an error logged, instead of hanging forever.
- Steady-state liveness / readiness behaviour after the agent finishes initialization is unchanged (same probe paths, same intervals).

How to verify:
- Roll out the agent on the affected cluster — pods reach `Running` / `Ready`.
- `kubectl -n d8-sds-node-configurator logs sds-node-configurator-<id>` shows `[main] ActivateVGs completed` followed by normal controller / scanner logs.
- Force a pod restart (`kubectl delete pod ...`) — container exits with `0` (or a logged error) within `terminationGracePeriodSeconds`, not `137` / `143`.
- Verify metrics: `UtilsCommandsDuration{cmd=\"vgchange\"}` and `LVMActivationTotal` are produced both from initial activation and from `EnsureVGActivation` during scanner cycles.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.