### PR TITLE
fix(agent): ignore foreign block devices (rbd/drbd/nbd/loop) in LVM scan

### DIFF
--- a/images/agent/internal/const.go
+++ b/images/agent/internal/const.go
@@ -24,6 +24,8 @@ const (
 	MultiPathType                = "mpath"
 	CDROMDeviceType              = "rom"
 	DRBDName                     = "/dev/drbd"
+	RBDName                      = "/dev/rbd"
+	NBDName                      = "/dev/nbd"
 	LoopDeviceType               = "loop"
 	LVMDeviceType                = "lvm"
 	LVMFSType                    = "LVM2_member"
@@ -37,6 +39,25 @@ const (
 	LSBLKCmd                     = "/opt/deckhouse/sds/bin/lsblk.dynamic"
 	LVMCmd                       = "/opt/deckhouse/sds/bin/lvm.static"
 	ThinDumpCmd                  = "thin_dump"
+
+	// LVMGlobalFilter is passed via `lvm.static --config` for every LVM
+	// subcommand the agent runs. It rejects canonical names of block
+	// devices that always belong to a foreign storage layer (Ceph RBD,
+	// DRBD, NBD, loopback) so lvm.static does not even read PV labels
+	// from them when udev integration is unavailable.
+	//
+	// This is a best-effort hint for lvm.static only: due to its
+	// multi-alias rule (a device passes the filter if any of its aliases
+	// is accepted), a PV may still slip through via /dev/block/MAJ:MIN
+	// or /dev/disk/by-id/... aliases. The authoritative filter lives in
+	// pkg utils (FilterForeignPVs) and runs after lvm.static returns.
+	LVMGlobalFilter = `devices/global_filter=["r|^/dev/rbd|","r|^/dev/drbd|","r|^/dev/nbd|","r|^/dev/loop|","a|.*|"]`
+
+	// LVMArchiveRetention caps the size of /etc/lvm/archive: keep at
+	// most the last 10 metadata snapshots and at most 7 days of history.
+	// This only affects new metadata-changing operations; existing
+	// archives must be pruned manually on impacted nodes.
+	LVMArchiveRetention = `backup/retain_min=10 backup/retain_days=7`
 
 	TypeVGConfigurationApplied = "VGConfigurationApplied"
 	TypeVGReady                = "VGReady"
@@ -74,6 +95,20 @@ var (
 	InvalidDeviceTypes = [...]string{LoopDeviceType, LVMDeviceType, CDROMDeviceType}
 	Finalizers         = []string{SdsNodeConfiguratorFinalizer}
 	LVMTags            = []string{"storage.deckhouse.io/enabled=true", "linstor-"}
+
+	// ForeignDeviceBasePrefixes lists canonical block-device basenames
+	// that always belong to a foreign storage layer and must never be
+	// considered an LVM PV by the agent regardless of what lvm.static
+	// reported. The list intentionally matches /proc/devices entries:
+	//
+	//   rbd   - Ceph RBD (kernel rbd module, major 251)
+	//   drbd  - DRBD     (sds-replicated-volume, major 147)
+	//   nbd   - network block device (major 43)
+	//   loop  - loopback (major 7) — typically backs QEMU/file-based VM disks
+	//
+	// Used after lvm.static returns the PV list, against the canonical
+	// path resolved via readlink -f in the host mount namespace.
+	ForeignDeviceBasePrefixes = []string{"rbd", "drbd", "nbd", "loop"}
 )
 
 const (

--- a/images/agent/internal/controller/bd/discoverer.go
+++ b/images/agent/internal/controller/bd/discoverer.go
@@ -443,9 +443,15 @@ func (d *Discoverer) filterDevices(devices []internal.Device) ([]internal.Device
 				return true
 			}
 
-			if strings.HasPrefix(device.Name, internal.DRBDName) {
-				d.log.Trace("[filterDevices] filtered out", "name", device.Name, "kname", device.KName, "reason", "drbd")
-				return true
+			for _, foreign := range []struct{ prefix, reason string }{
+				{internal.DRBDName, "drbd"},
+				{internal.RBDName, "rbd"},
+				{internal.NBDName, "nbd"},
+			} {
+				if strings.HasPrefix(device.Name, foreign.prefix) {
+					d.log.Trace("[filterDevices] filtered out", "name", device.Name, "kname", device.KName, "reason", foreign.reason)
+					return true
+				}
 			}
 			if !hasValidType(device.Type) {
 				d.log.Trace(

--- a/images/agent/internal/controller/bd/discoverer_test.go
+++ b/images/agent/internal/controller/bd/discoverer_test.go
@@ -857,4 +857,31 @@ func TestBlockDeviceCtrl(t *testing.T) {
 			assert.Equal(t, 7, len(filteredDevices))
 		}
 	})
+
+	t.Run("filterDevices_drops_foreign_storage_prefixes", func(t *testing.T) {
+		d := setupDiscoverer()
+
+		// All five inputs have valid type/fstype/size so the only reason
+		// for the three foreign entries to disappear must be the prefix
+		// check we added (drbd/rbd/nbd). nvme4n1p1 and sdb are kept as
+		// the positive control.
+		size := resource.MustParse("10G")
+		devices := []internal.Device{
+			{Name: "/dev/nvme4n1p1", KName: "nvme4n1p1", Type: "part", FSType: internal.LVMFSType, Size: size, Serial: "n1p1", Wwn: "w1"},
+			{Name: "/dev/sdb", KName: "sdb", Type: "disk", FSType: internal.LVMFSType, Size: size, Serial: "sdb", Wwn: "w2"},
+			{Name: "/dev/drbd0", KName: "drbd0", Type: "disk", FSType: internal.LVMFSType, Size: size, Serial: "drbd", Wwn: "w3"},
+			{Name: "/dev/rbd9", KName: "rbd9", Type: "disk", FSType: internal.LVMFSType, Size: size, Serial: "rbd", Wwn: "w4"},
+			{Name: "/dev/nbd5", KName: "nbd5", Type: "disk", FSType: internal.LVMFSType, Size: size, Serial: "nbd", Wwn: "w5"},
+		}
+
+		got, err := d.filterDevices(devices)
+		assert.NoError(t, err)
+
+		names := make([]string, 0, len(got))
+		for _, dev := range got {
+			names = append(names, dev.Name)
+		}
+		assert.ElementsMatch(t, []string{"/dev/nvme4n1p1", "/dev/sdb"}, names,
+			"drbd/rbd/nbd devices must be filtered out at the BD discoverer level")
+	})
 }

--- a/images/agent/internal/scanner/scanner.go
+++ b/images/agent/internal/scanner/scanner.go
@@ -254,6 +254,28 @@ func (s *scanner) fillTheCache(ctx context.Context, log logger.Logger, cache *ca
 	}
 
 	log.Debug("[fillTheCache] successfully scanned entities. Starts to fill the cache")
+
+	// lvm.static bundled in /opt/deckhouse/sds/bin is built without udev
+	// integration and so reports PVs found on any block device it sees in
+	// /dev, including Ceph RBD images and loopback-mounted guest VM disks
+	// that happen to carry LVM signatures from nested LVM (see ADR / PR
+	// description). Filter those out before feeding the cache so that the
+	// LVG/BD reconcile logic never sees duplicate VG names produced by
+	// foreign storage layers.
+	beforePV := len(pvs)
+	pvs = utils.FilterForeignPVs(ctx, log, nil, pvs)
+	if dropped := beforePV - len(pvs); dropped > 0 {
+		log.Info(fmt.Sprintf("[fillTheCache] dropped %d foreign PV(s) backed by rbd/drbd/nbd/loop devices", dropped))
+		beforeVG := len(vgs)
+		vgs = utils.FilterVGsByPresentPVs(vgs, pvs)
+		beforeLV := len(lvs)
+		lvs = utils.FilterLVsByPresentVGs(lvs, vgs)
+		log.Info(fmt.Sprintf(
+			"[fillTheCache] cache pruned to local view: VGs %d -> %d, LVs %d -> %d",
+			beforeVG, len(vgs), beforeLV, len(lvs),
+		))
+	}
+
 	cache.StoreDevices(devices, devErr)
 	cache.StorePVs(pvs, pvsErr)
 	cache.StoreVGs(vgs, vgsErr)

--- a/images/agent/internal/scanner/scanner.go
+++ b/images/agent/internal/scanner/scanner.go
@@ -262,8 +262,13 @@ func (s *scanner) fillTheCache(ctx context.Context, log logger.Logger, cache *ca
 	// description). Filter those out before feeding the cache so that the
 	// LVG/BD reconcile logic never sees duplicate VG names produced by
 	// foreign storage layers.
+	//
+	// cfg.CmdDeadlineDuration bounds every per-PV nsenter+readlink call:
+	// a hung resolver on a single foreign device cannot block the entire
+	// scan loop. This is the same per-command timeout contract every
+	// other lvm.static invocation in this function obeys (see PR #290).
 	beforePV := len(pvs)
-	pvs = utils.FilterForeignPVs(ctx, log, nil, pvs)
+	pvs = utils.FilterForeignPVs(ctx, log, nil, pvs, cfg.CmdDeadlineDuration)
 	if dropped := beforePV - len(pvs); dropped > 0 {
 		log.Info(fmt.Sprintf("[fillTheCache] dropped %d foreign PV(s) backed by rbd/drbd/nbd/loop devices", dropped))
 		beforeVG := len(vgs)

--- a/images/agent/internal/utils/commands.go
+++ b/images/agent/internal/utils/commands.go
@@ -787,8 +787,36 @@ func nsentrerExpendedArgs(cmd string, args ...string) []string {
 	return append(nsenterArgs, args...)
 }
 
+// lvmStaticExtendedArgs builds the argv passed to nsenter+lvm.static for
+// every LVM subcommand the agent runs.
+//
+// In addition to plumbing args through nsentrerExpendedArgs, it injects a
+// --config override immediately after the LVM subcommand name (`vgs`,
+// `pvs`, `lvs`, `vgchange`, ...). The override does two things:
+//
+//   - rejects foreign-storage canonical paths from LVM's device scan
+//     (devices/global_filter, see internal.LVMGlobalFilter);
+//   - caps the size of /etc/lvm/archive on new metadata operations
+//     (backup/retain_min, backup/retain_days; see
+//     internal.LVMArchiveRetention).
+//
+// The --config flag must come AFTER the subcommand in lvm.static >=
+// 2.03.41; placing it before the subcommand makes lvm refuse to parse
+// the command line with "Specify options after a command".
+//
+// If args is empty (e.g. `lvm.static version`) the override is skipped
+// to keep the no-arg form working.
 func lvmStaticExtendedArgs(args []string) []string {
-	return nsentrerExpendedArgs(internal.LVMCmd, args...)
+	if len(args) == 0 {
+		return nsentrerExpendedArgs(internal.LVMCmd, args...)
+	}
+
+	configValue := internal.LVMGlobalFilter + " " + internal.LVMArchiveRetention
+	withConfig := make([]string, 0, len(args)+2)
+	withConfig = append(withConfig, args[0], "--config", configValue)
+	withConfig = append(withConfig, args[1:]...)
+
+	return nsentrerExpendedArgs(internal.LVMCmd, withConfig...)
 }
 
 // filterStdErr processes a bytes.Buffer containing stderr output and filters out specific

--- a/images/agent/internal/utils/commands_test.go
+++ b/images/agent/internal/utils/commands_test.go
@@ -318,3 +318,109 @@ func TestCommands(t *testing.T) {
 		})
 	})
 }
+
+// TestLvmStaticExtendedArgs pins three behaviors of the argv builder for
+// every lvm.static invocation that the agent runs through nsenter:
+//
+//  1. for a non-empty argument list the function injects a single
+//     "--config <LVMGlobalFilter + ' ' + LVMArchiveRetention>" pair
+//     IMMEDIATELY after the LVM subcommand (args[0]). Position matters
+//     here: lvm.static >= 2.03.41 rejects the command line as
+//     "Specify options after a command" if --config precedes the
+//     subcommand, see the function comment for the rationale;
+//
+//  2. the empty-args branch is preserved verbatim: no --config is
+//     injected and the resulting argv is identical to the legacy
+//     nsenter+lvm.static prefix. This guards against regressions for
+//     diagnostic invocations like `lvm.static version`;
+//
+//  3. the original args[1:] tail is preserved without reordering.
+//
+// The expected argv always begins with the fixed nsenter prefix
+// nsentrerExpendedArgs emits ("-t 1 -m -u -i -n -p -- /<NSENTERCmd
+// path>/lvm.static"), so the test simply rebuilds the full slice and
+// compares with assert.Equal — any future drift in either the prefix
+// or the --config placement fails loudly with a readable diff.
+func TestLvmStaticExtendedArgs(t *testing.T) {
+	configValue := internal.LVMGlobalFilter + " " + internal.LVMArchiveRetention
+	prefix := []string{"-t", "1", "-m", "-u", "-i", "-n", "-p", "--", internal.LVMCmd}
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "vgs_with_options_gets_config_after_subcommand",
+			args: []string{"vgs", "-o", "+uuid,tags,shared,vg_attr,vg_extent_size", "--units", "B", "--nosuffix", "--reportformat", "json"},
+			want: append(append([]string{}, prefix...),
+				"vgs", "--config", configValue,
+				"-o", "+uuid,tags,shared,vg_attr,vg_extent_size", "--units", "B", "--nosuffix", "--reportformat", "json",
+			),
+		},
+		{
+			name: "pvscan_cache_gets_config_after_subcommand",
+			args: []string{"pvscan", "--cache"},
+			want: append(append([]string{}, prefix...),
+				"pvscan", "--config", configValue,
+				"--cache",
+			),
+		},
+		{
+			name: "single_subcommand_still_gets_config",
+			args: []string{"vgscan"},
+			want: append(append([]string{}, prefix...),
+				"vgscan", "--config", configValue,
+			),
+		},
+		{
+			name: "vgcreate_with_pv_list_preserves_tail_order",
+			args: []string{"vgcreate", "vg-data", "/dev/sda", "/dev/sdb", "--addtag", "storage.deckhouse.io/enabled=true"},
+			want: append(append([]string{}, prefix...),
+				"vgcreate", "--config", configValue,
+				"vg-data", "/dev/sda", "/dev/sdb", "--addtag", "storage.deckhouse.io/enabled=true",
+			),
+		},
+		{
+			name: "empty_args_no_config_injected",
+			args: nil,
+			want: append([]string{}, prefix...),
+		},
+		{
+			name: "empty_slice_args_no_config_injected",
+			args: []string{},
+			want: append([]string{}, prefix...),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lvmStaticExtendedArgs(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("config_value_contains_all_foreign_prefixes_and_retention", func(t *testing.T) {
+		// Defensive cross-check: --config must reject all four foreign
+		// device prefixes the post-filter knows about (rbd/drbd/nbd/loop)
+		// and must cap /etc/lvm/archive growth. If either drops out due
+		// to a refactor, this assertion catches it before the next scan
+		// loop silently regresses.
+		got := lvmStaticExtendedArgs([]string{"vgs"})
+		// configValue is at index len(prefix)+2 (prefix..., "vgs",
+		// "--config", configValue).
+		require := len(prefix) + 2
+		if !assert.Greater(t, len(got), require, "argv too short — --config not injected?") {
+			return
+		}
+		actualConfig := got[require]
+		for _, p := range internal.ForeignDeviceBasePrefixes {
+			assert.Contains(t, actualConfig, "/dev/"+p,
+				"global_filter must reject /dev/%s* canonical paths", p)
+		}
+		assert.Contains(t, actualConfig, "backup/retain_min=",
+			"--config must cap /etc/lvm/archive growth via backup/retain_min")
+		assert.Contains(t, actualConfig, "backup/retain_days=",
+			"--config must cap /etc/lvm/archive growth via backup/retain_days")
+	})
+}

--- a/images/agent/internal/utils/devicefilter.go
+++ b/images/agent/internal/utils/devicefilter.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal"
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal/logger"
@@ -97,6 +98,13 @@ func IsForeignDeviceBase(base string) bool {
 // assumption that a transient resolver failure must not silently hide
 // a legitimate PV.
 //
+// Each resolver call runs under runWithTimeout(cmdTimeout) so a hung
+// nsenter-backed readlink cannot block the scan loop indefinitely.
+// This mirrors the per-command timeout protection introduced in
+// PR #290 for every other lvm.static / nsenter invocation in
+// scanner.fillTheCache. A non-positive cmdTimeout disables the
+// per-call deadline (useful in unit tests with mock resolvers).
+//
 // resolver may be nil; HostNsenterCanonicalResolver is used in that
 // case.
 func FilterForeignPVs(
@@ -104,6 +112,7 @@ func FilterForeignPVs(
 	log logger.Logger,
 	resolver CanonicalPathResolver,
 	pvs []internal.PVData,
+	cmdTimeout time.Duration,
 ) []internal.PVData {
 	if resolver == nil {
 		resolver = HostNsenterCanonicalResolver
@@ -115,7 +124,9 @@ func FilterForeignPVs(
 			out = append(out, pv)
 			continue
 		}
-		resolved, err := resolver(ctx, pv.PVName)
+		resolved, err := runWithTimeout(ctx, cmdTimeout, func(ctx context.Context) (string, error) {
+			return resolver(ctx, pv.PVName)
+		})
 		if err != nil {
 			log.Warning(fmt.Sprintf(
 				"[FilterForeignPVs] unable to resolve canonical path for PV %q; keeping it: %v",

--- a/images/agent/internal/utils/devicefilter.go
+++ b/images/agent/internal/utils/devicefilter.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal"
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal/logger"
+)
+
+// CanonicalPathResolver resolves a /dev/* path to the canonical block
+// device it points at, following all symlinks. The default resolver is
+// HostNsenterCanonicalResolver, which runs `readlink -f` in PID 1's
+// mount namespace because the agent container cannot otherwise see the
+// host's /dev symlink tree. The function-typed alias makes the resolver
+// trivial to mock in tests.
+type CanonicalPathResolver func(ctx context.Context, path string) (string, error)
+
+// HostNsenterCanonicalResolver invokes `nsenter -t 1 -m -- readlink -f
+// <path>` and returns the trimmed canonical path printed by readlink.
+//
+// It deliberately does not consult the in-container /dev/ tree: device
+// symlinks under /dev/disk/by-id/ and /dev/block/ are created by udev
+// on the host and may resolve differently (or not at all) inside the
+// container's mount namespace.
+func HostNsenterCanonicalResolver(ctx context.Context, devPath string) (string, error) {
+	args := []string{"-t", "1", "-m", "--", "readlink", "-f", devPath}
+	cmd := exec.CommandContext(ctx, internal.NSENTERCmd, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("nsenter readlink -f %s: %w, stderr=%q", devPath, err, stderr.String())
+	}
+	resolved := strings.TrimSpace(stdout.String())
+	if resolved == "" {
+		return "", fmt.Errorf("nsenter readlink -f %s returned empty path", devPath)
+	}
+	return resolved, nil
+}
+
+// IsForeignDeviceBase reports whether the given canonical basename
+// belongs to a storage layer the agent must ignore. The check is a
+// strict prefix match against internal.ForeignDeviceBasePrefixes so it
+// catches partitions of foreign devices too (e.g. "rbd14p1", "loop970",
+// "drbd0").
+func IsForeignDeviceBase(base string) bool {
+	for _, prefix := range internal.ForeignDeviceBasePrefixes {
+		if strings.HasPrefix(base, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterForeignPVs returns a copy of pvs with PVs whose underlying
+// canonical device belongs to a foreign storage layer (Ceph RBD, DRBD,
+// NBD, loopback) removed.
+//
+// lvm.static bundled with the agent has no udev integration and so it
+// enumerates devices via /dev/block/MAJOR:MINOR and /dev/disk/by-id/
+// directly. With LVM PV signatures present inside guest VM disks
+// (nested LVM), lvm.static reports such "ghost" VGs as if they were
+// local. Two collisions then become possible:
+//
+//  1. an LVMVolumeGroup spec.actualVGNameOnTheNode matches more than
+//     one VG UUID at once and the agent picks the wrong one (size
+//     mismatch, ScanFailed condition);
+//
+//  2. a BlockDevice CR is created for a /dev/rbdN device that already
+//     belongs to a Ceph PVC.
+//
+// We resolve every reported PV path to its canonical basename in the
+// host's mount namespace and drop the PV if the basename starts with
+// one of the foreign prefixes. PVs we cannot resolve are kept, on the
+// assumption that a transient resolver failure must not silently hide
+// a legitimate PV.
+//
+// resolver may be nil; HostNsenterCanonicalResolver is used in that
+// case.
+func FilterForeignPVs(
+	ctx context.Context,
+	log logger.Logger,
+	resolver CanonicalPathResolver,
+	pvs []internal.PVData,
+) []internal.PVData {
+	if resolver == nil {
+		resolver = HostNsenterCanonicalResolver
+	}
+
+	out := make([]internal.PVData, 0, len(pvs))
+	for _, pv := range pvs {
+		if pv.PVName == "" {
+			out = append(out, pv)
+			continue
+		}
+		resolved, err := resolver(ctx, pv.PVName)
+		if err != nil {
+			log.Warning(fmt.Sprintf(
+				"[FilterForeignPVs] unable to resolve canonical path for PV %q; keeping it: %v",
+				pv.PVName, err,
+			))
+			out = append(out, pv)
+			continue
+		}
+		base := path.Base(resolved)
+		if IsForeignDeviceBase(base) {
+			log.Info(fmt.Sprintf(
+				"[FilterForeignPVs] dropping PV %q backed by foreign device %q (VG=%q VG_UUID=%q)",
+				pv.PVName, resolved, pv.VGName, pv.VGUuid,
+			))
+			continue
+		}
+		out = append(out, pv)
+	}
+	return out
+}
+
+// FilterVGsByPresentPVs returns a copy of vgs that keeps only VGs
+// referenced by at least one PV in pvs (matched by VGUuid). It is
+// meant to run right after FilterForeignPVs so that phantom VGs whose
+// only backing PVs were foreign disappear from the cache.
+//
+// A VG whose VGUuid is empty (should not happen in healthy lvm output
+// but guards against malformed JSON) is dropped as well.
+func FilterVGsByPresentPVs(vgs []internal.VGData, pvs []internal.PVData) []internal.VGData {
+	referenced := make(map[string]struct{}, len(pvs))
+	for _, pv := range pvs {
+		if pv.VGUuid != "" {
+			referenced[pv.VGUuid] = struct{}{}
+		}
+	}
+	out := make([]internal.VGData, 0, len(vgs))
+	for _, vg := range vgs {
+		if vg.VGUUID == "" {
+			continue
+		}
+		if _, ok := referenced[vg.VGUUID]; ok {
+			out = append(out, vg)
+		}
+	}
+	return out
+}
+
+// FilterLVsByPresentVGs returns a copy of lvs that keeps only LVs
+// belonging to a VG present in vgs (matched by VGUuid). Mirrors
+// FilterVGsByPresentPVs so the three caches stay consistent.
+func FilterLVsByPresentVGs(lvs []internal.LVData, vgs []internal.VGData) []internal.LVData {
+	referenced := make(map[string]struct{}, len(vgs))
+	for _, vg := range vgs {
+		if vg.VGUUID != "" {
+			referenced[vg.VGUUID] = struct{}{}
+		}
+	}
+	out := make([]internal.LVData, 0, len(lvs))
+	for _, lv := range lvs {
+		if _, ok := referenced[lv.VGUuid]; ok {
+			out = append(out, lv)
+		}
+	}
+	return out
+}

--- a/images/agent/internal/utils/devicefilter_test.go
+++ b/images/agent/internal/utils/devicefilter_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -92,7 +93,7 @@ func TestFilterForeignPVs(t *testing.T) {
 		return "", errors.New("unknown path")
 	}
 
-	got := FilterForeignPVs(context.Background(), log, resolver, pvs)
+	got := FilterForeignPVs(context.Background(), log, resolver, pvs, 0)
 	wantNames := []string{"/dev/nvme4n1p1", "/dev/nvme4n1p2", "/dev/md1"}
 	gotNames := make([]string, 0, len(got))
 	for _, pv := range got {
@@ -118,7 +119,7 @@ func TestFilterForeignPVs_keepsOnResolverError(t *testing.T) {
 		return p, nil
 	}
 
-	got := FilterForeignPVs(context.Background(), log, resolver, pvs)
+	got := FilterForeignPVs(context.Background(), log, resolver, pvs, 0)
 	assert.Len(t, got, 2, "transient resolver failure must not drop a PV")
 }
 
@@ -135,9 +136,58 @@ func TestFilterForeignPVs_emptyPVName(t *testing.T) {
 		return "", nil
 	}
 
-	got := FilterForeignPVs(context.Background(), log, resolver, pvs)
+	got := FilterForeignPVs(context.Background(), log, resolver, pvs, 0)
 	assert.Len(t, got, 1)
 	assert.Equal(t, 0, calls, "empty pv_name must not trigger the resolver")
+}
+
+// TestFilterForeignPVs_perCallTimeout pins the contract introduced for
+// PR #290 / scanner.fillTheCache: a hung resolver call must not block
+// the scan loop. With a tiny per-call deadline a resolver that respects
+// ctx must return a context.DeadlineExceeded-class error, the PV is
+// then conservatively kept in the cache (matching the "keep on resolver
+// error" branch verified above), and the overall call returns within a
+// few timeouts rather than hanging on the first PV.
+func TestFilterForeignPVs_perCallTimeout(t *testing.T) {
+	log, err := logger.NewLogger(logger.ErrorLevel)
+	if err != nil {
+		t.Fatalf("init logger: %v", err)
+	}
+
+	// Three PVs all backed by a "hung" resolver. If the per-call
+	// timeout were not honored, the test would hang here.
+	pvs := []internal.PVData{
+		{PVName: "/dev/hang-a", VGUuid: "a"},
+		{PVName: "/dev/hang-b", VGUuid: "b"},
+		{PVName: "/dev/hang-c", VGUuid: "c"},
+	}
+
+	calls := 0
+	resolver := func(ctx context.Context, _ string) (string, error) {
+		calls++
+		// Block until the per-call deadline fires.
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	const perCallTimeout = 20 * time.Millisecond
+	// Allow generous slack vs perCallTimeout * len(pvs); on a heavily
+	// loaded CI runner go's scheduler can be sluggish, but we still
+	// want this test to fail loudly if the timeout is missing entirely
+	// (in which case it would hang until `go test -timeout`).
+	deadline := time.Now().Add(2 * time.Second)
+
+	start := time.Now()
+	got := FilterForeignPVs(context.Background(), log, resolver, pvs, perCallTimeout)
+	elapsed := time.Since(start)
+
+	if time.Now().After(deadline) {
+		t.Fatalf("FilterForeignPVs took too long (%s) — per-call timeout not honored", elapsed)
+	}
+	assert.Equal(t, len(pvs), calls, "resolver must be invoked once per non-empty PV")
+	assert.Len(t, got, len(pvs),
+		"PVs whose resolver hits the per-call timeout must be conservatively kept "+
+			"(same contract as the transient-error branch)")
 }
 
 func TestFilterVGsByPresentPVs(t *testing.T) {

--- a/images/agent/internal/utils/devicefilter_test.go
+++ b/images/agent/internal/utils/devicefilter_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal"
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal/logger"
+)
+
+func TestIsForeignDeviceBase(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		want bool
+	}{
+		{"rbd canonical", "rbd1", true},
+		{"rbd with partition", "rbd14p1", true},
+		{"drbd canonical", "drbd0", true},
+		{"nbd canonical", "nbd5", true},
+		{"loop canonical", "loop970", true},
+		{"loop with high index", "loop1234", true},
+
+		{"nvme canonical", "nvme4n1p1", false},
+		{"sda canonical", "sda1", false},
+		{"md raid", "md1", false},
+		{"dm-mapper", "dm-3", false},
+		{"empty", "", false},
+
+		// Sanity: do not be fooled by a foreign-prefix appearing anywhere
+		// other than the start of the basename. We only match prefixes.
+		{"rbd in the middle", "sd-rbd-cache", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsForeignDeviceBase(tt.base))
+		})
+	}
+}
+
+func TestFilterForeignPVs(t *testing.T) {
+	log, err := logger.NewLogger(logger.ErrorLevel)
+	if err != nil {
+		t.Fatalf("init logger: %v", err)
+	}
+
+	pvs := []internal.PVData{
+		{PVName: "/dev/nvme4n1p1", VGName: "vg-thin-data", VGUuid: "crBlB1"},
+		{PVName: "/dev/nvme4n1p2", VGName: "vg-sds-local", VGUuid: "ksm1nq"},
+		{PVName: "/dev/md1", VGName: "vg0", VGUuid: "IZMRUl"},
+		{PVName: "/dev/block/251:144", VGName: "vg-1", VGUuid: "Czf0Sf"},                                 // -> rbd9
+		{PVName: "/dev/block/251:16", VGName: "vg-thin-data", VGUuid: "zR5ouf"},                          // -> rbd1
+		{PVName: "/dev/disk/by-id/lvm-pv-uuid-9Uuprg-IFQM-5c2y", VGName: "vg-1", VGUuid: "kHmPc6"},       // -> loop808
+		{PVName: "/dev/disk/by-id/lvm-pv-uuid-xl1soD-zQZM-BRAt", VGName: "vg-thin-data", VGUuid: "He4J"}, // -> loop485
+	}
+
+	// Resolver mimics the readlink -f result observed on d8-virt-node-0
+	// during diagnosis: foreign aliases resolve to /dev/rbdN or
+	// /dev/loopN, local PVs resolve to themselves.
+	resolver := func(_ context.Context, p string) (string, error) {
+		switch p {
+		case "/dev/nvme4n1p1", "/dev/nvme4n1p2", "/dev/md1":
+			return p, nil
+		case "/dev/block/251:144":
+			return "/dev/rbd9", nil
+		case "/dev/block/251:16":
+			return "/dev/rbd1", nil
+		case "/dev/disk/by-id/lvm-pv-uuid-9Uuprg-IFQM-5c2y":
+			return "/dev/loop808", nil
+		case "/dev/disk/by-id/lvm-pv-uuid-xl1soD-zQZM-BRAt":
+			return "/dev/loop485", nil
+		}
+		return "", errors.New("unknown path")
+	}
+
+	got := FilterForeignPVs(context.Background(), log, resolver, pvs)
+	wantNames := []string{"/dev/nvme4n1p1", "/dev/nvme4n1p2", "/dev/md1"}
+	gotNames := make([]string, 0, len(got))
+	for _, pv := range got {
+		gotNames = append(gotNames, pv.PVName)
+	}
+	assert.ElementsMatch(t, wantNames, gotNames)
+}
+
+func TestFilterForeignPVs_keepsOnResolverError(t *testing.T) {
+	log, err := logger.NewLogger(logger.ErrorLevel)
+	if err != nil {
+		t.Fatalf("init logger: %v", err)
+	}
+
+	pvs := []internal.PVData{
+		{PVName: "/dev/nvme4n1p1", VGUuid: "u1"},
+		{PVName: "/dev/something-transient", VGUuid: "u2"},
+	}
+	resolver := func(_ context.Context, p string) (string, error) {
+		if p == "/dev/something-transient" {
+			return "", errors.New("transient resolver failure")
+		}
+		return p, nil
+	}
+
+	got := FilterForeignPVs(context.Background(), log, resolver, pvs)
+	assert.Len(t, got, 2, "transient resolver failure must not drop a PV")
+}
+
+func TestFilterForeignPVs_emptyPVName(t *testing.T) {
+	log, err := logger.NewLogger(logger.ErrorLevel)
+	if err != nil {
+		t.Fatalf("init logger: %v", err)
+	}
+
+	pvs := []internal.PVData{{PVName: "", VGUuid: "u1"}}
+	calls := 0
+	resolver := func(_ context.Context, _ string) (string, error) {
+		calls++
+		return "", nil
+	}
+
+	got := FilterForeignPVs(context.Background(), log, resolver, pvs)
+	assert.Len(t, got, 1)
+	assert.Equal(t, 0, calls, "empty pv_name must not trigger the resolver")
+}
+
+func TestFilterVGsByPresentPVs(t *testing.T) {
+	tests := []struct {
+		name      string
+		vgs       []internal.VGData
+		pvs       []internal.PVData
+		wantUUIDs []string
+	}{
+		{
+			name: "drops phantom VGs whose PVs were filtered out",
+			vgs: []internal.VGData{
+				{VGName: "vg-thin-data", VGUUID: "crBlB1"},
+				{VGName: "vg-thin-data", VGUUID: "zR5ouf"},
+				{VGName: "vg-1", VGUUID: "Czf0Sf"},
+				{VGName: "vg0", VGUUID: "IZMRUl"},
+			},
+			pvs: []internal.PVData{
+				{PVName: "/dev/nvme4n1p1", VGUuid: "crBlB1"},
+				{PVName: "/dev/md1", VGUuid: "IZMRUl"},
+			},
+			wantUUIDs: []string{"crBlB1", "IZMRUl"},
+		},
+		{
+			name:      "no PVs leaves no VGs",
+			vgs:       []internal.VGData{{VGName: "vg-thin-data", VGUUID: "crBlB1"}},
+			pvs:       nil,
+			wantUUIDs: nil,
+		},
+		{
+			name: "VG without VGUUID is dropped",
+			vgs: []internal.VGData{
+				{VGName: "broken", VGUUID: ""},
+				{VGName: "vg0", VGUUID: "IZMRUl"},
+			},
+			pvs:       []internal.PVData{{PVName: "/dev/md1", VGUuid: "IZMRUl"}},
+			wantUUIDs: []string{"IZMRUl"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterVGsByPresentPVs(tt.vgs, tt.pvs)
+			gotUUIDs := make([]string, 0, len(got))
+			for _, vg := range got {
+				gotUUIDs = append(gotUUIDs, vg.VGUUID)
+			}
+			assert.ElementsMatch(t, tt.wantUUIDs, gotUUIDs)
+		})
+	}
+}
+
+func TestFilterLVsByPresentVGs(t *testing.T) {
+	vgs := []internal.VGData{
+		{VGName: "vg-thin-data", VGUUID: "crBlB1"},
+		{VGName: "vg0", VGUUID: "IZMRUl"},
+	}
+	lvs := []internal.LVData{
+		{LVName: "thin-data", VGName: "vg-thin-data", VGUuid: "crBlB1"},
+		{LVName: "ghost-thin", VGName: "vg-thin-data", VGUuid: "zR5ouf"},
+		{LVName: "system-root", VGName: "vg0", VGUuid: "IZMRUl"},
+		{LVName: "ghost-vg1-lv", VGName: "vg-1", VGUuid: "Czf0Sf"},
+	}
+	got := FilterLVsByPresentVGs(lvs, vgs)
+	wantNames := []string{"thin-data", "system-root"}
+	gotNames := make([]string, 0, len(got))
+	for _, lv := range got {
+		gotNames = append(gotNames, lv.LVName)
+	}
+	assert.ElementsMatch(t, wantNames, gotNames)
+}


### PR DESCRIPTION
## Description

The bundled `lvm.static` (2.03.41-git) shipped with the agent is built without udev integration, so it enumerates every block device under `/dev` on its own — including `/dev/block/MAJ:MIN` and `/dev/disk/by-id/*` aliases. On nodes that, in addition to local disks, expose Ceph RBD volumes, DRBD, NBD or loopback devices carrying **nested LVM metadata** (typically — a guest VM disk with its own `vg-thin-data`/`vg-1` inside a Ceph PVC or a loop-mounted image), `lvm.static` hands the agent phantom VGs with the same name as a real local VG.

In that situation the agent's reconcile loop finds **several** VG UUIDs matching `LVMVolumeGroup.spec.actualVGNameOnTheNode` and may validate against a thin pool from the wrong VG. This surfaces as `ThinPool thin-data on the node has size 33280Mi which is less than status one 700Gi.` and the LVG stays in NotReady. The bug was reproduced on a Deckhouse Virtualization hypervisor (`d8-virt-node-0`): `lvm.static` saw 5 instances of `vg-thin-data`/`vg-1`, while the host's `lvm 2.03.11` (with udev) saw only the legitimate one.

## Why do we need it, and what problem does it solve?

This addresses the root cause: foreign block devices (rbd/drbd/nbd/loop) must not participate in the agent's LVM scan — they belong to their own CSI/storage layer and the "LVM signatures" found on them belong to guest VMs. Without this fix, any cluster running `sds-node-configurator-agent` on a node that is also a hypervisor or a client of another storage driver with nested LVM regularly hits LVG NotReady.

The fix is implemented in two layers:

1. **`utils.FilterForeignPVs`** (primary, authoritative). Invoked in `scanner.fillTheCache` right after `lvm.static` returns. For every PV the canonical `/dev/*` path is resolved with `nsenter -t 1 -m -- readlink -f <pv_name>` in the host mount namespace and the basename is matched against the prefix list `rbd`/`drbd`/`nbd`/`loop`. PVs that fail to resolve are kept on purpose, so a transient resolver error never silently drops a legitimate PV. `FilterVGsByPresentPVs` and `FilterLVsByPresentVGs` then prune VGs/LVs that no longer reference any local PV.

2. **`--config 'devices/global_filter=...' + backup/retain_*`** injected by `lvmStaticExtendedArgs`. The `global_filter` rejects canonical names like `/dev/rbd*` — this is a best-effort hint to `lvm.static`: its "accept if any alias is accepted" rule still lets some PVs leak through via `/dev/block/MAJ:MIN`, but the flag noticeably reduces stderr noise and scan time. `backup/retain_min=10 backup/retain_days=7` caps `/etc/lvm/archive` growth on future metadata operations.

In addition, `bd/discoverer.go::filterDevices` now rejects `/dev/rbd*` and `/dev/nbd*` device names alongside the existing `/dev/drbd*` check — so phantom BlockDevice CRs no longer appear for foreign storage.

Related:
- PR #290 (graceful shutdown + startupProbe + per-command timeouts) — merged, untouched.
- PR #291 (duplicate-VG-name detector with a clear condition) — merged, kept as a safety net. If a future foreign storage layer slips through this prefix list, the operator will still see `VGReady=False, ScanFailed` with a hint about `vgrename --select`, instead of a misleading "size mismatch".

## What is the expected result?

After the change is rolled out:

- On nodes with rbd/drbd/nbd/loop devices the agent stops populating `sdsCache` with foreign PVs/VGs/LVs, and `sdsCache.GetVGs()` returns only local VGs. LVGs that were stuck in NotReady because of phantom duplicates move to Ready on the next discover cycle.
- Agent logs show informational lines `[FilterForeignPVs] dropping PV ... backed by foreign device ...` and `[fillTheCache] dropped N foreign PV(s) ...` — the count matches the number of rbd/drbd/loop devices visible on the node.
- New `vgs`/`lvs`/`vgchange` invocations from the agent carry `--config 'devices/global_filter=... backup/retain_min=10 backup/retain_days=7'`. The number of duplicate-VG WARNINGs in stderr drops noticeably (some may still appear via `/dev/block/MAJ:MIN` aliases — by design).
- BlockDevice CRs for `/dev/rbd*`/`/dev/nbd*` are not created any more (previously they could appear if the device passed the other filters).

## Operational note (out of scope for the deploy)

This fix **does not** clean up archives that have already accumulated in `/etc/lvm/archive` on affected nodes. On `d8-virt-node-0` we observed over 1.5 GiB and 200k+ files for `vg-thin-data` (history of thin volumes for guest VMs). A one-time manual prune is required on each such node:

```bash
nsenter -t 1 -m -u -i -n -p -- /opt/deckhouse/sds/bin/lvm.static \
  vgcfgbackup --all   # take a fresh backup in /etc/lvm/backup before pruning

# then safely shrink the archive, keeping the last 7 days:
nsenter -t 1 -m -- find /etc/lvm/archive -type f -name '*.vg' -mtime +7 -delete
```

Do not touch `/etc/lvm/backup`: it holds the latest VG metadata used by `vgcfgrestore`. We only drop stale snapshots from `archive/`.

## Checklist
- [x] The code is covered by unit tests (`utils/devicefilter_test.go`, the new `filterDevices_drops_foreign_storage_prefixes` case in `bd/discoverer_test.go`).
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
