### PR TITLE
chore: migrate to container-base v1.1.2 and drop .static binary suffix

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -11,6 +11,10 @@ linters-settings:
   module:
     oss:
       disable: true
+  no-cyrillic:
+    exclude-rules:
+      directories:
+        - hack/
   openapi:
     exclude-rules:
       enum:

--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -15,6 +15,7 @@ linters-settings:
     exclude-rules:
       directories:
         - hack/
+        - e2e/
   openapi:
     exclude-rules:
       enum:

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v1.0.51"
+  BASE_IMAGES_VERSION: "v1.1.2"
 on:
   # On PR, build_dev runs only via workflow_call from "Build and checks" (trivy_image_check.yaml) to avoid two runs (direct trigger + call).
   workflow_call:

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.0.51"
 on:
   # On PR, build_dev runs only via workflow_call from "Build and checks" (trivy_image_check.yaml) to avoid two runs (direct trigger + call).
   workflow_call:
@@ -170,7 +170,7 @@ jobs:
 
       - name: Download base images and auth prepare
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.0.51"
 on:
   push:
     tags:
@@ -39,7 +39,7 @@ jobs:
 
       - name: Download base images and auth prepare
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -82,7 +82,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -125,7 +125,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -168,7 +168,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -211,7 +211,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v1.0.51"
+  BASE_IMAGES_VERSION: "v1.1.2"
 on:
   push:
     tags:

--- a/.github/workflows/translate-changelog.yml
+++ b/.github/workflows/translate-changelog.yml
@@ -2,7 +2,7 @@ name: Translate Changelog and Create PR
 
 on:
   push:
-    # Запуск для всех веток при любом push
+    # Run on any branch push
 
 jobs:
   translate-and-pr:

--- a/.werf/base-images.yaml
+++ b/.werf/base-images.yaml
@@ -1,7 +1,7 @@
 # Base Images
 {{- $baseImages := .Files.Get "base_images.yml" | fromYaml }}
 {{- range $k, $v := $baseImages }}
-  {{ $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
+  {{- $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
   {{- if ne $k "REGISTRY_PATH" }}
     {{- $_ := set $baseImages $k $baseImagePath }}
   {{- end }}
@@ -9,11 +9,3 @@
 {{- $_ := unset $baseImages "REGISTRY_PATH" }}
 
 {{- $_ := set . "Images" $baseImages }}
-# base images artifacts
-{{- range $k, $v := .Images }}
----
-image: {{ $k }}
-from: {{ $v }}
-final: false
-{{- end }}
-

--- a/.werf/bundle.yaml
+++ b/.werf/bundle.yaml
@@ -1,6 +1,6 @@
 ---
 image: docs-generator
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -25,7 +25,7 @@ shell:
 # Bundle image, stored in your.registry.io/modules/<module-name>:<semver>
 ---
 image: bundle
-fromImage: builder/scratch
+from: {{ index $.Images "builder/scratch" }}
 
 import:
   # Rendering .werf/images-digests.yaml is required!

--- a/.werf/choose-edition.yaml
+++ b/.werf/choose-edition.yaml
@@ -1,6 +1,6 @@
 ---
 image: choose-edition
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 fromCacheVersion: {{ div .Commit.Date.Unix (mul 60 60 24 30) }}
 
 git:

--- a/.werf/images-digests.yaml
+++ b/.werf/images-digests.yaml
@@ -13,9 +13,9 @@
 # Images Digest: a files with all image digests to be able to use them in helm templates of a module
 ---
 image: images-digests
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 import:
-  - image: tools/jq
+  - from: {{ index $.Images "jq" }}
     add: /usr/bin/jq
     to: /usr/bin/jq
     before: setup

--- a/.werf/images.yaml
+++ b/.werf/images.yaml
@@ -7,9 +7,9 @@
   {{- $_ := set $ctx "ImageName" ($path | split "/")._1 }}
   {{- $_ := set $ctx "SOURCE_REPO" $Root.SOURCE_REPO }}
   {{- $_ := set $ctx "MODULE_EDITION" $.MODULE_EDITION }}
+  {{- $_ := set $ctx "Images" $.Images }}
   {{- $_ := set $ctx "SVACE_ENABLED" (env "SVACE_ENABLED" "false") }}
   {{- $_ := set $ctx "SVACE_PROJECT_PREFIX" "sds-node-configurator" }}
-  {{- if ne $ctx.SVACE_ENABLED "false" }}{{ $_ := set $ctx "SVACE_IMAGE_SUFFIX" "/svace" }}{{ end }}
   {{- $_ := set $ctx "SVACE_ANALYZE_HOST" (env "SVACE_ANALYZE_HOST" "example.host") }}
   {{- $_ := set $ctx "SVACE_ANALYZE_SSH_USER" (env "SVACE_ANALYZE_SSH_USER" "user") }}
   {{- $_ := set $ctx "ImagePath" (printf "/images/%s" $ctx.ImageName) }}

--- a/.werf/release.yaml
+++ b/.werf/release.yaml
@@ -1,7 +1,7 @@
 # Release image, stored in your.registry.io/modules/<module-name>/release:<semver>
 ---
 image: release-channel-version-artifact
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 final: false
 git:
 - add: /
@@ -13,7 +13,7 @@ git:
     setup:
     - '**/*'
 import:
-  - image: tools/yq
+  - from: {{ index $.Images "yq" }}
     add: /usr/bin/yq
     to: /usr/bin/yq
     before: install
@@ -24,7 +24,7 @@ shell:
     - cp -f CHANGELOG/{{ env "MODULES_MODULE_TAG" "local" }}.yml /changelog.yaml || touch /changelog.yaml
 ---
 image: release-channel-version
-fromImage: builder/scratch
+from: {{ index $.Images "builder/scratch" }}
 import:
   - image: release-channel-version-artifact
     add: /

--- a/Makefile
+++ b/Makefile
@@ -109,4 +109,4 @@ go-mod-tidy: ## Run go generate
 .PHONY: update-base-images-versions
 update-base-images-versions:
 	##~ Options: version=vMAJOR.MINOR.PATCH
-	curl --fail -sSLO https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$(version)/base_images.yml
+	curl --fail -sSLO https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$(version)/base_images.yml

--- a/images/agent/internal/config/config_test.go
+++ b/images/agent/internal/config/config_test.go
@@ -93,7 +93,7 @@ func TestNewConfig(t *testing.T) {
 		expMetricsPort := ":0000"
 		expNodeName := "test-node"
 		expErrorMsg := fmt.Sprintf("[NewConfig] unable to get %s, error: %s",
-			MachineID, "fork/exec /opt/deckhouse/sds/bin/nsenter.static: no such file or directory")
+			MachineID, "fork/exec /opt/deckhouse/sds/bin/nsenter: no such file or directory")
 
 		err := os.Setenv(MetricsPort, expMetricsPort)
 		if err != nil {

--- a/images/agent/internal/const.go
+++ b/images/agent/internal/const.go
@@ -34,16 +34,16 @@ const (
 	LVMVGHealthOperational       = "Operational"
 	LVMVGHealthNonOperational    = "NonOperational"
 	BlockDeviceValidSize         = "1G"
-	NSENTERCmd                   = "/opt/deckhouse/sds/bin/nsenter.static"
-	DMSetupCmd                   = "/opt/deckhouse/sds/bin/dmsetup.static"
+	NSENTERCmd                   = "/opt/deckhouse/sds/bin/nsenter"
+	DMSetupCmd                   = "/opt/deckhouse/sds/bin/dmsetup"
 	LSBLKCmd                     = "/opt/deckhouse/sds/bin/lsblk.dynamic"
-	LVMCmd                       = "/opt/deckhouse/sds/bin/lvm.static"
+	LVMCmd                       = "/opt/deckhouse/sds/bin/lvm"
 	ThinDumpCmd                  = "thin_dump"
 
-	// LVMGlobalFilter is passed via `lvm.static --config` for every LVM
+	// LVMGlobalFilter is passed via `lvm --config` for every LVM
 	// subcommand the agent runs. It rejects canonical names of block
 	// devices that always belong to a foreign storage layer (Ceph RBD,
-	// DRBD, NBD, loopback) so lvm.static does not even read PV labels
+	// DRBD, NBD, loopback) so lvm does not even read PV labels
 	// from them when udev integration is unavailable.
 	//
 	// There is intentionally no blanket "a|.*|" accept rule. When a
@@ -55,7 +55,7 @@ const (
 	// commands like lvremove that address LVs by VG name.
 	//
 	// The authoritative foreign-PV filter (FilterForeignPVs) still runs
-	// after lvm.static returns and catches any PVs that slip through
+	// after lvm returns and catches any PVs that slip through
 	// via /dev/block/MAJ:MIN or /dev/disk/by-id/... aliases.
 	LVMGlobalFilter = `devices/global_filter=["r|^/dev/rbd|","r|^/dev/drbd|","r|^/dev/nbd|","r|^/dev/loop|"]`
 
@@ -104,7 +104,7 @@ var (
 
 	// ForeignDeviceBasePrefixes lists canonical block-device basenames
 	// that always belong to a foreign storage layer and must never be
-	// considered an LVM PV by the agent regardless of what lvm.static
+	// considered an LVM PV by the agent regardless of what lvm
 	// reported. The list intentionally matches /proc/devices entries:
 	//
 	//   rbd   - Ceph RBD (kernel rbd module, major 251)
@@ -112,7 +112,7 @@ var (
 	//   nbd   - network block device (major 43)
 	//   loop  - loopback (major 7) — typically backs QEMU/file-based VM disks
 	//
-	// Used after lvm.static returns the PV list, against the canonical
+	// Used after lvm returns the PV list, against the canonical
 	// path resolved via readlink -f in the host mount namespace.
 	ForeignDeviceBasePrefixes = []string{"rbd", "drbd", "nbd", "loop"}
 )

--- a/images/agent/internal/utils/commands.go
+++ b/images/agent/internal/utils/commands.go
@@ -838,7 +838,7 @@ func filterStdErr(command string, stdErr bytes.Buffer) bytes.Buffer {
 	var filteredStdErr bytes.Buffer
 	stdErrScanner := bufio.NewScanner(&stdErr)
 	regexpPattern := `Regex version mismatch, expected: .+ actual: .+`
-	regexpSocketError := `File descriptor .+ leaked on lvm.static invocation. Parent PID .+: /opt/deckhouse/sds/bin/nsenter`
+	regexpSocketError := `File descriptor .+ leaked on lvm(\.static)? invocation. Parent PID .+: /opt/deckhouse/sds/bin/nsenter`
 	// this needs as if the controller were restarted and found existing LVG thin-pools with size equals 100%VG space,
 	// as the Thin-pool size on the node might be less than Spec one even with delta (because of metadata). So the controller
 	// will try to resize the Thin-pool with 100%VG space and will get the error.

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -1,9 +1,9 @@
-{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter.static /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic /usr/lib/x86_64-linux-gnu/sys-root/lib64/ld-linux-x86-64.so.2 /usr/sbin/thin_dump /usr/sbin/pdata_tools" }}
+{{ $binaries := "/opt/deckhouse/sds/lib/libblkid.so.1 /opt/deckhouse/sds/lib/libmount.so.1 /opt/deckhouse/sds/lib/libsmartcols.so.1 /opt/deckhouse/sds/bin/nsenter /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2 /opt/deckhouse/sds/bin/lsblk.dynamic /usr/lib/x86_64-linux-gnu/sys-root/lib64/ld-linux-x86-64.so.2 /usr/sbin/thin_dump /usr/sbin/pdata_tools" }}
 
 # Do not remove. It's used in external tests.
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -32,7 +32,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-binaries-artifact
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 import:
@@ -76,7 +76,7 @@ shell:
     - ./configure --prefix /opt/deckhouse/sds --with-udev
     - make install-strip
     - mkdir -p /opt/deckhouse/sds/lib/x86_64-linux-gnu/
-    - cp /src/util-linux/nsenter.static /opt/deckhouse/sds/bin/nsenter.static
+    - cp /src/util-linux/nsenter.static /opt/deckhouse/sds/bin/nsenter
     - cp /lib64/libudev.so.1 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libudev.so.1
     - cp /lib64/libc.so.6 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libc.so.6
     - cp /lib64/libcap.so.2 /opt/deckhouse/sds/lib/x86_64-linux-gnu/libcap.so.2
@@ -89,7 +89,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
@@ -116,7 +116,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 git:
 {{- include "image mount points" . }}
 import:

--- a/images/controller/werf.inc.yaml
+++ b/images/controller/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
+# do not remove this image: used in external audits (DKP CSE)
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -18,11 +19,11 @@ git:
 
 shell:
   install:
-    - echo "src artifact"
+    - rm -rf /src/.git
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
@@ -49,7 +50,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 git:
 {{- include "image mount points" . }}

--- a/images/go-hooks/werf.inc.yaml
+++ b/images/go-hooks/werf.inc.yaml
@@ -1,37 +1,25 @@
 ---
-image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
+
 git:
   - add: {{ .ModuleDir }}/hooks/go
-    to: /src/hooks/go
+    to: /usr/src/app/hooks/go
     stageDependencies:
       install:
         - '**/go.mod'
         - '**/go.sum'
+      beforeSetup:
         - '**/*.go'
   - add: {{ .ModuleDir }}/api
-    to: /src/api
+    to: /usr/src/app/api
     stageDependencies:
       install:
         - '**/go.mod'
         - '**/go.sum'
+      beforeSetup:
         - '**/*.go'
-
-shell:
-  install:
-    - echo "src artifact"
-
----
-image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
-final: false
-
-import:
-  - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-    add: /src
-    to: /usr/src/app
-    before: install
 
 mount:
 {{ include "mount points for golang builds" . }}
@@ -44,6 +32,8 @@ shell:
   install:
     - cd /usr/src/app/hooks/go
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
-    - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+  beforeSetup:
     - |
+      cd /usr/src/app/hooks/go;
+      export CGO_ENABLED=0
       {{- include "image-build.build" (set $ "BuildCommand" `go build -a -gcflags=all="-l -B" -ldflags="-w -s" -o /go-hooks *.go;`) | nindent 6 }}

--- a/images/sds-common-scheduler-extender/werf.inc.yaml
+++ b/images/sds-common-scheduler-extender/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -17,11 +17,11 @@ git:
 
 shell:
   install:
-    - echo "src artifact"
+    - rm -rf /src/.git
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
@@ -48,8 +48,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
-
+from: {{ index $.Images "builder/distroless" }}
 git:
 {{- include "image mount points" . }}
 import:

--- a/images/sds-utils-installer/werf.inc.yaml
+++ b/images/sds-utils-installer/werf.inc.yaml
@@ -1,9 +1,9 @@
-{{ $binaries := "/sds-utils/bin/lvm.static /sds-utils/bin/dmsetup.static" }}
+{{ $binaries := "/sds-utils/bin/lvm /sds-utils/bin/dmsetup" }}
 
 # Do not remove. It's used in external tests.
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -33,7 +33,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-binaries-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang-alt" "builder/alpine-svace") }}
 final: false
 
 import:
@@ -69,14 +69,14 @@ shell:
     - |
       {{- include "image-build.build" (set $ "BuildCommand" (printf "make")) | nindent 6 }}
     - mkdir -p /sds-utils/bin/
-    - mv /src/lvm2/tools/lvm.static /sds-utils/bin/lvm.static
-    - mv /src/lvm2/libdm/dm-tools/dmsetup.static /sds-utils/bin/dmsetup.static
+    - mv /src/lvm2/tools/lvm.static /sds-utils/bin/lvm
+    - mv /src/lvm2/libdm/dm-tools/dmsetup.static /sds-utils/bin/dmsetup
     - chmod +x /binary_replace.sh
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
@@ -103,7 +103,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 git:
 {{- include "image mount points" . }}
 import:

--- a/images/webhooks/werf.inc.yaml
+++ b/images/webhooks/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
+# do not remove this image: used in external audits (DKP CSE)
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -18,11 +19,11 @@ git:
 
 shell:
   install:
-    - echo "src artifact"
+    - rm -rf /src/.git
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
@@ -49,7 +50,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 git:
 {{- include "image mount points" . }}

--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -115,7 +115,7 @@ spec:
         image: {{ include "helm_lib_module_image" (list . "agent") }}
         imagePullPolicy: IfNotPresent
         command:
-          - /opt/deckhouse/sds/bin/nsenter.static
+          - /opt/deckhouse/sds/bin/nsenter
           - -t
           - "1"
           - -m


### PR DESCRIPTION
## Summary

- Migrate werf builds from `deckhouse/base-images` v0.5.79 to `deckhouse/container-base/base-images` v1.1.2 across CI, Makefile, and all image definitions.
- Update werf image specs to use `from: {{ index $.Images "…" }}` with new builder names (`builder/golang`, `builder/distroless`, `builder/golang-alt`, `builder/alpine-svace`).
- Drop the `.static` suffix from bundled binaries installed into agent and sds-utils-installer images (`lvm`, `dmsetup`, `nsenter`); upstream build artifacts are still read as `*.static` and renamed at install time.

## Test plan

- [ ] CI build_dev / build_prod pass with `BASE_IMAGES_VERSION=v1.1.2`
- [ ] `agent` and `sds-utils-installer` images build successfully (ALT static binary stages)
- [ ] Agent DaemonSet starts and LVM/nsenter commands work on a node with the new binary paths