### PR TITLE
fix(agent): prevent LVMVolumeGroup discover panic on empty lv_attr

### DIFF
--- a/images/agent/internal/controller/lvg/discoverer_test.go
+++ b/images/agent/internal/controller/lvg/discoverer_test.go
@@ -84,6 +84,31 @@ func TestLVMVolumeGroupDiscover(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("getThinPools_skips_lv_with_empty_attr_without_panicking", func(t *testing.T) {
+		// An LV observed by lvs in a transient state may have an empty
+		// lv_attr; getThinPools must not panic on it (index out of range).
+		lvs := []internal.LVData{
+			{
+				LVName: "lv_with_empty_attr",
+				LVAttr: "",
+			},
+			{
+				LVName: "thinPool",
+				LVAttr: "twi-aotz--",
+			},
+		}
+
+		expected := []internal.LVData{
+			{
+				LVName: "thinPool",
+				LVAttr: "twi-aotz--",
+			},
+		}
+
+		actual := getThinPools(lvs)
+		assert.Equal(t, expected, actual)
+	})
+
 	t.Run("checkVGHealth_returns_Operational", func(t *testing.T) {
 		const (
 			vgName = "testVg"

--- a/images/agent/internal/controller/lvg/reconciler.go
+++ b/images/agent/internal/controller/lvg/reconciler.go
@@ -1016,7 +1016,7 @@ func (r *Reconciler) reconcileThinPoolsIfNeeded(
 ) error {
 	actualThinPools := make(map[string]internal.LVData, len(lvs))
 	for _, lv := range lvs {
-		if string(lv.LVAttr[0]) == "t" {
+		if isThinPool(lv) {
 			actualThinPools[lv.LVName] = lv
 		}
 	}

--- a/images/agent/internal/controller/lvg/utils.go
+++ b/images/agent/internal/controller/lvg/utils.go
@@ -39,7 +39,10 @@ func isApplied(lvg *v1alpha1.LVMVolumeGroup) bool {
 }
 
 func isThinPool(lv internal.LVData) bool {
-	return string(lv.LVAttr[0]) == "t"
+	// LVAttr may be empty for an LV observed by lvs in a transient state
+	// (e.g. mid create/delete); guard the index to avoid panicking the
+	// whole discover reconcile. Mirrors utils.IsLVThinPool.
+	return len(lv.LVAttr) > 0 && lv.LVAttr[0] == 't'
 }
 
 func getVGAllocatedSize(vg internal.VGData) resource.Quantity {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

`isThinPool` (and the duplicated check in `reconcileThinPoolsIfNeeded`) indexed `lv.LVAttr[0]` without a length check. When `lvs` reports an LV with an empty `lv_attr` — which happens for an LV observed in a transient state (e.g. mid create/delete under concurrent LVM activity) — the access panics with `index out of range [0] with length 0`.

The panic occurs inside the `lvm-volume-group-discover-controller` reconcile (iterating the cached LV list). controller-runtime recovers it and immediately retries, so the discoverer **panic-loops** and stops updating `LVMVolumeGroup` discovery/status for the node until the scan cache refreshes without the offending LV.

Changes:
- `lvg.isThinPool`: guard the index — `len(lv.LVAttr) > 0 && lv.LVAttr[0] == 't'` — mirroring the already-correct `utils.IsLVThinPool` / `monitoring.isThinPool`.
- `reconcileThinPoolsIfNeeded`: reuse `isThinPool(lv)` instead of the same unguarded `string(lv.LVAttr[0]) == "t"`.
- Add a regression unit test (`getThinPools` skips an empty-`lv_attr` LV without panicking).

Note: `llv.checkIfLVBelongsToLLV` has a similar unguarded `lv.LVAttr[2]/[0]` access reachable from one of its callers; left out of this focused fix but worth a follow-up.

## Why do we need it, and what problem does it solve?
<!--- Impact of the bug. -->

Observed on a live cluster: the agent's discover controller panic-looped ~2900 times, which blocks `LVMVolumeGroup` discovery and status reconciliation on the affected node for as long as the bad LV stays in the scan cache. A single transient LV state should not be able to take down the whole discoverer.

```
panic: runtime error: index out of range [0] with length 0
  .../lvg.isThinPool(...)                                  utils.go:42
  .../lvg.getThinPools(...)                                discoverer.go:794
  .../lvg.(*Discoverer).GetLVMVolumeGroupCandidates(...)   discoverer.go:393
```

## What is the expected result?

The discover controller no longer panics when an LV reports an empty `lv_attr`; such an LV is treated as "not a thin pool" and skipped, and `LVMVolumeGroup` discovery keeps working. The added unit test panics on the old code and passes on the fixed code (`go test ./internal/controller/lvg/`).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.