### PR TITLE
fix(agent): handle duplicate VG names without corrupting LVG status

### DIFF
--- a/images/agent/internal/controller/lvg/discoverer.go
+++ b/images/agent/internal/controller/lvg/discoverer.go
@@ -149,13 +149,46 @@ func (d *Discoverer) LVMVolumeGroupDiscoverReconcile(ctx context.Context) bool {
 		d.log.Debug("[RunLVMVolumeGroupDiscoverController] no candidates were found on the node")
 	}
 
+	shouldRequeue := false
+
+	// When LVM reports more than one VG with the same name, it stops resolving
+	// such VGs by name (`vgs <name>`/`lvs <name>` fail with
+	// `Multiple VGs found with the same name: skipping`). The agent's name-keyed
+	// caches (`cache.FindVG`/`FindLV`) and the discoverer's `filteredLVGs` map
+	// would silently mix LV data from unrelated VGs in that case, producing
+	// misleading conditions such as `ThinPool ... size X is less than status one Y`.
+	// Refuse to act on those LVGs and surface a single, actionable error message
+	// instead.
+	allVGs, _ := d.sdsCache.GetVGs()
+	duplicateVGs := findDuplicateVGNames(allVGs)
+	if len(duplicateVGs) > 0 {
+		for name, uuids := range duplicateVGs {
+			d.log.Warning(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] VG name %q is used by multiple VGs on the node (UUIDs: %s); LVMVolumeGroup resources referencing it will be marked NotReady until the duplicate is resolved", name, strings.Join(uuids, ", ")))
+		}
+
+		for _, lvg := range filteredLVGs {
+			uuids, dup := duplicateVGs[lvg.Spec.ActualVGNameOnTheNode]
+			if !dup {
+				continue
+			}
+			if updErr := d.lvgCl.UpdateLVGConditionIfNeeded(ctx, &lvg, metav1.ConditionFalse, internal.TypeVGReady, internal.ReasonScanFailed, duplicateVGMessage(lvg.Spec.ActualVGNameOnTheNode, uuids)); updErr != nil {
+				d.log.Error(updErr, fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] unable to add VGReady=False condition for duplicate VG name to the LVMVolumeGroup %s", lvg.Name))
+				shouldRequeue = true
+			}
+		}
+
+		for vgName := range duplicateVGs {
+			delete(filteredLVGs, vgName)
+		}
+		candidates = filterCandidatesByDuplicateVGs(candidates, duplicateVGs)
+	}
+
 	candidates, err = d.ReconcileUnhealthyLVMVolumeGroups(ctx, candidates, filteredLVGs)
 	if err != nil {
 		d.log.Error(err, fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] an error has occurred while clearing the LVMVolumeGroups resources. Requeue the request in %s", d.cfg.VolumeGroupScanInterval.String()))
 		return true
 	}
 
-	shouldRequeue := false
 	for _, candidate := range candidates {
 		if lvg, exist := filteredLVGs[candidate.ActualVGNameOnTheNode]; exist {
 			d.log.Debug(fmt.Sprintf("[RunLVMVolumeGroupDiscoverController] the LVMVolumeGroup %s is already exist. Tries to update it", lvg.Name))

--- a/images/agent/internal/controller/lvg/reconciler.go
+++ b/images/agent/internal/controller/lvg/reconciler.go
@@ -811,6 +811,19 @@ func (r *Reconciler) validateLVGForUpdateFunc(
 	blockDevices map[string]v1alpha1.BlockDevice,
 ) (bool, string) {
 	reason := strings.Builder{}
+
+	// Bail out before any name-keyed cache lookups when the underlying VG name
+	// is ambiguous on the node. Without this, FindVG/FindLV would return data
+	// from an arbitrary VG of the same name and produce misleading reasons
+	// (e.g. "Added thin-pools requested sizes are more than allowed free space
+	// in VG") that hide the real problem.
+	allVGs, _ := r.sdsCache.GetVGs()
+	if duplicateVGs := findDuplicateVGNames(allVGs); len(duplicateVGs) > 0 {
+		if uuids, dup := duplicateVGs[lvg.Spec.ActualVGNameOnTheNode]; dup {
+			return false, duplicateVGMessage(lvg.Spec.ActualVGNameOnTheNode, uuids)
+		}
+	}
+
 	pvs, _ := r.sdsCache.GetPVs()
 	r.log.Debug(fmt.Sprintf("[validateLVGForUpdateFunc] check if every new BlockDevice of the LVMVolumeGroup %s is comsumable", lvg.Name))
 	actualPVPaths := make(map[string]struct{}, len(pvs))

--- a/images/agent/internal/controller/lvg/utils.go
+++ b/images/agent/internal/controller/lvg/utils.go
@@ -17,6 +17,10 @@ limitations under the License.
 package lvg
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -42,4 +46,74 @@ func getVGAllocatedSize(vg internal.VGData) resource.Quantity {
 	allocatedSize := vg.VGSize
 	allocatedSize.Sub(vg.VGFree)
 	return allocatedSize
+}
+
+// findDuplicateVGNames returns VG names that appear on the node more than
+// once, mapped to the sorted list of their UUIDs.
+//
+// LVM cannot resolve VGs by name when duplicates exist (`vgs <name>` and
+// `lvs <name>` fail with `Multiple VGs found with the same name: skipping`),
+// and the agent's internal lookups (`cache.FindVG`, `cache.FindLV`, the
+// candidate/LVG maps in the discoverer) are keyed by VG name alone, so a
+// duplicate silently mixes data from two unrelated VGs. The discoverer and
+// the watcher reconciler use this helper to refuse to act on such VGs and
+// to surface a clear, actionable error in the LVMVolumeGroup status instead
+// of comparing data from the wrong VG.
+func findDuplicateVGNames(vgs []internal.VGData) map[string][]string {
+	uuidsByName := make(map[string]map[string]struct{}, len(vgs))
+	for _, vg := range vgs {
+		if vg.VGName == "" {
+			continue
+		}
+		set, ok := uuidsByName[vg.VGName]
+		if !ok {
+			set = make(map[string]struct{}, 2)
+			uuidsByName[vg.VGName] = set
+		}
+		set[vg.VGUUID] = struct{}{}
+	}
+
+	duplicates := make(map[string][]string, len(uuidsByName))
+	for name, set := range uuidsByName {
+		if len(set) < 2 {
+			continue
+		}
+		uuids := make([]string, 0, len(set))
+		for uuid := range set {
+			uuids = append(uuids, uuid)
+		}
+		sort.Strings(uuids)
+		duplicates[name] = uuids
+	}
+	return duplicates
+}
+
+// duplicateVGMessage formats the standard human-readable message used in the
+// LVMVolumeGroup status when the underlying VG name is ambiguous on the node.
+func duplicateVGMessage(vgName string, uuids []string) string {
+	return fmt.Sprintf(
+		"Multiple LVM VGs share the name %q on the node (UUIDs: %s). LVM cannot resolve the VG by name and the agent cannot safely reconcile this LVMVolumeGroup. Resolve the conflict on the node (e.g. `vgrename --select vg_uuid=<uuid> %s <new-name>`, or remove the stale duplicate) and the agent will recover automatically.",
+		vgName, strings.Join(uuids, ", "), vgName,
+	)
+}
+
+// filterCandidatesByDuplicateVGs drops candidates whose VG name is ambiguous
+// on the node. Such candidates were assembled from a mix of LV/PV data
+// belonging to different VGs that happen to share a name and would corrupt
+// the LVMVolumeGroup status if propagated.
+func filterCandidatesByDuplicateVGs(
+	candidates []internal.LVMVolumeGroupCandidate,
+	duplicateVGs map[string][]string,
+) []internal.LVMVolumeGroupCandidate {
+	if len(duplicateVGs) == 0 || len(candidates) == 0 {
+		return candidates
+	}
+	filtered := candidates[:0]
+	for _, c := range candidates {
+		if _, dup := duplicateVGs[c.ActualVGNameOnTheNode]; dup {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered
 }

--- a/images/agent/internal/controller/lvg/utils_test.go
+++ b/images/agent/internal/controller/lvg/utils_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lvg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal"
+)
+
+func TestFindDuplicateVGNames(t *testing.T) {
+	t.Run("no_duplicates_returns_empty_map", func(t *testing.T) {
+		vgs := []internal.VGData{
+			{VGName: "vg-a", VGUUID: "uuid-a"},
+			{VGName: "vg-b", VGUUID: "uuid-b"},
+			{VGName: "vg-c", VGUUID: "uuid-c"},
+		}
+		got := findDuplicateVGNames(vgs)
+		assert.Empty(t, got)
+	})
+
+	t.Run("single_duplicate_pair_is_detected", func(t *testing.T) {
+		vgs := []internal.VGData{
+			{VGName: "vg-thin-data", VGUUID: "uuid-1"},
+			{VGName: "vg-thin-data", VGUUID: "uuid-2"},
+			{VGName: "vg-other", VGUUID: "uuid-x"},
+		}
+		got := findDuplicateVGNames(vgs)
+		assert.Len(t, got, 1)
+		assert.Equal(t, []string{"uuid-1", "uuid-2"}, got["vg-thin-data"])
+	})
+
+	t.Run("multiple_duplicate_groups_are_detected", func(t *testing.T) {
+		vgs := []internal.VGData{
+			{VGName: "vg-thin-data", VGUUID: "uuid-1"},
+			{VGName: "vg-thin-data", VGUUID: "uuid-2"},
+			{VGName: "vg-1", VGUUID: "uuid-3"},
+			{VGName: "vg-1", VGUUID: "uuid-4"},
+			{VGName: "vg-unique", VGUUID: "uuid-5"},
+		}
+		got := findDuplicateVGNames(vgs)
+		assert.Len(t, got, 2)
+		assert.Equal(t, []string{"uuid-1", "uuid-2"}, got["vg-thin-data"])
+		assert.Equal(t, []string{"uuid-3", "uuid-4"}, got["vg-1"])
+		_, hasUnique := got["vg-unique"]
+		assert.False(t, hasUnique)
+	})
+
+	t.Run("triple_duplicate_returns_all_uuids_sorted", func(t *testing.T) {
+		vgs := []internal.VGData{
+			{VGName: "vg-x", VGUUID: "ccc"},
+			{VGName: "vg-x", VGUUID: "aaa"},
+			{VGName: "vg-x", VGUUID: "bbb"},
+		}
+		got := findDuplicateVGNames(vgs)
+		assert.Equal(t, []string{"aaa", "bbb", "ccc"}, got["vg-x"])
+	})
+
+	t.Run("same_uuid_listed_twice_is_not_a_duplicate", func(t *testing.T) {
+		vgs := []internal.VGData{
+			{VGName: "vg-a", VGUUID: "uuid-a"},
+			{VGName: "vg-a", VGUUID: "uuid-a"},
+		}
+		got := findDuplicateVGNames(vgs)
+		assert.Empty(t, got, "two records with identical UUID describe the same VG and must not be reported as a duplicate name")
+	})
+
+	t.Run("vgs_with_empty_name_are_ignored", func(t *testing.T) {
+		vgs := []internal.VGData{
+			{VGName: "", VGUUID: "uuid-a"},
+			{VGName: "", VGUUID: "uuid-b"},
+			{VGName: "vg-a", VGUUID: "uuid-c"},
+		}
+		got := findDuplicateVGNames(vgs)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty_input_returns_empty", func(t *testing.T) {
+		got := findDuplicateVGNames(nil)
+		assert.Empty(t, got)
+	})
+}
+
+func TestDuplicateVGMessage(t *testing.T) {
+	msg := duplicateVGMessage("vg-thin-data", []string{"uuid-1", "uuid-2"})
+	assert.Contains(t, msg, `"vg-thin-data"`)
+	assert.Contains(t, msg, "uuid-1, uuid-2")
+	assert.Contains(t, msg, "vgrename --select vg_uuid=")
+	assert.True(t, strings.HasPrefix(msg, "Multiple LVM VGs share the name"))
+}
+
+func TestFilterCandidatesByDuplicateVGs(t *testing.T) {
+	t.Run("no_duplicates_returns_input_unchanged", func(t *testing.T) {
+		in := []internal.LVMVolumeGroupCandidate{
+			{ActualVGNameOnTheNode: "vg-a"},
+			{ActualVGNameOnTheNode: "vg-b"},
+		}
+		got := filterCandidatesByDuplicateVGs(in, nil)
+		assert.Equal(t, in, got)
+	})
+
+	t.Run("drops_candidates_for_duplicated_names", func(t *testing.T) {
+		in := []internal.LVMVolumeGroupCandidate{
+			{ActualVGNameOnTheNode: "vg-thin-data", VGUUID: "uuid-1"},
+			{ActualVGNameOnTheNode: "vg-thin-data", VGUUID: "uuid-2"},
+			{ActualVGNameOnTheNode: "vg-clean", VGUUID: "uuid-3"},
+		}
+		dup := map[string][]string{"vg-thin-data": {"uuid-1", "uuid-2"}}
+		got := filterCandidatesByDuplicateVGs(in, dup)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "vg-clean", got[0].ActualVGNameOnTheNode)
+	})
+
+	t.Run("empty_candidates_is_a_noop", func(t *testing.T) {
+		got := filterCandidatesByDuplicateVGs(nil, map[string][]string{"vg-a": {"u1", "u2"}})
+		assert.Empty(t, got)
+	})
+}


### PR DESCRIPTION
## Description

When more than one LVM VG on the node shares the same name (e.g. a cloned/imported PV brings a second `vg-thin-data`, see the warnings emitted by `lvm.static` itself: `Multiple VGs found with the same name: skipping vg-thin-data`), the agent silently mixes LV/PV data from those unrelated VGs.

`vgs`/`lvs` scans return rows for both VGs, and several lookups in the agent are keyed by VG name alone, so the wrong VG wins:

- `cache.configureLVKey(vgName, lvName)` (`internal/cache/cache.go`)
- `cache.FindVG(vgName)` — returns the first matching VG by name
- `discoverer.candidateMap[ActualVGNameOnTheNode]` and `filteredLVGs[ActualVGNameOnTheNode]`
- `reconciler.validateLVGForUpdateFunc` calls `sdsCache.FindLV`/`FindVG` by spec name

The visible effect on an affected `LVMVolumeGroup`:

```
Conditions:
  Type:    VGReady
  Status:  False
  Reason:  ScanFailed
  Message: ThinPool thin-data on the node has size 33280Mi which is less than status one 700Gi.
  Type:    VGConfigurationApplied
  Status:  False
  Reason:  ValidationFailed
  Message: Added thin-pools requested sizes are more than allowed free space in VG.
```

…while the real ThinPool LV on disk is intact (in our case `lv_size = 751619276800` bytes, i.e. exactly 700 GiB) and there is simply a stale duplicate VG metadata on a second device.

## Why do we need it, and what problem does it solve?

This is a minimal, targeted fix to stop the agent from corrupting the LVMVolumeGroup status when LVM cannot resolve VGs by name. Instead of overwriting `Status.ThinPools[*]` with data from the wrong VG and emitting two misleading reasons, the agent now:

- detects duplicate VG names from the sds cache (`findDuplicateVGNames`);
- in the discoverer (`LVMVolumeGroupDiscoverReconcile`), drops affected candidates, removes affected LVGs from the main reconcile loop, and writes a single actionable `VGReady=False, ScanFailed` condition pointing at the conflicting UUIDs;
- in the watcher reconciler (`validateLVGForUpdateFunc`), short-circuits before any name-keyed cache lookups so the user sees the same duplicate-VG message via `VGConfigurationApplied=False, ValidationFailed`.

The message tells the operator exactly what to do on the node:

```
Multiple LVM VGs share the name "vg-thin-data" on the node (UUIDs: crBlB1-..., zR5ouf-...). LVM cannot resolve the VG by name and the agent cannot safely reconcile this LVMVolumeGroup. Resolve the conflict on the node (e.g. `vgrename --select vg_uuid=<uuid> vg-thin-data <new-name>`, or remove the stale duplicate) and the agent will recover automatically.
```

The deeper refactor — keying the sds cache and the discoverer/reconciler lookups by `VGName+VGUUID`, plumbing `lvg.Status.VGUuid` through `FindLV`/`FindVG`, the LLV/LLVS reconcilers etc. — is intentionally left for a follow-up PR.

## What is the expected result?

- Before the fix: `kubectl describe lvg <name>` on a node with duplicate VG names shows the misleading `ThinPool ... is less than status one ...` and `Added thin-pools requested sizes are more than allowed free space in VG` reasons; status thin-pool data may drift; the LVG is stuck in `NotReady`.
- After the fix: the same LVG shows a single, accurate reason that names the duplicate UUIDs and points at the `vgrename --select vg_uuid=...` workaround; `Status.ThinPools[*]` is no longer overwritten with the wrong VG's data.
- Once the duplicate is resolved on the node, the agent automatically reconciles the LVG back to `Ready` without any restart.

## Checklist
- [x] The code is covered by unit tests (`TestFindDuplicateVGNames`, `TestDuplicateVGMessage`, `TestFilterCandidatesByDuplicateVGs`).
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.