### PR TITLE
fix(agent): remove blanket accept rule from LVM global_filter

### DIFF
--- a/images/agent/internal/const.go
+++ b/images/agent/internal/const.go
@@ -46,12 +46,18 @@ const (
 	// DRBD, NBD, loopback) so lvm.static does not even read PV labels
 	// from them when udev integration is unavailable.
 	//
-	// This is a best-effort hint for lvm.static only: due to its
-	// multi-alias rule (a device passes the filter if any of its aliases
-	// is accepted), a PV may still slip through via /dev/block/MAJ:MIN
-	// or /dev/disk/by-id/... aliases. The authoritative filter lives in
-	// pkg utils (FilterForeignPVs) and runs after lvm.static returns.
-	LVMGlobalFilter = `devices/global_filter=["r|^/dev/rbd|","r|^/dev/drbd|","r|^/dev/nbd|","r|^/dev/loop|","a|.*|"]`
+	// There is intentionally no blanket "a|.*|" accept rule. When a
+	// device matches none of the reject patterns, LVM accepts it by
+	// default. Adding an explicit accept-all rule would override LVM's
+	// built-in device filter and cause it to scan non-standard paths
+	// (e.g. /dev/disk/by-diskseq/*), surfacing duplicate VG names when
+	// the same PV is visible through multiple aliases and breaking
+	// commands like lvremove that address LVs by VG name.
+	//
+	// The authoritative foreign-PV filter (FilterForeignPVs) still runs
+	// after lvm.static returns and catches any PVs that slip through
+	// via /dev/block/MAJ:MIN or /dev/disk/by-id/... aliases.
+	LVMGlobalFilter = `devices/global_filter=["r|^/dev/rbd|","r|^/dev/drbd|","r|^/dev/nbd|","r|^/dev/loop|"]`
 
 	// LVMArchiveRetention caps the size of /etc/lvm/archive: keep at
 	// most the last 10 metadata snapshots and at most 7 days of history.

--- a/images/agent/internal/const_test.go
+++ b/images/agent/internal/const_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLVMGlobalFilter_NoBlanketAccept verifies that LVMGlobalFilter does not
+// contain a blanket "a|.*|" accept rule. Adding such a rule overrides LVM's
+// built-in device filter and forces lvm.static to scan non-standard paths
+// (e.g. /dev/disk/by-diskseq/*), which may surface duplicate VG names when the
+// same PV is visible through multiple device aliases. Duplicate VG names break
+// lvremove and other commands that address LVs by VG name.
+func TestLVMGlobalFilter_NoBlanketAccept(t *testing.T) {
+	if strings.Contains(LVMGlobalFilter, `a|.*|`) {
+		t.Fatalf(
+			"LVMGlobalFilter must not contain a blanket accept rule \"a|.*|\". "+
+				"It overrides LVM's built-in device filter and causes duplicate VG names "+
+				"when PVs are visible through non-standard paths. "+
+				"Remove it and let LVM use its default accept-on-no-match behaviour. "+
+				"Current filter: %s",
+			LVMGlobalFilter,
+		)
+	}
+}


### PR DESCRIPTION
## Description

Remove the blanket `"a|.*|"` accept rule from `LVMGlobalFilter` constant in `images/agent/internal/const.go`.

The `"a|.*|"` rule overrides LVM's built-in device filter and forces `lvm.static` to scan non-standard paths like `/dev/disk/by-diskseq/*`. When the same PV is visible through multiple aliases (`/dev/block/MAJ:MIN` and `/dev/disk/by-diskseq/N`), LVM reports duplicate VG names:

```
WARNING: VG name vg-1 is used by VGs BEBywM-... and iks8Ei-...
```

Commands that address LVs by VG name (`lvremove /dev/vg-1/pvc-...`) then fail with exit status 5 because LVM cannot unambiguously resolve which VG the LV belongs to.

LVM accepts devices that do not match any reject rule by default, so the explicit accept-all is unnecessary. Removing it restores LVM's built-in device-discovery behaviour.

A guard test (`TestLVMGlobalFilter_NoBlanketAccept`) is added to prevent accidental reintroduction.

## Why do we need it, and what problem does it solve?

LV deletion is broken on nodes where PVs are visible through non-standard device paths — the agent enters a reconcile-delete loop, marking LVMLogicalVolume as Failed and never removing the actual LVM volume.

## What is the expected result?

After applying the fix:
- `lvm.static vgs` with the agent's `--config` must show each VG exactly once (no `WARNING: VG name ... is used by VGs ...` duplicate messages)
- `lvremove` addressed by VG name must succeed regardless of how many device aliases exist for the PVs
- The guard test must pass: `go test ./internal/ -run TestLVMGlobalFilter_NoBlanketAccept`

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
