### PR TITLE
fix(agent): load dm_snapshot when storage-foundation is enabled

### DIFF
--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -127,7 +127,7 @@ spec:
           - modprobe
           - -a
           - dm_thin_pool
-{{- if  (.Values.global.enabledModules | has "snapshot-controller") }}
+{{- if or (.Values.global.enabledModules | has "snapshot-controller") (.Values.global.enabledModules | has "storage-foundation") }}
           - dm_snapshot
 {{- end }}
         # Privileged mode is required to use nsenter and access the host's mount namespace.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The thin-volumes-enabler init container only added dm_snapshot to the modprobe args when the snapshot-controller module was enabled. Clusters that provide snapshot functionality through the storage-foundation module (the extended VolumeSnapshot fork) left dm_snapshot unloaded, so LVM snapshot creation failed with "Required device-mapper target(s) not detected in your kernel". Load dm_snapshot when either snapshot-controller or storage-foundation is enabled.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to enable dm_snapshot while only storage-foundation enabled

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct module work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
