### PR TITLE
fix(agent): trigger udevadm after pvcreate/vgcreate to update udev DB

### DIFF
--- a/images/agent/internal/controller/lvg/reconciler.go
+++ b/images/agent/internal/controller/lvg/reconciler.go
@@ -1301,7 +1301,25 @@ func (r *Reconciler) extendVGComplex(extendPVs []string, vgName string) error {
 		r.log.Error(err, "ExtendVG ")
 		return err
 	}
+
+	r.triggerUdevForPaths(extendPVs)
+
 	return nil
+}
+
+// triggerUdevForPaths sends a "change" uevent for the given device paths so that
+// the host udev re-probes them. lvm.static is built without udev integration, so
+// after pvcreate/vgcreate the udev DB stays stale and lsblk never reports
+// LVM2_member as fstype — which blocks the BD discoverer from linking the device
+// to its VG.
+func (r *Reconciler) triggerUdevForPaths(paths []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd, err := r.commands.UdevadmTrigger(ctx, paths)
+	if err != nil {
+		r.log.Warning(fmt.Sprintf("[triggerUdevForPaths] udevadm trigger failed for %v (non-fatal): %v, cmd: %s", paths, err, cmd))
+	}
 }
 
 func (r *Reconciler) createVGComplex(lvg *v1alpha1.LVMVolumeGroup, blockDevices map[string]v1alpha1.BlockDevice) error {
@@ -1349,6 +1367,8 @@ func (r *Reconciler) createVGComplex(lvg *v1alpha1.LVMVolumeGroup, blockDevices 
 	}
 
 	r.log.Debug(fmt.Sprintf("[CreateVGComplex] successfully create VG %s of the LVMVolumeGroup %s", lvg.Spec.ActualVGNameOnTheNode, lvg.Name))
+
+	r.triggerUdevForPaths(paths)
 
 	return nil
 }

--- a/images/agent/internal/controller/lvg/reconciler.go
+++ b/images/agent/internal/controller/lvg/reconciler.go
@@ -41,6 +41,18 @@ import (
 
 const ReconcilerName = "lvm-volume-group-watcher-controller"
 
+// udevadmTriggerTimeout caps a single best-effort `udevadm trigger
+// --action=change <paths>` invocation that the reconciler issues after
+// pvcreate/vgcreate. The trigger only enqueues uevents in the kernel and
+// normally returns within ~100ms; 10s leaves a wide safety margin for
+// nodes under heavy stress without blocking a graceful shutdown for long.
+const udevadmTriggerTimeout = 10 * time.Second
+
+// udevadmTriggerCmdLabel is the metric label used for UdevadmTrigger in
+// UtilsCommandsDuration / UtilsCommandsExecutionCount / UtilsCommandsErrorsCount.
+// Keep it in sync with how operators query Prometheus.
+const udevadmTriggerCmdLabel = "udevadm-trigger"
+
 // lvmDefaultPhysicalExtent is LVM's default PE when vgcreate is run without --physicalextentsize.
 var lvmDefaultPhysicalExtent = resource.MustParse("4Mi")
 
@@ -518,7 +530,7 @@ func (r *Reconciler) reconcileLVGCreateFunc(
 	r.log.Debug(fmt.Sprintf("[reconcileLVGCreateFunc] successfully validated the LVMVolumeGroup %s", lvg.Name))
 
 	r.log.Debug(fmt.Sprintf("[reconcileLVGCreateFunc] tries to create VG for the LVMVolumeGroup %s", lvg.Name))
-	err := r.createVGComplex(lvg, blockDevices)
+	err := r.createVGComplex(ctx, lvg, blockDevices)
 	if err != nil {
 		r.log.Error(err, fmt.Sprintf("[reconcileLVGCreateFunc] unable to create VG for the LVMVolumeGroup %s", lvg.Name))
 		err = r.lvgCl.UpdateLVGConditionIfNeeded(ctx, lvg, v1.ConditionFalse, internal.TypeVGConfigurationApplied, "VGCreationFailed", fmt.Sprintf("unable to create VG, err: %s", err.Error()))
@@ -1177,7 +1189,7 @@ func (r *Reconciler) extendVGIfNeeded(
 
 	r.log.Debug(fmt.Sprintf("[ExtendVGIfNeeded] VG %s should be extended as there are some BlockDevices were added to Spec field of the LVMVolumeGroup %s", vg.VGName, lvg.Name))
 	paths := extractPathsFromBlockDevices(devicesToExtend, blockDevices)
-	err := r.extendVGComplex(paths, vg.VGName)
+	err := r.extendVGComplex(ctx, paths, vg.VGName)
 	if err != nil {
 		r.log.Error(err, fmt.Sprintf("[ExtendVGIfNeeded] unable to extend VG %s of the LVMVolumeGroup %s", vg.VGName, lvg.Name))
 		return err
@@ -1277,7 +1289,7 @@ func (r *Reconciler) deleteVGIfExist(vgName string) error {
 	return nil
 }
 
-func (r *Reconciler) extendVGComplex(extendPVs []string, vgName string) error {
+func (r *Reconciler) extendVGComplex(ctx context.Context, extendPVs []string, vgName string) error {
 	for _, pvPath := range extendPVs {
 		start := time.Now()
 		command, err := r.commands.CreatePV(pvPath)
@@ -1302,7 +1314,7 @@ func (r *Reconciler) extendVGComplex(extendPVs []string, vgName string) error {
 		return err
 	}
 
-	r.triggerUdevForPaths(extendPVs)
+	r.triggerUdevForPaths(ctx, extendPVs)
 
 	return nil
 }
@@ -1312,17 +1324,34 @@ func (r *Reconciler) extendVGComplex(extendPVs []string, vgName string) error {
 // after pvcreate/vgcreate the udev DB stays stale and lsblk never reports
 // LVM2_member as fstype — which blocks the BD discoverer from linking the device
 // to its VG.
-func (r *Reconciler) triggerUdevForPaths(paths []string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+//
+// The call is best-effort: a failure is logged as a warning and never propagates
+// to the caller. Operators observe the call frequency and error rate through
+// the UtilsCommands* metrics with cmd label "udevadm-trigger".
+//
+// The timeout is bounded by a child context derived from the caller's context,
+// so a SIGTERM from kubelet (or any cancellation of the reconcile loop) is
+// honoured immediately instead of being absorbed by a detached background ctx.
+func (r *Reconciler) triggerUdevForPaths(parent context.Context, paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(parent, udevadmTriggerTimeout)
 	defer cancel()
 
+	start := time.Now()
 	cmd, err := r.commands.UdevadmTrigger(ctx, paths)
+	r.metrics.UtilsCommandsDuration(ReconcilerName, udevadmTriggerCmdLabel).Observe(r.metrics.GetEstimatedTimeInSeconds(start))
+	r.metrics.UtilsCommandsExecutionCount(ReconcilerName, udevadmTriggerCmdLabel).Inc()
+	r.log.Debug(cmd)
 	if err != nil {
+		r.metrics.UtilsCommandsErrorsCount(ReconcilerName, udevadmTriggerCmdLabel).Inc()
 		r.log.Warning(fmt.Sprintf("[triggerUdevForPaths] udevadm trigger failed for %v (non-fatal): %v, cmd: %s", paths, err, cmd))
 	}
 }
 
-func (r *Reconciler) createVGComplex(lvg *v1alpha1.LVMVolumeGroup, blockDevices map[string]v1alpha1.BlockDevice) error {
+func (r *Reconciler) createVGComplex(ctx context.Context, lvg *v1alpha1.LVMVolumeGroup, blockDevices map[string]v1alpha1.BlockDevice) error {
 	paths := extractPathsFromBlockDevices(nil, blockDevices)
 
 	r.log.Trace(fmt.Sprintf("[CreateVGComplex] LVMVolumeGroup %s devices paths %v", lvg.Name, paths))
@@ -1368,7 +1397,7 @@ func (r *Reconciler) createVGComplex(lvg *v1alpha1.LVMVolumeGroup, blockDevices 
 
 	r.log.Debug(fmt.Sprintf("[CreateVGComplex] successfully create VG %s of the LVMVolumeGroup %s", lvg.Spec.ActualVGNameOnTheNode, lvg.Name))
 
-	r.triggerUdevForPaths(paths)
+	r.triggerUdevForPaths(ctx, paths)
 
 	return nil
 }

--- a/images/agent/internal/controller/lvg/trigger_udev_test.go
+++ b/images/agent/internal/controller/lvg/trigger_udev_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lvg
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal/mock_utils"
+)
+
+// TestTriggerUdevForPaths pins the behavioural contract of the best-effort
+// udev-DB refresh that the reconciler issues after pvcreate/vgcreate.
+//
+// The fix in this PR exists because lvm.static is built without udev
+// integration; the trigger is the only mechanism that keeps the host udev
+// database in sync with newly created PVs. If any of the invariants below
+// regresses, freshly created LVMVolumeGroups will silently stop reaching
+// the Ready phase, which is exactly the symptom this PR was opened to
+// fix — so the tests intentionally guard each invariant explicitly.
+func TestTriggerUdevForPaths(t *testing.T) {
+	t.Run("forwards_paths_verbatim_on_happy_path", func(t *testing.T) {
+		// On a normal create/extend the reconciler must hand the exact
+		// list of newly added PV paths to UdevadmTrigger so the
+		// downstream udevd refreshes only those devices. Reordering or
+		// deduplication would change which device gets re-probed and
+		// is therefore explicitly disallowed.
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCmds := mock_utils.NewMockCommands(ctrl)
+		r := setupReconciler()
+		r.commands = mockCmds
+
+		paths := []string{"/dev/sdc", "/dev/sda", "/dev/sdb"}
+		mockCmds.EXPECT().
+			UdevadmTrigger(gomock.Any(), gomock.Eq(paths)).
+			Return("nsenter ... udevadm trigger --action=change -- /dev/sdc /dev/sda /dev/sdb", nil).
+			Times(1)
+
+		r.triggerUdevForPaths(context.Background(), paths)
+	})
+
+	t.Run("is_noop_on_nil_paths", func(t *testing.T) {
+		// Without this guard, `udevadm trigger --action=change` (with
+		// no positional args) would enqueue a change uevent for EVERY
+		// block device on the host. The reconciler must never reach
+		// the command layer in that case.
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCmds := mock_utils.NewMockCommands(ctrl)
+		r := setupReconciler()
+		r.commands = mockCmds
+
+		// No EXPECT(): any call to UdevadmTrigger fails the test.
+		r.triggerUdevForPaths(context.Background(), nil)
+	})
+
+	t.Run("is_noop_on_empty_paths_slice", func(t *testing.T) {
+		// Same guarantee as the nil case — empty slices and nil
+		// slices must be treated identically.
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCmds := mock_utils.NewMockCommands(ctrl)
+		r := setupReconciler()
+		r.commands = mockCmds
+
+		r.triggerUdevForPaths(context.Background(), []string{})
+	})
+
+	t.Run("swallows_udevadm_error_as_non_fatal", func(t *testing.T) {
+		// The refresh is best-effort: the BD discoverer will pick up
+		// the change on the next periodic scan even if `udevadm
+		// trigger` fails (e.g. udevd not running on the node). A
+		// failure here must therefore NOT propagate to the caller —
+		// otherwise createVGComplex/extendVGComplex would surface
+		// "VGCreationFailed" on the LVG and force a manual recovery
+		// for what is, in practice, only a temporary observability
+		// gap.
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCmds := mock_utils.NewMockCommands(ctrl)
+		r := setupReconciler()
+		r.commands = mockCmds
+
+		mockCmds.EXPECT().
+			UdevadmTrigger(gomock.Any(), gomock.Any()).
+			Return("nsenter ... udevadm trigger ...", errors.New("udevd not running")).
+			Times(1)
+
+		assert.NotPanics(t, func() {
+			r.triggerUdevForPaths(context.Background(), []string{"/dev/sda"})
+		})
+	})
+
+	t.Run("passes_a_bounded_child_context_derived_from_parent", func(t *testing.T) {
+		// Two invariants are checked at once:
+		//  1. the ctx forwarded to UdevadmTrigger has a Deadline set
+		//     (i.e. it isn't context.Background()) — without it a
+		//     hung nsenter would block reconciliation indefinitely;
+		//  2. the deadline is in the future and within
+		//     udevadmTriggerTimeout of "now" — pins the magic-value
+		//     extraction so any future bump of the constant requires
+		//     touching this test.
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCmds := mock_utils.NewMockCommands(ctrl)
+		r := setupReconciler()
+		r.commands = mockCmds
+
+		var captured context.Context
+		mockCmds.EXPECT().
+			UdevadmTrigger(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ []string) (string, error) {
+				captured = ctx
+				return "", nil
+			}).
+			Times(1)
+
+		r.triggerUdevForPaths(context.Background(), []string{"/dev/sda"})
+
+		if !assert.NotNil(t, captured, "UdevadmTrigger was not invoked") {
+			return
+		}
+		dl, ok := captured.Deadline()
+		if !assert.True(t, ok, "ctx must carry a deadline; udevadmTriggerTimeout must be enforced") {
+			return
+		}
+		assert.True(t, dl.After(time.Now()), "deadline must be in the future")
+		assert.LessOrEqual(t, time.Until(dl), udevadmTriggerTimeout,
+			"deadline must be within udevadmTriggerTimeout of now")
+	})
+
+	t.Run("honours_parent_context_cancellation", func(t *testing.T) {
+		// A SIGTERM from kubelet cancels the reconcile loop's ctx.
+		// Because triggerUdevForPaths derives its ctx from the parent
+		// (via context.WithTimeout(parent, ...)), the cancellation
+		// must reach UdevadmTrigger as a Done() signal — proving that
+		// the original PR's `context.Background()` was replaced with
+		// the parent ctx.
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCmds := mock_utils.NewMockCommands(ctrl)
+		r := setupReconciler()
+		r.commands = mockCmds
+
+		parent, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		mockCmds.EXPECT().
+			UdevadmTrigger(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ []string) (string, error) {
+				select {
+				case <-ctx.Done():
+					return "", ctx.Err()
+				default:
+					return "", errors.New("ctx not propagated: parent cancellation did not reach UdevadmTrigger")
+				}
+			}).
+			Times(1)
+
+		r.triggerUdevForPaths(parent, []string{"/dev/sda"})
+	})
+}

--- a/images/agent/internal/mock_utils/commands.go
+++ b/images/agent/internal/mock_utils/commands.go
@@ -389,6 +389,21 @@ func (mr *MockCommandsMockRecorder) PVScan(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PVScan", reflect.TypeOf((*MockCommands)(nil).PVScan), ctx)
 }
 
+// UdevadmTrigger mocks base method.
+func (m *MockCommands) UdevadmTrigger(ctx context.Context, paths []string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UdevadmTrigger", ctx, paths)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UdevadmTrigger indicates an expected call of UdevadmTrigger.
+func (mr *MockCommandsMockRecorder) UdevadmTrigger(ctx, paths any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UdevadmTrigger", reflect.TypeOf((*MockCommands)(nil).UdevadmTrigger), ctx, paths)
+}
+
 // ReTag mocks base method.
 func (m *MockCommands) ReTag(ctx context.Context, log logger.Logger, metrics *monitoring.Metrics, ctrlName string, cmdTimeout time.Duration) error {
 	m.ctrl.T.Helper()

--- a/images/agent/internal/utils/commands.go
+++ b/images/agent/internal/utils/commands.go
@@ -607,10 +607,22 @@ func (commands) PVScan(ctx context.Context) (string, error) {
 // the host udev re-probes them and updates its database. This is necessary
 // because lvm.static is built without udev integration: after pvcreate/vgcreate
 // the udev DB stays stale and lsblk never reports LVM2_member as fstype.
+//
+// Defensive contract:
+//   - When paths is empty the function returns ("", nil) without invoking
+//     udevadm. Running `udevadm trigger --action=change` with no positional
+//     arguments would otherwise trigger ALL matching devices on the host,
+//     producing a burst of uevents that can disturb other udev consumers
+//     (multipathd, sds-replicated-volume, etc.).
+//   - "--" end-of-options is inserted before the path list so that any path
+//     starting with '-' (an unexpected but cheap-to-defend case) is treated
+//     as a positional argument rather than as an udevadm flag.
 func (commands) UdevadmTrigger(ctx context.Context, paths []string) (string, error) {
-	args := []string{"udevadm", "trigger", "--action=change"}
-	args = append(args, paths...)
-	extendedArgs := nsentrerExpendedArgs(args[0], args[1:]...)
+	if len(paths) == 0 {
+		return "", nil
+	}
+
+	extendedArgs := udevadmTriggerExtendedArgs(paths)
 	cmd := exec.CommandContext(ctx, internal.NSENTERCmd, extendedArgs...)
 
 	var stderr bytes.Buffer
@@ -620,6 +632,23 @@ func (commands) UdevadmTrigger(ctx context.Context, paths []string) (string, err
 		return cmd.String(), fmt.Errorf("unable to run cmd: %s, err: %w, stderr: %s", cmd.String(), err, stderr.String())
 	}
 	return cmd.String(), nil
+}
+
+// udevadmTriggerExtendedArgs builds the argv passed to nsenter+udevadm for
+// the change-uevent trigger after pvcreate/vgcreate. It is split out from
+// UdevadmTrigger so that argv construction can be unit-tested without
+// invoking exec.
+//
+// The first three argv slots are fixed (`udevadm`, `trigger`,
+// `--action=change`); a literal `--` end-of-options separator is appended
+// before the path list to guarantee that any path beginning with '-' is
+// treated as a positional argument rather than an udevadm flag. Callers
+// MUST guarantee len(paths) > 0; passing an empty slice would otherwise
+// trigger ALL block devices on the host (udevadm-trigger(8) default).
+func udevadmTriggerExtendedArgs(paths []string) []string {
+	args := []string{"udevadm", "trigger", "--action=change", "--"}
+	args = append(args, paths...)
+	return nsentrerExpendedArgs(args[0], args[1:]...)
 }
 
 func (commands) UnmarshalDevices(out []byte) ([]internal.Device, error) {

--- a/images/agent/internal/utils/commands.go
+++ b/images/agent/internal/utils/commands.go
@@ -67,6 +67,7 @@ type Commands interface {
 	LVActivate(ctx context.Context, vgName, lvName string) (string, error)
 	VGScan(ctx context.Context) (string, error)
 	PVScan(ctx context.Context) (string, error)
+	UdevadmTrigger(ctx context.Context, paths []string) (string, error)
 	UnmarshalDevices(out []byte) ([]internal.Device, error)
 	ReTag(ctx context.Context, log logger.Logger, metrics *monitoring.Metrics, ctrlName string, cmdTimeout time.Duration) error
 }
@@ -591,6 +592,25 @@ func (commands) VGScan(ctx context.Context) (string, error) {
 func (commands) PVScan(ctx context.Context) (string, error) {
 	args := []string{"pvscan", "--cache"}
 	extendedArgs := lvmStaticExtendedArgs(args)
+	cmd := exec.CommandContext(ctx, internal.NSENTERCmd, extendedArgs...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return cmd.String(), fmt.Errorf("unable to run cmd: %s, err: %w, stderr: %s", cmd.String(), err, stderr.String())
+	}
+	return cmd.String(), nil
+}
+
+// UdevadmTrigger sends a "change" uevent for the given device paths so that
+// the host udev re-probes them and updates its database. This is necessary
+// because lvm.static is built without udev integration: after pvcreate/vgcreate
+// the udev DB stays stale and lsblk never reports LVM2_member as fstype.
+func (commands) UdevadmTrigger(ctx context.Context, paths []string) (string, error) {
+	args := []string{"udevadm", "trigger", "--action=change"}
+	args = append(args, paths...)
+	extendedArgs := nsentrerExpendedArgs(args[0], args[1:]...)
 	cmd := exec.CommandContext(ctx, internal.NSENTERCmd, extendedArgs...)
 
 	var stderr bytes.Buffer

--- a/images/agent/internal/utils/commands_test.go
+++ b/images/agent/internal/utils/commands_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -422,5 +423,89 @@ func TestLvmStaticExtendedArgs(t *testing.T) {
 			"--config must cap /etc/lvm/archive growth via backup/retain_min")
 		assert.Contains(t, actualConfig, "backup/retain_days=",
 			"--config must cap /etc/lvm/archive growth via backup/retain_days")
+	})
+}
+
+// TestUdevadmTriggerExtendedArgs pins the argv layout that the agent uses
+// to refresh the host udev DB after pvcreate/vgcreate. Three invariants are
+// verified explicitly:
+//
+//  1. the first three udevadm tokens are `trigger --action=change` — any
+//     accidental drop of `--action=change` would make the trigger emit the
+//     default "add" event and `lsblk` would still report fstype: null for
+//     the freshly created PVs;
+//
+//  2. a literal `--` end-of-options separator sits between the udevadm
+//     flags and the path list. This guards the (cheap to defend) edge case
+//     of a BlockDevice whose Status.Path begins with '-' and would
+//     otherwise be parsed by udevadm as a flag;
+//
+//  3. the whole command is wrapped by the standard nsenter prefix
+//     `-t 1 -m -u -i -n -p -- /<NSENTERCmd path>/udevadm`. udevadm relies
+//     on the host /run/udev socket which is reachable only inside PID 1's
+//     mount/ipc namespaces, so dropping any namespace flag would break the
+//     trigger silently.
+//
+// Path-list ordering must be preserved verbatim (no sort, no dedup):
+// downstream metrics group by path string, and reordering would break log
+// correlation.
+func TestUdevadmTriggerExtendedArgs(t *testing.T) {
+	prefix := []string{"-t", "1", "-m", "-u", "-i", "-n", "-p", "--", "udevadm"}
+
+	tests := []struct {
+		name  string
+		paths []string
+		want  []string
+	}{
+		{
+			name:  "single_path",
+			paths: []string{"/dev/sda"},
+			want: append(append([]string{}, prefix...),
+				"trigger", "--action=change", "--", "/dev/sda",
+			),
+		},
+		{
+			name:  "multiple_paths_preserve_order",
+			paths: []string{"/dev/sdc", "/dev/sda", "/dev/sdb"},
+			want: append(append([]string{}, prefix...),
+				"trigger", "--action=change", "--", "/dev/sdc", "/dev/sda", "/dev/sdb",
+			),
+		},
+		{
+			name:  "path_starting_with_dash_is_isolated_by_end_of_options",
+			paths: []string{"--help"},
+			want: append(append([]string{}, prefix...),
+				"trigger", "--action=change", "--", "--help",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := udevadmTriggerExtendedArgs(tt.paths)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestUdevadmTriggerEmptyPathsIsNoop pins the defensive early-return for an
+// empty path list. Without it, `udevadm trigger --action=change` (no
+// positional args) would enqueue a change uevent for EVERY block device on
+// the host, producing a burst that disrupts other udev consumers
+// (multipathd, drbd, …). The function must return ("", nil) and must not
+// reach exec.CommandContext.
+func TestUdevadmTriggerEmptyPathsIsNoop(t *testing.T) {
+	c := commands{}
+
+	t.Run("nil_paths", func(t *testing.T) {
+		out, err := c.UdevadmTrigger(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("empty_paths", func(t *testing.T) {
+		out, err := c.UdevadmTrigger(context.Background(), []string{})
+		assert.NoError(t, err)
+		assert.Empty(t, out)
 	})
 }


### PR DESCRIPTION
## Description

After `pvcreate`/`vgcreate`, call `udevadm trigger --action=change` on the affected device paths via nsenter so that the host udev database is refreshed.

This is needed because the bundled `lvm.static` is built without udev integration — LVM operations do not emit udev events and the udev DB stays stale.

## Changes

### Core fix
- Add `UdevadmTrigger(ctx, paths)` method to the `Commands` interface and its implementation. It runs `nsenter -t 1 -m -u -i -n -p -- udevadm trigger --action=change -- <paths>` against the host namespaces (the `--` end-of-options separator isolates path arguments from udevadm flags).
- Call it at the end of `createVGComplex` and `extendVGComplex` in the LVG reconciler via a small `triggerUdevForPaths` helper.
- The call is best-effort (non-fatal): a failure logs a warning and does not block VG creation/extension.

### Context propagation
- `createVGComplex` and `extendVGComplex` now take `ctx context.Context` and forward it down to `triggerUdevForPaths`.
- `triggerUdevForPaths` derives a bounded child context with `context.WithTimeout(parent, udevadmTriggerTimeout)` instead of detaching to `context.Background()`. A SIGTERM from kubelet (or any cancellation of the reconcile loop) is now honoured immediately by the trigger call as well.

### Defensive guards
- `triggerUdevForPaths` and `UdevadmTrigger` both return early on an empty `paths` slice. Without this guard, `udevadm trigger --action=change` with no positional arguments would enqueue a change uevent for every block device on the host, which can disturb other udev consumers (multipathd, drbd, …).
- A literal `--` end-of-options separator is inserted between udevadm flags and the path list, so any path beginning with `-` is treated as a positional argument instead of an udevadm flag.

### Observability & timeout knob
- New named constant `udevadmTriggerTimeout = 10 * time.Second` (documented why 10s is the chosen safety margin for an operation that normally completes in ~100ms).
- `UtilsCommandsDuration` / `UtilsCommandsExecutionCount` / `UtilsCommandsErrorsCount` metrics are emitted with the cmd label `udevadm-trigger`, mirroring every other `lvm.static` invocation in the reconciler. Operators can now graph frequency, duration and error rate of the udev refresh in Prometheus.
- The resolved `cmd` string is logged at Debug on the success path (matches the convention of every neighbouring command in the reconciler).

### Refactor for testability
- argv construction extracted into a small helper `udevadmTriggerExtendedArgs(paths []string) []string`, so the argv layout can be unit-tested without invoking `exec`.

## Why do we need it, and what problem does it solve?

`lvm.static` is built without udev integration. When the agent creates a PV/VG via `pvcreate`+`vgcreate`, the host udev database is never updated with the new device type (`LVM2_member`). As a result:

1. `lsblk` (which reads fstype from udev DB, not by direct probing) permanently reports `fstype: null` for the device.
2. The BD discoverer relies on `fstype == LVM2_member` to associate a BlockDevice with its VG — so `status.actualVGNameOnTheNode` stays empty.
3. The LVG discoverer cannot populate `status.nodes` (it needs BDs matched to the VG).
4. `sds_infra_watcher` uses `status.nodes` to set the `AgentReady` condition — with an empty list, `AgentReady` is never created.
5. `lvg_conditions_watcher` requires all 5 conditions to transition Phase to Ready — with only 4, the LVG is stuck in `Pending` forever.

## What is the expected result?

After applying this fix, newly created LVMVolumeGroups must transition from `Pending` to `Ready` phase within 1-2 scanner cycles (typically under 30 seconds) without manual intervention.

Verification:

1. Create a new LVMVolumeGroup resource pointing to a consumable BlockDevice.
2. Observe that `status.phase` transitions to `Ready`.
3. Confirm `status.nodes` is populated and all 5 conditions are present (including `AgentReady=True`).
4. (Optional, for observability) Confirm the new metrics are exposed with `cmd="udevadm-trigger"` label on `sds_node_configurator_utils_command_execution_total` / `..._duration_seconds_bucket` / `..._errors_total`.

## Tests

Unit tests added in this PR:

`images/agent/internal/utils/commands_test.go`:

- `TestUdevadmTriggerExtendedArgs` — pins the argv layout (subcommand, `--action=change`, `--` end-of-options separator, full nsenter prefix, path-order preservation across 3 subcases including a path starting with `-`).
- `TestUdevadmTriggerEmptyPathsIsNoop` — pins the early-return contract for `nil` and empty slices; guarantees `exec` is never reached and `UdevadmTrigger` returns `("", nil)`.

`images/agent/internal/controller/lvg/trigger_udev_test.go` (new file, gomock-based):

- `forwards_paths_verbatim_on_happy_path` — paths reach `UdevadmTrigger` without reordering or dedup.
- `is_noop_on_nil_paths` / `is_noop_on_empty_paths_slice` — `UdevadmTrigger` is not invoked when there are no paths.
- `swallows_udevadm_error_as_non_fatal` — a failure from `UdevadmTrigger` does not propagate / panic; createVGComplex/extendVGComplex semantics are preserved.
- `passes_a_bounded_child_context_derived_from_parent` — the ctx forwarded to `UdevadmTrigger` carries a `Deadline()` within `udevadmTriggerTimeout` of now. Pins the magic-value extraction.
- `honours_parent_context_cancellation` — a cancelled parent ctx propagates to `UdevadmTrigger` (verifies that `context.Background()` is no longer used).

Builds are green under both `-tags ce` and `-tags ee`. All new and existing tests in `internal/utils/...` and `internal/controller/lvg/...` pass.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
