### PR TITLE
Add reusable workflow for E2E testing in storage module

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,38 @@
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Thin caller for the storage-e2e reusable workflow.
+# The heavy e2e pipeline (resolve -> bootstrap -> run-tests -> teardown) lives in
+# deckhouse/storage-e2e/.github/workflows/e2e.yml. This job only gates on the
+# `e2e/run` PR label and delegates, inheriting the org/repo secrets.
+# Required PR labels: e2e/run, e2e/keep-cluster, e2e/label:* — see
+# https://github.com/deckhouse/storage-e2e#ci-reusable-workflow
+
+name: E2E
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  e2e:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'e2e/run') }}
+    uses: deckhouse/storage-e2e/.github/workflows/e2e.yml@main
+    with:
+      module_slug: sds-node-configurator
+      module_path: e2e
+      test_package: ./tests/
+      cluster_config: e2e/tests/cluster_config.yml
+      cluster_provider: dvp
+    secrets: inherit


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for end-to-end (E2E) testing. The workflow acts as a thin wrapper that triggers a reusable E2E workflow from another repository when the appropriate PR label is present.

**CI/CD Integration:**

* Added a new workflow file `.github/workflows/e2e-tests.yml` that delegates E2E test execution to the `deckhouse/storage-e2e` reusable workflow, triggering only when the `e2e/run` label is applied to a pull request.
* Configured the workflow to pass module-specific parameters and inherit secrets, ensuring proper context and security for E2E test execution.
* Included detailed documentation in the workflow file about its purpose, required labels, and how it integrates with the main E2E pipeline.