### PR TITLE
fix(agent): extend cloned/restored LV to the requested size

### DIFF
--- a/e2e/tests/lvmlogicalvolume_clone_test.go
+++ b/e2e/tests/lvmlogicalvolume_clone_test.go
@@ -1,0 +1,245 @@
+/*
+	Copyright 2026 Flant JSC
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
+	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
+	"github.com/deckhouse/sds-node-configurator/e2e/framework"
+	"github.com/deckhouse/sds-node-configurator/e2e/sdsclient"
+	"github.com/deckhouse/storage-e2e/pkg/e2e"
+	"github.com/deckhouse/storage-e2e/pkg/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// The origin is deliberately not a round number of extents' worth of MiB in the
+// request: 35Mi rounds up to 36Mi on a 4Mi extent, which is the drift the CSI
+// side used to leave in Spec.Size. The clone then asks for a strictly larger
+// size, because `lvcreate -s` produces an LV of the origin size and the agent
+// has to extend it before reporting Created.
+const (
+	llvCloneOriginRequest = "35Mi"
+	llvCloneOriginActual  = "36Mi"
+	llvCloneTargetRequest = "52Mi"
+
+	llvCloneReadyTimeout = 5 * time.Minute
+	llvClonePollInterval = 5 * time.Second
+)
+
+var _ = Describe("LVMLogicalVolume clone", Label("sds-node-configurator", "lvmlogicalvolume"), Ordered, ContinueOnFailure, func() {
+	var (
+		ctx       context.Context
+		conf      *cfg.Config
+		cl        *e2e.Cluster
+		k8sClient client.Client
+
+		targetNode string
+		runID      string
+
+		createdDisks []*e2e.Disk
+
+		lvgName      string
+		vgName       string
+		thinPoolName string
+	)
+
+	BeforeAll(func() {
+		ctx = context.Background()
+
+		var cfgErr error
+		conf, cfgErr = cfg.Load()
+		Expect(cfgErr).NotTo(HaveOccurred(), "failed to load config")
+
+		var clErr error
+		cl, clErr = e2e.Connect(ctx, e2e.WithTestName("lvmlogicalvolume-clone"))
+		Expect(clErr).NotTo(HaveOccurred(), "failed to connect to cluster")
+		DeferCleanup(func() {
+			if err := cl.Close(context.Background()); err != nil {
+				GinkgoWriter.Println("Error closing cluster: ", err)
+			}
+		})
+
+		var k8sErr error
+		k8sClient, k8sErr = sdsclient.New(cl.RESTConfig())
+		Expect(k8sErr).NotTo(HaveOccurred(), "failed to build controller-runtime client")
+
+		nodeList, nlErr := cl.Clientset().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		Expect(nlErr).NotTo(HaveOccurred(), "failed to list nodes")
+		Expect(nodeList.Items).NotTo(BeEmpty(), "cluster must have at least one node")
+		targetNode = nodeList.Items[0].Name
+
+		runID = fmt.Sprintf("%d", time.Now().Unix())
+
+		By("Snapshotting consumable BlockDevices before attach")
+		before, bdErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
+		Expect(bdErr).NotTo(HaveOccurred())
+
+		diskName := fmt.Sprintf("e2e-llv-clone-disk-%s", runID)
+		By("Creating and attaching a virtual disk: " + diskName)
+		disk, createErr := cl.Disks().CreateDisk(ctx, e2e.DiskSpec{
+			Name:         diskName,
+			Size:         resource.MustParse("2Gi"),
+			StorageClass: conf.TestCluster.StorageClass,
+		})
+		Expect(createErr).NotTo(HaveOccurred(), "failed to create disk")
+		createdDisks = append(createdDisks, disk)
+		Expect(cl.Disks().AttachDisk(ctx, targetNode, disk.Name)).To(Succeed(), "failed to attach disk")
+
+		By("Waiting for the new consumable BlockDevice on node " + targetNode)
+		newBD, waitErr := framework.WaitNewConsumableBlockDevice(ctx, cl.RESTConfig(), targetNode, before, 5*time.Minute)
+		Expect(waitErr).NotTo(HaveOccurred())
+
+		vgName = "e2e-vg-llv-clone-" + runID
+		thinPoolName = "e2e-thin-pool-clone"
+		lvgName = lvmVGNamePrefix + "llv-clone-" + runID
+
+		By(fmt.Sprintf("Creating LVMVolumeGroup %s on node %s, VG %s, thin-pool %s", lvgName, targetNode, vgName, thinPoolName))
+		Expect(kubernetes.CreateLVMVolumeGroupWithThinPool(
+			ctx, cl.RESTConfig(), lvgName, targetNode, []string{newBD.Name}, vgName,
+			[]kubernetes.ThinPoolSpec{{Name: thinPoolName, Size: "60%", AllocationLimit: "150%"}},
+		)).To(Succeed())
+
+		By("Waiting for LVMVolumeGroup to become Ready")
+		Eventually(func(g Gomega) {
+			var lvg v1alpha1.LVMVolumeGroup
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: lvgName}, &lvg)).To(Succeed())
+			g.Expect(lvg.Status.Phase).To(Equal(v1alpha1.PhaseReady), "Phase should be Ready, got %s", lvg.Status.Phase)
+		}, lvmVolumeGroupReadyTimeout, 10*time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		By("Cleaning up e2e LVMLogicalVolumes")
+		cleanupLVMLogicalVolumes(ctx, k8sClient)
+
+		By("Cleaning up e2e LVMVolumeGroups")
+		cleanupLVMVolumeGroups(ctx, k8sClient)
+
+		By("Removing any leftover thin-pool stack on the node")
+		_, _ = framework.NodeExecChecked(ctx, cl, targetNode, framework.RemoveThinPoolStackScript(vgName, thinPoolName))
+
+		By("Detaching and deleting test disks")
+		for _, d := range createdDisks {
+			if d == nil {
+				continue
+			}
+			if err := cl.Disks().DetachDisk(ctx, targetNode, d.Name); err != nil {
+				GinkgoWriter.Printf("failed to detach disk %v: %v\n", d.Name, err)
+			}
+			if err := cl.Disks().DeleteDisk(ctx, d.Name); err != nil {
+				GinkgoWriter.Printf("failed to delete disk %v: %v\n", d.Name, err)
+			}
+		}
+	})
+
+	// Regression test for the restore-from-snapshot hang: a thin LV created from a
+	// source via `lvcreate -s` inherits the origin size, so a clone requested at a
+	// larger size used to stay at the origin size forever. The CSI controller waits
+	// for Status.ActualSize to reach the request before returning from CreateVolume,
+	// so the PVC stayed Pending indefinitely.
+	It("Should extend a cloned LVMLogicalVolume to the requested size", func() {
+		originName := "e2e-llv-clone-origin-" + runID
+		originLVName := "e2e-lv-clone-origin-" + runID
+
+		By(fmt.Sprintf("Creating the origin LVMLogicalVolume %s with size %s", originName, llvCloneOriginRequest))
+		origin := &v1alpha1.LVMLogicalVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: originName},
+			Spec: v1alpha1.LVMLogicalVolumeSpec{
+				ActualLVNameOnTheNode: originLVName,
+				Type:                  "Thin",
+				Size:                  llvCloneOriginRequest,
+				LVMVolumeGroupName:    lvgName,
+				Thin:                  &v1alpha1.LVMLogicalVolumeThinSpec{PoolName: thinPoolName},
+			},
+		}
+		Expect(k8sClient.Create(ctx, origin)).To(Succeed())
+
+		By("Waiting for the origin to become Created")
+		originActual := waitLLVCreated(ctx, k8sClient, originName)
+
+		// The node provisions whole extents, so a 35Mi request lands on a 36Mi LV.
+		By(fmt.Sprintf("Verifying the origin was rounded up to the extent boundary (%s)", llvCloneOriginActual))
+		expectedOrigin := resource.MustParse(llvCloneOriginActual)
+		Expect(originActual.Value()).To(Equal(expectedOrigin.Value()),
+			"origin ActualSize should be the extent-aligned %s, got %s", llvCloneOriginActual, originActual.String())
+
+		cloneName := "e2e-llv-clone-target-" + runID
+		cloneLVName := "e2e-lv-clone-target-" + runID
+
+		By(fmt.Sprintf("Creating the clone %s from %s with a larger size %s", cloneName, originName, llvCloneTargetRequest))
+		clone := &v1alpha1.LVMLogicalVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: cloneName},
+			Spec: v1alpha1.LVMLogicalVolumeSpec{
+				ActualLVNameOnTheNode: cloneLVName,
+				Type:                  "Thin",
+				Size:                  llvCloneTargetRequest,
+				LVMVolumeGroupName:    lvgName,
+				Thin:                  &v1alpha1.LVMLogicalVolumeThinSpec{PoolName: thinPoolName},
+				Source: &v1alpha1.LVMLogicalVolumeSource{
+					Kind: "LVMLogicalVolume",
+					Name: originName,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, clone)).To(Succeed())
+
+		By("Waiting for the clone to become Created")
+		cloneActual := waitLLVCreated(ctx, k8sClient, cloneName)
+
+		By(fmt.Sprintf("Verifying the clone reached the requested size %s and not the origin size %s", llvCloneTargetRequest, llvCloneOriginActual))
+		expectedClone := resource.MustParse(llvCloneTargetRequest)
+		Expect(cloneActual.Value()).To(BeNumerically(">=", expectedClone.Value()),
+			"clone ActualSize %s is below the requested %s: the LV was not extended after `lvcreate -s`",
+			cloneActual.String(), llvCloneTargetRequest)
+
+		By("Verifying the size LVM reports on the node matches the status")
+		out, execErr := framework.NodeExecChecked(ctx, cl, targetNode,
+			fmt.Sprintf("lvs --noheadings --units b --nosuffix -o lv_size /dev/%s/%s 2>/dev/null || sudo -n lvs --noheadings --units b --nosuffix -o lv_size /dev/%s/%s",
+				vgName, cloneLVName, vgName, cloneLVName))
+		Expect(execErr).NotTo(HaveOccurred(), "failed to read the LV size from the node")
+		Expect(strings.TrimSpace(out)).To(Equal(fmt.Sprintf("%d", cloneActual.Value())),
+			"LVM reports a different size than Status.ActualSize")
+
+		By("✓ the cloned LVMLogicalVolume was extended from the origin size to the requested size")
+	})
+})
+
+// waitLLVCreated blocks until the LVMLogicalVolume reaches the Created phase and
+// returns the ActualSize the agent published, failing the spec on Failed.
+func waitLLVCreated(ctx context.Context, cl client.Client, name string) resource.Quantity {
+	GinkgoHelper()
+
+	var llv v1alpha1.LVMLogicalVolume
+	Eventually(func(g Gomega) {
+		g.Expect(cl.Get(ctx, client.ObjectKey{Name: name}, &llv)).To(Succeed())
+		g.Expect(llv.Status).NotTo(BeNil(), "LVMLogicalVolume %s has no status yet", name)
+		g.Expect(llv.Status.Phase).NotTo(Equal(v1alpha1.PhaseFailed),
+			"LVMLogicalVolume %s failed: %s", name, llv.Status.Reason)
+		g.Expect(llv.Status.Phase).To(Equal(v1alpha1.PhaseCreated),
+			"LVMLogicalVolume %s phase=%s (waiting for Created)", name, llv.Status.Phase)
+	}, llvCloneReadyTimeout, llvClonePollInterval).Should(Succeed())
+
+	return llv.Status.ActualSize
+}

--- a/images/agent/internal/controller/llv/reconciler.go
+++ b/images/agent/internal/controller/llv/reconciler.go
@@ -402,6 +402,20 @@ func (r *Reconciler) reconcileLLVCreateFunc(
 	r.log.Debug(fmt.Sprintf("[reconcileLLVCreateFunc] successfully got the LV %s actual size", llv.Spec.ActualLVNameOnTheNode))
 	r.log.Trace(fmt.Sprintf("[reconcileLLVCreateFunc] the LV %s in VG: %s has actual size: %s", llv.Spec.ActualLVNameOnTheNode, lvg.Spec.ActualVGNameOnTheNode, actualSize.String()))
 
+	// A thin volume created from a snapshot or another LV via `lvcreate -s` inherits
+	// the origin size instead of being created at the requested size. When the
+	// requested (extent-aligned) size is larger, extend the LV now; otherwise the CSI
+	// CreateVolume call waits indefinitely for a size that is never reached.
+	if llv.Spec.Type == internal.Thin && llv.Spec.Source != nil && actualSize.Value() < alignedRequestSize.Value() {
+		r.log.Info(fmt.Sprintf("[reconcileLLVCreateFunc] the LV %s cloned from source %s has actual size %s, extending to the requested aligned size %s", llv.Spec.ActualLVNameOnTheNode, llv.Spec.Source.Name, actualSize.String(), alignedRequestSize.String()))
+
+		extendedSize, shouldRequeue, extendErr := r.extendLVToSize("reconcileLLVCreateFunc", llv, lvg, alignedRequestSize)
+		if shouldRequeue {
+			return true, extendErr
+		}
+		actualSize = extendedSize
+	}
+
 	if err := r.llvCl.UpdatePhaseToCreatedIfNeeded(ctx, llv, actualSize); err != nil {
 		return true, err
 	}
@@ -488,31 +502,11 @@ func (r *Reconciler) reconcileLLVUpdateFunc(
 		return true, err
 	}
 
-	r.log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] LV %s of the LVMLogicalVolume %s will be extended with size: %s", llv.Spec.ActualLVNameOnTheNode, llv.Name, llvRequestSize.String()))
-	cmd, err := r.commands.ExtendLV(llvRequestSize.Value(), lvg.Spec.ActualVGNameOnTheNode, llv.Spec.ActualLVNameOnTheNode)
-	r.log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] runs cmd: %s", cmd))
-	if err != nil {
-		r.log.Error(err, fmt.Sprintf("[reconcileLLVUpdateFunc] unable to ExtendLV, name: %s, type: %s", llv.Spec.ActualLVNameOnTheNode, llv.Spec.Type))
+	r.log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] LV %s of the LVMLogicalVolume %s will be extended to size: %s", llv.Spec.ActualLVNameOnTheNode, llv.Name, alignedRequestSize.String()))
+	newActualSize, shouldRequeue, err := r.extendLVToSize("reconcileLLVUpdateFunc", llv, lvg, alignedRequestSize)
+	if shouldRequeue {
 		return true, err
 	}
-
-	r.log.Info(fmt.Sprintf("[reconcileLLVUpdateFunc] successfully extended LV %s in VG %s for LVMLogicalVolume resource with name: %s", llv.Spec.ActualLVNameOnTheNode, lvg.Spec.ActualVGNameOnTheNode, llv.Name))
-
-	r.log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] tries to get LVMLogicalVolume %s actual size after the extension directly from LVM", llv.Name))
-	lvData, getLVCmd, _, getLVErr := r.commands.GetLV(lvg.Spec.ActualVGNameOnTheNode, llv.Spec.ActualLVNameOnTheNode)
-	r.log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] ran cmd: %s", getLVCmd))
-	if getLVErr != nil {
-		r.log.Warning(fmt.Sprintf("[reconcileLLVUpdateFunc] unable to get LV %s info from LVM after extension: %s, will retry", llv.Spec.ActualLVNameOnTheNode, getLVErr.Error()))
-		return true, nil
-	}
-	newActualSize := lvData.LVSize
-	if newActualSize.Value() == 0 || newActualSize.Value() == actualSize.Value() {
-		r.log.Warning(fmt.Sprintf("[reconcileLLVUpdateFunc] LV %s of the LVMLogicalVolume %s was extended but LVM still reports old size %s, will retry", llv.Spec.ActualLVNameOnTheNode, llv.Name, newActualSize.String()))
-		return true, nil
-	}
-
-	r.log.Debug(fmt.Sprintf("[reconcileLLVUpdateFunc] successfully got LVMLogicalVolume %s actual size before the extension", llv.Name))
-	r.log.Trace(fmt.Sprintf("[reconcileLLVUpdateFunc] the LV %s in VG %s actual size %s", llv.Spec.ActualLVNameOnTheNode, lvg.Spec.ActualVGNameOnTheNode, newActualSize.String()))
 
 	// need this here as a user might create the LLV with existing LV
 	if err := r.llvCl.UpdatePhaseToCreatedIfNeeded(ctx, llv, newActualSize); err != nil {
@@ -521,6 +515,52 @@ func (r *Reconciler) reconcileLLVUpdateFunc(
 
 	r.log.Info(fmt.Sprintf("[reconcileLLVUpdateFunc] successfully ended reconciliation for the LVMLogicalVolume %s", llv.Name))
 	return false, nil
+}
+
+// extendLVToSize grows the LV of the given LVMLogicalVolume to alignedSize and
+// returns the size LVM reports afterwards.
+//
+// The size is re-read and validated instead of being assumed, because ExtendLV
+// reports a no-op resize as success: LVM signals it on stderr ("No size change.",
+// "New size (...) matches existing size (...)") and filterStdErr deliberately
+// treats those lines as benign. Handing an unverified size to
+// UpdatePhaseToCreatedIfNeeded would move the LLV to Created at the wrong size
+// with no further reconcile scheduled, and the CSI caller would then wait
+// forever for a size that never materialises.
+//
+// The returned flag means "requeue"; it is set both on a hard error (returned as
+// the third value) and when the extension simply could not be confirmed yet.
+func (r *Reconciler) extendLVToSize(
+	caller string,
+	llv *v1alpha1.LVMLogicalVolume,
+	lvg *v1alpha1.LVMVolumeGroup,
+	alignedSize resource.Quantity,
+) (resource.Quantity, bool, error) {
+	cmd, err := r.commands.ExtendLV(alignedSize.Value(), lvg.Spec.ActualVGNameOnTheNode, llv.Spec.ActualLVNameOnTheNode)
+	r.log.Debug(fmt.Sprintf("[%s] ran cmd: %s", caller, cmd))
+	if err != nil {
+		r.log.Error(err, fmt.Sprintf("[%s] unable to extend the LV %s of the LVMLogicalVolume %s to size %s, type: %s", caller, llv.Spec.ActualLVNameOnTheNode, llv.Name, alignedSize.String(), llv.Spec.Type))
+		return resource.Quantity{}, true, err
+	}
+
+	r.log.Info(fmt.Sprintf("[%s] successfully extended LV %s in VG %s for LVMLogicalVolume resource with name: %s", caller, llv.Spec.ActualLVNameOnTheNode, lvg.Spec.ActualVGNameOnTheNode, llv.Name))
+
+	r.log.Debug(fmt.Sprintf("[%s] tries to get LVMLogicalVolume %s actual size after the extension directly from LVM", caller, llv.Name))
+	lvData, getLVCmd, _, getLVErr := r.commands.GetLV(lvg.Spec.ActualVGNameOnTheNode, llv.Spec.ActualLVNameOnTheNode)
+	r.log.Debug(fmt.Sprintf("[%s] ran cmd: %s", caller, getLVCmd))
+	if getLVErr != nil {
+		r.log.Warning(fmt.Sprintf("[%s] unable to get LV %s info from LVM after the extension: %s, will retry", caller, llv.Spec.ActualLVNameOnTheNode, getLVErr.Error()))
+		return resource.Quantity{}, true, nil
+	}
+
+	newActualSize := lvData.LVSize
+	if newActualSize.Value() < alignedSize.Value() {
+		r.log.Warning(fmt.Sprintf("[%s] LV %s of the LVMLogicalVolume %s was extended but LVM still reports size %s which is less than the requested %s, will retry", caller, llv.Spec.ActualLVNameOnTheNode, llv.Name, newActualSize.String(), alignedSize.String()))
+		return resource.Quantity{}, true, nil
+	}
+
+	r.log.Trace(fmt.Sprintf("[%s] the LV %s in VG %s has actual size %s after the extension", caller, llv.Spec.ActualLVNameOnTheNode, lvg.Spec.ActualVGNameOnTheNode, newActualSize.String()))
+	return newActualSize, false, nil
 }
 
 func (r *Reconciler) reconcileLLVDeleteFunc(
@@ -739,6 +779,14 @@ func (r *Reconciler) validateLVMLogicalVolume(llv *v1alpha1.LVMLogicalVolume, lv
 	case internal.Thick:
 		if llv.Spec.Thin != nil {
 			reason.WriteString("Thin pool specified for Thick LV. ")
+		}
+
+		// Cloning and restoring are done with `lvcreate -s`, which exists for thin
+		// volumes only. Without this check the create path falls into its Thick
+		// branch, produces an empty LV and drops the source silently, leaving the
+		// user with a volume that reports Created but holds no data.
+		if llv.Spec.Source != nil {
+			reason.WriteString("Source specified for Thick LV: cloning and restoring are supported for Thin LVs only. ")
 		}
 	}
 

--- a/images/agent/internal/controller/llv/reconciler_test.go
+++ b/images/agent/internal/controller/llv/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +31,7 @@ import (
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal"
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal/cache"
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal/logger"
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal/mock_utils"
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal/monitoring"
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal/test_utils"
 	"github.com/deckhouse/sds-node-configurator/images/agent/internal/utils"
@@ -209,6 +211,43 @@ func TestLVMLogicalVolumeWatcher(t *testing.T) {
 			v, reason := r.validateLVMLogicalVolume(llv, lvg)
 			if assert.True(t, v) {
 				assert.Equal(t, 0, len(reason))
+			}
+		})
+
+		// Cloning and restoring go through `lvcreate -s`, which is thin-only. The
+		// create path checks the Thick type first, so a Thick LLV carrying a Source
+		// used to produce an empty LV with the source dropped silently — a Created
+		// volume holding no data. It has to be rejected here instead.
+		t.Run("thick_with_source_returns_false", func(t *testing.T) {
+			const lvgName = "test-lvg"
+
+			r := setupReconciler()
+
+			lvg := &v1alpha1.LVMVolumeGroup{
+				ObjectMeta: v1.ObjectMeta{
+					Name: lvgName,
+				},
+				Status: v1alpha1.LVMVolumeGroupStatus{
+					VGSize: resource.MustParse("1Gi"),
+				},
+			}
+
+			llv := &v1alpha1.LVMLogicalVolume{
+				Spec: v1alpha1.LVMLogicalVolumeSpec{
+					ActualLVNameOnTheNode: "test-lv",
+					Type:                  internal.Thick,
+					Size:                  "10M",
+					LVMVolumeGroupName:    lvgName,
+					Source: &v1alpha1.LVMLogicalVolumeSource{
+						Kind: "LVMLogicalVolumeSnapshot",
+						Name: "some-snapshot",
+					},
+				},
+			}
+
+			v, reason := r.validateLVMLogicalVolume(llv, lvg)
+			if assert.False(t, v) {
+				assert.Equal(t, "Source specified for Thick LV: cloning and restoring are supported for Thin LVs only. ", reason)
 			}
 		})
 
@@ -846,6 +885,298 @@ func TestLVMLogicalVolumeWatcher(t *testing.T) {
 			assert.Error(t, err)
 		})
 	})
+}
+
+const (
+	cloneVGActual  = "test-vg"
+	cloneThinPool  = "test-pool"
+	cloneLLVName   = "restored-llv"
+	cloneLVName    = "restored-lv"
+	cloneSrcName   = "source-llv"
+	cloneSrcLVName = "source-lv"
+)
+
+type clonedVolumeEnv struct {
+	r        *Reconciler
+	cl       client.Client
+	mockCmds *mock_utils.MockCommands
+	lvg      *v1alpha1.LVMVolumeGroup
+	llv      *v1alpha1.LVMLogicalVolume
+}
+
+// newClonedVolumeEnv builds the fixture shared by the clone/restore tests: a thin
+// LVG with a 4Mi extent, a 36Mi source LLV, and a target LLV cloned from it that
+// asks for requestedSize.
+func newClonedVolumeEnv(ctx context.Context, t *testing.T, requestedSize string) *clonedVolumeEnv {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockCmds := mock_utils.NewMockCommands(ctrl)
+	cl := test_utils.NewFakeClient(&v1alpha1.LVMLogicalVolume{})
+	r := NewReconciler(cl, logger.Logger{}, monitoring.GetMetrics(""), cache.New(), mockCmds, ReconcilerConfig{})
+
+	lvg := &v1alpha1.LVMVolumeGroup{
+		ObjectMeta: v1.ObjectMeta{Name: "test-lvg"},
+		Spec: v1alpha1.LVMVolumeGroupSpec{
+			ActualVGNameOnTheNode: cloneVGActual,
+			Local:                 v1alpha1.LVMVolumeGroupLocalSpec{NodeName: "node-1"},
+		},
+		Status: v1alpha1.LVMVolumeGroupStatus{
+			ExtentSize: resource.MustParse("4Mi"),
+			ThinPools: []v1alpha1.LVMVolumeGroupThinPoolStatus{
+				{
+					Name:            cloneThinPool,
+					ActualSize:      resource.MustParse("1Gi"),
+					AvailableSpace:  resource.MustParse("1Gi"),
+					AllocationLimit: "150%",
+				},
+			},
+		},
+	}
+
+	sourceLLV := &v1alpha1.LVMLogicalVolume{
+		ObjectMeta: v1.ObjectMeta{Name: cloneSrcName},
+		Spec: v1alpha1.LVMLogicalVolumeSpec{
+			ActualLVNameOnTheNode: cloneSrcLVName,
+			Type:                  internal.Thin,
+			LVMVolumeGroupName:    lvg.Name,
+			Thin:                  &v1alpha1.LVMLogicalVolumeThinSpec{PoolName: cloneThinPool},
+			Size:                  "36Mi",
+		},
+	}
+	assert.NoError(t, cl.Create(ctx, sourceLLV))
+
+	llv := &v1alpha1.LVMLogicalVolume{
+		ObjectMeta: v1.ObjectMeta{Name: cloneLLVName},
+		Spec: v1alpha1.LVMLogicalVolumeSpec{
+			ActualLVNameOnTheNode: cloneLVName,
+			Type:                  internal.Thin,
+			LVMVolumeGroupName:    lvg.Name,
+			Thin:                  &v1alpha1.LVMLogicalVolumeThinSpec{PoolName: cloneThinPool},
+			Size:                  requestedSize,
+			Source:                &v1alpha1.LVMLogicalVolumeSource{Kind: "LVMLogicalVolume", Name: cloneSrcName},
+		},
+		Status: &v1alpha1.LVMLogicalVolumeStatus{Phase: v1alpha1.PhasePending},
+	}
+	assert.NoError(t, cl.Create(ctx, llv))
+
+	return &clonedVolumeEnv{r: r, cl: cl, mockCmds: mockCmds, lvg: lvg, llv: llv}
+}
+
+func (e *clonedVolumeEnv) expectClone() *gomock.Call {
+	return e.mockCmds.EXPECT().
+		CreateThinLogicalVolumeFromSource(cloneLVName, cloneVGActual, cloneSrcLVName).
+		Return("lvcreate -s", nil).
+		Times(1)
+}
+
+func (e *clonedVolumeEnv) expectGetLV(size resource.Quantity) *gomock.Call {
+	return e.mockCmds.EXPECT().
+		GetLV(cloneVGActual, cloneLVName).
+		Return(internal.LVData{LVName: cloneLVName, VGName: cloneVGActual, LVSize: size}, "lvs", bytes.Buffer{}, nil).
+		Times(1)
+}
+
+func (e *clonedVolumeEnv) expectExtendLV(size resource.Quantity) *gomock.Call {
+	return e.mockCmds.EXPECT().
+		ExtendLV(size.Value(), cloneVGActual, cloneLVName).
+		Return("lvextend", nil).
+		Times(1)
+}
+
+// seedCachedLV puts the LV into the scan cache, which is where the update path
+// reads the pre-extension size from (the create path goes straight to LVM
+// instead, because the cache has not seen the LV yet).
+func (e *clonedVolumeEnv) seedCachedLV(size resource.Quantity) {
+	e.r.sdsCache.StoreLVs(
+		[]internal.LVData{{LVName: cloneLVName, VGName: cloneVGActual, LVSize: size}},
+		bytes.Buffer{},
+	)
+}
+
+// TestReconcileLLVCreateFunc_ClonedVolumeExtendedToRequestedSize pins the fix
+// for restore/clone from a snapshot or another LV: `lvcreate -s` produces an LV
+// of the origin size, not the requested size. When the requested (extent-aligned)
+// size is larger, the create path must extend the LV before reporting Created —
+// otherwise the CSI CreateVolume call waits forever for a size that never
+// materialises and the PVC stays Pending.
+func TestReconcileLLVCreateFunc_ClonedVolumeExtendedToRequestedSize(t *testing.T) {
+	ctx := context.Background()
+
+	originSize := resource.MustParse("36Mi")    // size the clone inherits from the origin LV
+	requestedSize := resource.MustParse("52Mi") // PVC-requested size, already a multiple of the 4Mi extent
+
+	env := newClonedVolumeEnv(ctx, t, "52Mi")
+
+	gomock.InOrder(
+		env.expectClone(),
+		// right after the clone the LV still reports the origin size
+		env.expectGetLV(originSize),
+		// the clone must be extended to the requested (aligned) size
+		env.mockCmds.EXPECT().
+			ExtendLV(requestedSize.Value(), cloneVGActual, cloneLVName).
+			Return("lvextend", nil).
+			Times(1),
+		// after the extension the LV reports the requested size
+		env.expectGetLV(requestedSize),
+	)
+
+	shouldRequeue, err := env.r.reconcileLLVCreateFunc(ctx, env.llv, env.lvg)
+	assert.NoError(t, err)
+	assert.False(t, shouldRequeue)
+
+	updated := &v1alpha1.LVMLogicalVolume{}
+	assert.NoError(t, env.cl.Get(ctx, client.ObjectKey{Name: cloneLLVName}, updated))
+	assert.Equal(t, v1alpha1.PhaseCreated, updated.Status.Phase)
+	assert.Equal(t, requestedSize.Value(), updated.Status.ActualSize.Value())
+}
+
+// TestReconcileLLVCreateFunc_ClonedVolumeNotExtendedWhenAlreadyLargeEnough
+// guards the other direction: a same-size (or smaller) restore must not touch
+// lvextend at all. The strict mock fails the test on any unexpected ExtendLV.
+func TestReconcileLLVCreateFunc_ClonedVolumeNotExtendedWhenAlreadyLargeEnough(t *testing.T) {
+	ctx := context.Background()
+
+	originSize := resource.MustParse("36Mi")
+
+	env := newClonedVolumeEnv(ctx, t, "36Mi")
+
+	gomock.InOrder(
+		env.expectClone(),
+		env.expectGetLV(originSize),
+	)
+
+	shouldRequeue, err := env.r.reconcileLLVCreateFunc(ctx, env.llv, env.lvg)
+	assert.NoError(t, err)
+	assert.False(t, shouldRequeue)
+
+	updated := &v1alpha1.LVMLogicalVolume{}
+	assert.NoError(t, env.cl.Get(ctx, client.ObjectKey{Name: cloneLLVName}, updated))
+	assert.Equal(t, v1alpha1.PhaseCreated, updated.Status.Phase)
+	assert.Equal(t, originSize.Value(), updated.Status.ActualSize.Value())
+}
+
+// TestReconcileLLVCreateFunc_ClonedVolumeExtensionNotConfirmed covers the case
+// that makes verifying the post-extension size mandatory: ExtendLV reports
+// success while the LV did not actually grow (LVM's "No size change." is
+// filtered out as benign, so a no-op resize is indistinguishable from a real
+// one at the command level). The LLV must NOT be moved to Created at the origin
+// size — that would strand the CSI caller waiting for a size that is never
+// reached, with no further reconcile scheduled.
+func TestReconcileLLVCreateFunc_ClonedVolumeExtensionNotConfirmed(t *testing.T) {
+	ctx := context.Background()
+
+	originSize := resource.MustParse("36Mi")
+	requestedSize := resource.MustParse("52Mi")
+
+	env := newClonedVolumeEnv(ctx, t, "52Mi")
+
+	gomock.InOrder(
+		env.expectClone(),
+		env.expectGetLV(originSize),
+		env.mockCmds.EXPECT().
+			ExtendLV(requestedSize.Value(), cloneVGActual, cloneLVName).
+			Return("lvextend", nil).
+			Times(1),
+		// LVM still reports the origin size: the extension was not effective
+		env.expectGetLV(originSize),
+	)
+
+	shouldRequeue, err := env.r.reconcileLLVCreateFunc(ctx, env.llv, env.lvg)
+	assert.NoError(t, err)
+	assert.True(t, shouldRequeue)
+
+	assert.Equal(t, v1alpha1.PhasePending, env.llv.Status.Phase)
+
+	stored := &v1alpha1.LVMLogicalVolume{}
+	assert.NoError(t, env.cl.Get(ctx, client.ObjectKey{Name: cloneLLVName}, stored))
+	if stored.Status != nil {
+		assert.NotEqual(t, v1alpha1.PhaseCreated, stored.Status.Phase)
+	}
+}
+
+// TestReconcileLLVUpdateFunc_ExtendsToTheAlignedRequestedSize pins the resize
+// path onto the extent-aligned size rather than the raw Spec.Size. LVM rounds
+// `lvextend -L` up to the extent boundary anyway, so the resulting LV is the
+// same either way — but the size the reconciler then verifies against, and the
+// ActualSize it publishes, have to be the rounded one. Verifying against the
+// raw request would keep the LLV out of Created forever whenever Spec.Size is
+// not a multiple of the extent.
+func TestReconcileLLVUpdateFunc_ExtendsToTheAlignedRequestedSize(t *testing.T) {
+	ctx := context.Background()
+
+	currentSize := resource.MustParse("36Mi")
+	// 50Mi is not a multiple of the 4Mi extent, the LV can only reach 52Mi
+	alignedSize := resource.MustParse("52Mi")
+
+	env := newClonedVolumeEnv(ctx, t, "50Mi")
+	env.seedCachedLV(currentSize)
+
+	gomock.InOrder(
+		env.expectExtendLV(alignedSize),
+		env.expectGetLV(alignedSize),
+	)
+
+	shouldRequeue, err := env.r.reconcileLLVUpdateFunc(ctx, env.llv, env.lvg)
+	assert.NoError(t, err)
+	assert.False(t, shouldRequeue)
+
+	updated := &v1alpha1.LVMLogicalVolume{}
+	assert.NoError(t, env.cl.Get(ctx, client.ObjectKey{Name: cloneLLVName}, updated))
+	assert.Equal(t, v1alpha1.PhaseCreated, updated.Status.Phase)
+	assert.Equal(t, alignedSize.Value(), updated.Status.ActualSize.Value())
+}
+
+// TestReconcileLLVUpdateFunc_RequeuesWhenExtensionNotConfirmed is the resize-path
+// counterpart of the create-path test above: a no-op lvextend is reported as
+// success, so the LLV must stay out of Created until LVM confirms the new size.
+func TestReconcileLLVUpdateFunc_RequeuesWhenExtensionNotConfirmed(t *testing.T) {
+	ctx := context.Background()
+
+	currentSize := resource.MustParse("36Mi")
+	requestedSize := resource.MustParse("52Mi")
+
+	env := newClonedVolumeEnv(ctx, t, "52Mi")
+	env.seedCachedLV(currentSize)
+
+	gomock.InOrder(
+		env.expectExtendLV(requestedSize),
+		// LVM still reports the pre-extension size
+		env.expectGetLV(currentSize),
+	)
+
+	shouldRequeue, err := env.r.reconcileLLVUpdateFunc(ctx, env.llv, env.lvg)
+	assert.NoError(t, err)
+	assert.True(t, shouldRequeue)
+
+	stored := &v1alpha1.LVMLogicalVolume{}
+	assert.NoError(t, env.cl.Get(ctx, client.ObjectKey{Name: cloneLLVName}, stored))
+	assert.Equal(t, v1alpha1.PhaseResizing, stored.Status.Phase)
+	assert.NotEqual(t, requestedSize.Value(), stored.Status.ActualSize.Value())
+}
+
+// TestReconcileLLVUpdateFunc_NoExtendWhenAlreadyLargeEnough guards the branch a
+// restored volume lands in once the create path has already grown it: the LV is
+// big enough, so lvextend must not run again. The strict mock fails the test on
+// any unexpected ExtendLV.
+func TestReconcileLLVUpdateFunc_NoExtendWhenAlreadyLargeEnough(t *testing.T) {
+	ctx := context.Background()
+
+	currentSize := resource.MustParse("52Mi")
+
+	env := newClonedVolumeEnv(ctx, t, "52Mi")
+	env.seedCachedLV(currentSize)
+
+	shouldRequeue, err := env.r.reconcileLLVUpdateFunc(ctx, env.llv, env.lvg)
+	assert.NoError(t, err)
+	assert.False(t, shouldRequeue)
+
+	updated := &v1alpha1.LVMLogicalVolume{}
+	assert.NoError(t, env.cl.Get(ctx, client.ObjectKey{Name: cloneLLVName}, updated))
+	assert.Equal(t, v1alpha1.PhaseCreated, updated.Status.Phase)
+	assert.Equal(t, currentSize.Value(), updated.Status.ActualSize.Value())
 }
 
 func setupReconciler() *Reconciler {


### PR DESCRIPTION
## Problem

Creating a PVC from a VolumeSnapshot (or cloning a PVC) on `sds-local-volume` hangs with the PVC stuck in `Pending` whenever the requested size is larger than the source volume.

A volume created from a snapshot or another LV is provisioned via `lvcreate -s`, which produces an LV of the **origin** size, not the requested size. `reconcileLLVCreateFunc` then marked the `LVMLogicalVolume` as `Created` at the origin size and returned without a requeue. Because `ShouldReconcileUpdate` ignores status-only changes, no resize reconcile was ever triggered, so the LV stayed at the origin size.

Meanwhile the CSI controller's `WaitForStatusUpdate` blocks until `Status.ActualSize >= aligned(requested size)`, which never becomes true → `CreateVolume` never returns → external-provisioner retries forever → PVC `Pending`.

Concretely (from a Deckhouse Virtualization restore): origin LV ≈ 36Mi, restore PVC requests 52Mi → hang. Same-or-smaller restores worked; larger ones did not.

## Fix

In `reconcileLLVCreateFunc`, after the clone, if the requested (extent-aligned) size is larger than the origin's actual size, extend the LV to the aligned size before reporting `Created`. Covers both `LVMLogicalVolume` clones and `LVMLogicalVolumeSnapshot` restores.

The extension goes through a new `extendLVToSize`, shared with `reconcileLLVUpdateFunc`, which re-reads the LV size from LVM afterwards and requeues unless it actually reached the requested size.

That verification is required rather than defensive: `ExtendLV` reports a no-op resize as success, because LVM signals it on stderr (`No size change.`, `New size (...) matches existing size (...)`) and `filterStdErr` deliberately treats those lines as benign. Reporting an unverified size would move the LLV to `Created` at the origin size with no further reconcile scheduled — reintroducing exactly the indefinite wait this PR fixes.

The extension is restricted to thin volumes with a source, which is the only case `lvcreate -s` is used for; thick volumes are already created at the requested size.

### Behaviour change in the resize path

Sharing `extendLVToSize` also moves `reconcileLLVUpdateFunc` onto the extent-aligned size: it now calls `ExtendLV(alignedRequestSize)` instead of `ExtendLV(llvRequestSize)`, and verifies `newActualSize >= alignedSize` instead of `newActualSize != actualSize`.

The resulting LV is unchanged — `lvextend -L` rounds up to the extent boundary anyway, and `GetLV` runs `lvs --units B --nosuffix`, so no precision is lost by the stricter predicate. What changes is the size the reconciler verifies against and publishes as `ActualSize`: it has to be the rounded one, otherwise an LLV whose `Spec.Size` is not a multiple of the extent could never satisfy its own check.

### Reject a Thick LV with a Source

`validateLVMLogicalVolume` now rejects a `Thick` `LVMLogicalVolume` that carries a `Source`. The create path matches the `Thick` type before the source branches, so such a resource used to create an empty LV and drop the source silently, leaving a volume that reports `Created` but holds no data. The combination is reachable through a snapshot restore into a thick storage class; the CSI side rejects it up front in the paired PR.

## Related

Paired with the `sds-local-volume` change that fixes the unaligned (`35Mi`, not a multiple of 4Mi) reported capacity / snapshot `restoreSize`: deckhouse/sds-local-volume#248

## Testing

Unit tests for both reconcile paths:

- create path — the clone is extended, a same-size restore does not call `lvextend`, and an unconfirmed extension requeues instead of reporting `Created`;
- resize path — `lvextend` targets the aligned size (`Spec.Size: 50Mi` → `ExtendLV(52Mi)`), an unconfirmed extension requeues and leaves the LLV in `Resizing`, and an already-large-enough LV is not extended at all;
- validation — a `Thick` LLV with a `Source` is rejected.

The two "unconfirmed extension" tests and the aligned-size test were verified to fail when the corresponding check is removed.

E2E: `e2e/tests/lvmlogicalvolume_clone_test.go` provisions a thin pool, creates an origin LLV at `35Mi` (asserting it is rounded up to `36Mi`), clones it at `52Mi`, and checks that the clone reaches `Created` with `ActualSize >= 52Mi` and that `lvs` on the node agrees with the published status. This is the scenario that used to hang. Not run in this branch — it needs a live cluster; the spec is picked up automatically by the `e2e/run` workflow.

- `go test -tags ee ./...` / `go test -tags ce ./...` (whole agent module)
- `go vet -tags ee ./...` / `go vet -tags ce ./...`, `go vet ./...` in the `e2e` module
- `golangci-lint run --build-tags ee ./...` — 0 issues