### PR TITLE
fix(agent): treat lvextend no-op resize as benign across LVM versions

### DIFF
--- a/images/agent/internal/utils/commands.go
+++ b/images/agent/internal/utils/commands.go
@@ -891,7 +891,10 @@ func filterStdErr(command string, stdErr bytes.Buffer) bytes.Buffer {
 	// this needs as if the controller were restarted and found existing LVG thin-pools with size equals 100%VG space,
 	// as the Thin-pool size on the node might be less than Spec one even with delta (because of metadata). So the controller
 	// will try to resize the Thin-pool with 100%VG space and will get the error.
-	regexpNoSizeChangeError := ` No size change.+`
+	// Different LVM versions report a no-op resize differently: older ones print "No size change.",
+	// newer ones (e.g. 2.03.16) print "New size (<n> extents) matches existing size (<n> extents).".
+	// Both mean the LV is already at the requested size and must be treated as a benign no-op.
+	regexpNoSizeChangeError := ` (No size change\..*|New size \(.+\) matches existing size \(.+\)\.)`
 	regex1, err := regexp.Compile(regexpPattern)
 	if err != nil {
 		return stdErr

--- a/images/agent/internal/utils/commands_test.go
+++ b/images/agent/internal/utils/commands_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -508,4 +509,55 @@ func TestUdevadmTriggerEmptyPathsIsNoop(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, out)
 	})
+}
+
+func TestFilterStdErr(t *testing.T) {
+	const cmd = "lvextend -l 100%VG /dev/vg/lv"
+
+	tests := []struct {
+		name     string
+		stdErr   string
+		filtered bool // true if the whole output is expected to be filtered out
+	}{
+		{
+			name:     "old_lvm_no_size_change",
+			stdErr:   "  No size change.",
+			filtered: true,
+		},
+		{
+			name:     "new_lvm_matches_existing_size",
+			stdErr:   "  New size (953801 extents) matches existing size (953801 extents).",
+			filtered: true,
+		},
+		{
+			name:     "regex_version_mismatch",
+			stdErr:   "Regex version mismatch, expected: 10.42 2022-12-11 actual: 10.34 2019-11-21",
+			filtered: true,
+		},
+		{
+			name:     "file_descriptor_leaked",
+			stdErr:   "File descriptor 7 leaked on lvm invocation. Parent PID 1: /opt/deckhouse/sds/bin/nsenter",
+			filtered: true,
+		},
+		{
+			name:     "real_error_is_kept",
+			stdErr:   "  Volume group \"vg\" not found.",
+			filtered: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			buf.WriteString(tt.stdErr)
+
+			result := filterStdErr(cmd, buf)
+
+			if tt.filtered {
+				assert.Equal(t, 0, result.Len(), "expected stderr to be fully filtered, got: %q", result.String())
+			} else {
+				assert.Contains(t, result.String(), tt.stdErr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

`filterStdErr` swallows benign LVM output so that a no-op `lvextend` is not treated as a failure. It only matched the old LVM wording ` No size change.`. Newer LVM (e.g. 2.03.16, shipped on the affected nodes) prints `New size (<n> extents) matches existing size (<n> extents).` instead, which slipped through the filter and surfaced as a real error.

This PR extends the regexp to match both wordings and adds a unit test for `filterStdErr` covering both no-op messages, the existing filtered lines, and a real error that must be kept.

No component restarts are required; the change only affects how the agent interprets `lvextend` stderr.

## Why do we need it, and what problem does it solve?

When a thin-pool with `size: 100%` already occupies the whole VG, the reconciler still runs `lvextend -l 100%VG` on every pass, because the on-disk LV size is a few extents smaller than `Status.VGSize` (thin-pool metadata overhead). LVM performs no resize and exits with status 5.

On LVM 2.03.16 the resulting stderr `New size (…) matches existing size (…).` was not filtered, so `ExtendLVFullVGSpace` returned an error → `ReconcileThinPoolsIfNeeded` set `VGConfigurationApplied=False` (reason `ThinPoolReconcileFailed`) → `Ready=False`, leaving LVMVolumeGroups stuck in `NotReady` even though nothing was actually wrong.

Observed in a cluster where multiple LVGs were stuck in `NotReady`:

```
unable to reconcile thin-pools, err: unable to resize thin-pool ...,
err: ... lvextend ... -l 100%VG ...,
err: exit status 5, stderr:   New size (953801 extents) matches existing size (953801 extents).
```

## What is the expected result?

Affected LVMVolumeGroups reconcile cleanly: the no-op `lvextend` is treated as benign, `VGConfigurationApplied` and `Ready` return to `True`, and the LVGs leave `NotReady`. Real `lvextend` failures are still reported.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
