### PR TITLE
fix(agent): prevent empty blockDeviceSelector when taking existing VG under management

### DIFF
--- a/images/agent/internal/controller/lvg/discoverer.go
+++ b/images/agent/internal/controller/lvg/discoverer.go
@@ -469,10 +469,14 @@ func (d *Discoverer) CreateLVMVolumeGroupByCandidate(
 		},
 	}
 
+	if len(candidate.BlockDevicesNames) == 0 {
+		d.log.Warning(fmt.Sprintf("[CreateLVMVolumeGroupByCandidate] no BlockDevices found for VG %s, postponing LVMVolumeGroup creation until BlockDevices are discovered", candidate.ActualVGNameOnTheNode))
+		return lvmVolumeGroup, nil
+	}
+
 	for _, node := range candidate.Nodes {
 		for _, dev := range node {
-			i := len(dev.BlockDevice)
-			if i == 0 {
+			if len(dev.BlockDevice) == 0 {
 				d.log.Warning("The attempt to create the LVG resource failed because it was not possible to find a BlockDevice for it.")
 				return lvmVolumeGroup, nil
 			}
@@ -496,6 +500,14 @@ func (d *Discoverer) UpdateLVMVolumeGroupByCandidate(
 	lvg *v1alpha1.LVMVolumeGroup,
 	candidate internal.LVMVolumeGroupCandidate,
 ) error {
+	if len(candidate.BlockDevicesNames) > 0 && hasEmptyBlockDeviceSelector(lvg) {
+		d.log.Warning(fmt.Sprintf("[UpdateLVMVolumeGroupByCandidate] the LVMVolumeGroup %s has an empty blockDeviceSelector, updating it with discovered BlockDevices", lvg.Name))
+		lvg.Spec.BlockDeviceSelector = configureBlockDeviceSelector(candidate)
+		if err := d.cl.Update(ctx, lvg); err != nil {
+			return fmt.Errorf("[UpdateLVMVolumeGroupByCandidate] unable to fix empty blockDeviceSelector for LVMVolumeGroup %s: %w", lvg.Name, err)
+		}
+	}
+
 	// Check if VG has some problems
 	if candidate.Health == internal.NonOperational {
 		d.log.Warning(fmt.Sprintf("[UpdateLVMVolumeGroupByCandidate] candidate for LVMVolumeGroup %s has NonOperational health, message %s. Update the VGReady condition to False", lvg.Name, candidate.Message))
@@ -925,6 +937,18 @@ func hasStatusPoolDiff(first, second []v1alpha1.LVMVolumeGroupThinPoolStatus) bo
 		}
 	}
 
+	return false
+}
+
+func hasEmptyBlockDeviceSelector(lvg *v1alpha1.LVMVolumeGroup) bool {
+	if lvg.Spec.BlockDeviceSelector == nil {
+		return true
+	}
+	for _, me := range lvg.Spec.BlockDeviceSelector.MatchExpressions {
+		if me.Key == internal.MetadataNameLabelKey && me.Operator == metav1.LabelSelectorOpIn {
+			return len(me.Values) == 0
+		}
+	}
 	return false
 }
 

--- a/images/agent/internal/controller/lvg/discoverer_test.go
+++ b/images/agent/internal/controller/lvg/discoverer_test.go
@@ -514,6 +514,87 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 		}
 	})
 
+	t.Run("CreateLVMVolumeGroup_skips_creation_when_no_block_devices", func(t *testing.T) {
+		const (
+			NodeName = "test-node"
+		)
+
+		d := setupDiscoverer(&DiscovererConfig{NodeName: NodeName})
+
+		candidate := internal.LVMVolumeGroupCandidate{
+			LVMVGName:             "test-lvg-empty-bds",
+			ActualVGNameOnTheNode: "test-vg",
+			BlockDevicesNames:     []string{},
+			Type:                  "Local",
+			AllocatedSize:         resource.MustParse("10G"),
+			VGSize:                resource.MustParse("10G"),
+			VGUUID:                "test-uuid",
+		}
+
+		created, err := d.CreateLVMVolumeGroupByCandidate(ctx, candidate)
+		assert.NoError(t, err)
+		assert.NotNil(t, created)
+
+		lvgs, err := d.GetAPILVMVolumeGroups(ctx)
+		assert.NoError(t, err)
+		_, exists := lvgs[candidate.LVMVGName]
+		assert.False(t, exists, "LVG should not be created when BlockDevicesNames is empty")
+	})
+
+	t.Run("hasEmptyBlockDeviceSelector", func(t *testing.T) {
+		t.Run("nil_selector_returns_true", func(t *testing.T) {
+			lvg := &v1alpha1.LVMVolumeGroup{}
+			assert.True(t, hasEmptyBlockDeviceSelector(lvg))
+		})
+
+		t.Run("empty_values_returns_true", func(t *testing.T) {
+			lvg := &v1alpha1.LVMVolumeGroup{
+				Spec: v1alpha1.LVMVolumeGroupSpec{
+					BlockDeviceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      internal.MetadataNameLabelKey,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{},
+							},
+						},
+					},
+				},
+			}
+			assert.True(t, hasEmptyBlockDeviceSelector(lvg))
+		})
+
+		t.Run("populated_values_returns_false", func(t *testing.T) {
+			lvg := &v1alpha1.LVMVolumeGroup{
+				Spec: v1alpha1.LVMVolumeGroupSpec{
+					BlockDeviceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      internal.MetadataNameLabelKey,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"dev-abc123"},
+							},
+						},
+					},
+				},
+			}
+			assert.False(t, hasEmptyBlockDeviceSelector(lvg))
+		})
+
+		t.Run("no_metadata_name_expression_returns_false", func(t *testing.T) {
+			lvg := &v1alpha1.LVMVolumeGroup{
+				Spec: v1alpha1.LVMVolumeGroupSpec{
+					BlockDeviceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/hostname": "node-1",
+						},
+					},
+				},
+			}
+			assert.False(t, hasEmptyBlockDeviceSelector(lvg))
+		})
+	})
+
 	t.Run("GetLVMVolumeGroup", func(t *testing.T) {
 		const (
 			LVMVGName = "test_lvm-1"


### PR DESCRIPTION
## Description

When an existing LVM VG is taken under management by adding the `storage.deckhouse.io/enabled=true` tag, a race condition between the LVG discoverer and BD discoverer can produce an invalid `spec.blockDeviceSelector` with `kubernetes.io/metadata.name In []` (empty values list). This PR adds two fixes:

1. **Prevent creation**: `CreateLVMVolumeGroupByCandidate` now checks `len(candidate.BlockDevicesNames) == 0` and postpones LVG creation until the next discovery cycle when BlockDevice resources are available.
2. **Self-heal existing LVGs**: `UpdateLVMVolumeGroupByCandidate` detects an existing LVG with an empty `In[]` selector and patches `spec.blockDeviceSelector` with the freshly discovered BlockDevice names.

## Why do we need it, and what problem does it solve?

The LVG discoverer and BD discoverer run on independent scan intervals. When a user adds a tag to an existing VG, the LVG discoverer may find the tagged VG before the BD discoverer has created/updated the corresponding BlockDevice resources. In this case:

- `sortBlockDevicesByVG` matches BDs by `Status.ActualVGNameOnTheNode + Status.VGUuid` — if BDs are not yet created or updated, the result is empty
- `configureBlockDeviceSelector` produces `kubernetes.io/metadata.name In []`
- The Kubernetes API either rejects this as invalid, or the selector matches nothing, making the LVG permanently broken
- `UpdateLVMVolumeGroupByCandidate` only touches status fields, so the broken selector is never corrected on subsequent passes

## What is the expected result?

- When taking an existing VG under management via tag, the LVMVolumeGroup resource is only created once BlockDevice resources are properly discovered (non-empty `BlockDevicesNames`)
- If an LVG was already created with an empty selector (before this fix), the discoverer will automatically patch `spec.blockDeviceSelector` on the next pass when BlockDevices become available
- The `spec.blockDeviceSelector.matchExpressions` will always contain a valid `In` operator with a non-empty `values` list

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.