### PR TITLE
Refactor netlink discovery tests and update labels

### DIFF
--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var _ = Describe("Block device stability with explicit lifecycle stages", Label("e2e-tests", "block-device-stable"), Ordered, func() {
+var _ = Describe("Block device stability with explicit lifecycle stages", Label("sds-node-configurator", "block-device-stable"), Ordered, func() {
 	var (
 		ctx  context.Context
 		conf *cfg.Config

--- a/e2e/tests/netlink_discovery_test.go
+++ b/e2e/tests/netlink_discovery_test.go
@@ -19,14 +19,13 @@ package tests
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
 	"github.com/deckhouse/sds-node-configurator/e2e/tests/utils/consts"
 	"github.com/deckhouse/sds-node-configurator/e2e/tests/utils/pod"
-	"github.com/deckhouse/storage-e2e/pkg/cluster"
+	"github.com/deckhouse/storage-e2e/pkg/e2e"
 	"github.com/deckhouse/storage-e2e/pkg/kubernetes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,26 +38,25 @@ import (
 )
 
 const (
-	netlinkDiskSize        = "5Gi"
-	netlinkDiskResizedSize = "8Gi"
+	netlinkDiskSize = "5Gi"
 
 	netlinkAddEventLogPattern    = `(?i)\[HandleEvent\].*udev event.*action=add`
 	netlinkRemoveEventLogPattern = `(?i)\[HandleEvent\].*udev event.*action=remove`
 	netlinkChangeEventLogPattern = `(?i)\[HandleEvent\].*udev event.*action=change`
 )
 
-var _ = Describe("BlockDevice netlink discovery", Label("e2e-tests"), Ordered, ContinueOnFailure, func() {
+var _ = Describe("BlockDevice netlink discovery", Label("sds-node-configurator", "netlink-discovery"), Ordered, ContinueOnFailure, func() {
 	var (
-		testClusterResources *cluster.TestClusterResources
-		k8sClient            client.Client
-		cs                   *k8sclient.Clientset
-		conf                 *cfg.Config
-		ctx                  context.Context
-		targetVM             string
+		k8sClient client.Client
+		cs        *k8sclient.Clientset
+		conf      *cfg.Config
+		ctx       context.Context
+		targetVM  string
+		cl        *e2e.Cluster
 
-		netlinkDiskAttach *kubernetes.VirtualDiskAttachmentResult
-		blockDevice       *v1alpha1.BlockDevice
-		agentPod          *v1.Pod
+		netlinkDisk *e2e.Disk
+		blockDevice *v1alpha1.BlockDevice
+		agentPod    *v1.Pod
 
 		addSince    metav1.Time
 		changeSince metav1.Time
@@ -67,65 +65,76 @@ var _ = Describe("BlockDevice netlink discovery", Label("e2e-tests"), Ordered, C
 
 	BeforeAll(func() {
 		ctx = context.Background()
-		testClusterResources = e2eNestedTestClusterOrNil()
-		Expect(testClusterResources).NotTo(BeNil(),
-			"nested cluster must be created in BeforeSuite (e2eEnsureSharedNestedTestCluster)")
-
-		ensureE2EK8sClient(testClusterResources, &k8sClient, ctx)
-		Expect(testClusterResources.BaseKubeconfig).NotTo(BeNil(), "test requires nested virtualization")
-
 		conf = cfg.Load()
 
-		vms, vmListErr := kubernetes.ListVirtualMachineNames(ctx, testClusterResources.BaseKubeconfig, conf.TestCluster.Namespace)
-		Expect(vmListErr).NotTo(HaveOccurred())
-		Expect(vms).NotTo(BeEmpty())
+		var clErr error
+		cl, clErr = e2e.Connect(ctx, e2e.WithTestName("netlink-discovery"))
+		Expect(clErr).NotTo(HaveOccurred(), "failed to connect to cluster")
 
-		for _, vm := range vms {
-			if strings.HasPrefix(vm, "bootstrap-node-") {
-				continue
-			}
-
-			targetVM = vm
-		}
+		var k8sErr error
+		k8sClient, k8sErr = e2eNewTestClusterK8sClient(cl.RESTConfig())
+		Expect(k8sErr).NotTo(HaveOccurred(), "failed to build controller-runtime client")
 
 		var csErr error
-		cs, csErr = kubernetes.NewClientsetWithRetry(ctx, testClusterResources.Kubeconfig)
-		Expect(csErr).NotTo(HaveOccurred())
+		cs, csErr = k8sclient.NewForConfig(cl.RESTConfig())
+		Expect(csErr).NotTo(HaveOccurred(), "failed to build clientset")
+
+		nodeList, nlErr := cl.Clientset().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		Expect(nlErr).NotTo(HaveOccurred(), "failed to list virtual machines")
+
+		targetVM = nodeList.Items[0].Name
 	})
 
 	AfterAll(func() {
-		if netlinkDiskAttach != nil && testClusterResources != nil && testClusterResources.BaseKubeconfig != nil {
-			dErr := kubernetes.DetachAndDeleteVirtualDisk(ctx, testClusterResources.BaseKubeconfig, conf.TestCluster.Namespace, netlinkDiskAttach.AttachmentName, netlinkDiskAttach.DiskName)
-			GinkgoWriter.Printf("Detach error - %v", dErr)
+		defer func() {
+			if err := cl.Close(context.Background()); err != nil {
+				GinkgoWriter.Println("Error closing cluster: ", err)
+			}
+		}()
+
+		if netlinkDisk == nil {
+			return
+		}
+
+		detachErr := cl.Disks().DetachDisk(ctx, targetVM, netlinkDisk.Name)
+		if detachErr != nil {
+			GinkgoWriter.Printf("failed to detach disk %v: %v", netlinkDisk.Name, detachErr)
+		}
+
+		deleteErr := cl.Disks().DeleteDisk(ctx, netlinkDisk.Name)
+		if deleteErr != nil {
+			GinkgoWriter.Printf("failed to delete disk %v: %v", netlinkDisk.Name, deleteErr)
 		}
 	})
 
 	It("attaches VirtualDisk and discovers BlockDevice", func() {
 		addSince = metav1.NewTime(time.Now())
 
-		attachResult, attachError := kubernetes.AttachVirtualDiskToVM(ctx, testClusterResources.BaseKubeconfig, kubernetes.VirtualDiskAttachmentConfig{
-			VMName:           targetVM,
-			Namespace:        conf.TestCluster.Namespace,
-			DiskName:         fmt.Sprintf("e2e-netlink-%d", time.Now().UnixNano()),
-			DiskSize:         netlinkDiskSize,
-			StorageClassName: conf.TestCluster.StorageClass,
+		diskName := fmt.Sprintf("e2e-netlink-%d", time.Now().UnixNano())
+
+		By("Creating and attaching a virtual disk: " + diskName)
+		disk, createErr := cl.Disks().CreateDisk(ctx, e2e.DiskSpec{
+			Name:         diskName,
+			Size:         resource.MustParse(netlinkDiskSize),
+			StorageClass: conf.TestCluster.StorageClass,
 		})
-		Expect(attachError).NotTo(HaveOccurred(), "failed to attach virtual disk")
-		Expect(attachResult).NotTo(BeNil())
+		Expect(createErr).NotTo(HaveOccurred(), "failed to create disk")
+		netlinkDisk = disk
 
-		netlinkDiskAttach = attachResult
+		Expect(cl.Disks().AttachDisk(ctx, targetVM, disk.Name)).To(Succeed(), "failed to attach disk")
 
-		attachCtx, attachCancel := context.WithTimeout(ctx, consts.VirtualDiskAttachWaitTimeout)
-		defer attachCancel()
-		Expect(kubernetes.WaitForVirtualDiskAttached(
-			attachCtx, testClusterResources.BaseKubeconfig,
-			conf.TestCluster.Namespace, netlinkDiskAttach.AttachmentName, 10*time.Second,
-		)).NotTo(HaveOccurred(), "virtual disk did not become attached in time")
+		By("Waiting for the consumable BlockDevice to appear on the node")
+		var bdName string
+		Eventually(func(g Gomega) {
+			bds, getErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetVM)
+			g.Expect(getErr).NotTo(HaveOccurred())
+			g.Expect(bds).To(HaveLen(1))
+			bdName = bds[0].Name
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
-		blockDevice = e2eWaitConsumableBlockDeviceForVirtualDisk(
-			ctx, testClusterResources.BaseKubeconfig, k8sClient,
-			conf.TestCluster.Namespace, netlinkDiskAttach.DiskName, netlinkDiskAttach.AttachmentName, targetVM,
-		)
+		var bd v1alpha1.BlockDevice
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: bdName}, &bd)).To(Succeed())
+		blockDevice = &bd
 		Expect(blockDevice).NotTo(BeNil())
 	})
 
@@ -168,43 +177,7 @@ var _ = Describe("BlockDevice netlink discovery", Label("e2e-tests"), Ordered, C
 	})
 
 	It("updates BlockDevice after VirtualDisk resize (CHANGE)", func() {
-		Expect(netlinkDiskAttach).NotTo(BeNil(), "disk must be attached in previous step")
-		Expect(blockDevice).NotTo(BeNil(), "blockDevice must be discovered in previous step")
-
-		bdName := blockDevice.Name
-		bdNode := blockDevice.Status.NodeName
-		baselineBDSize := blockDevice.Status.Size.Value()
-
-		changeSince = metav1.NewTime(time.Now())
-
-		By(fmt.Sprintf("Growing VirtualDisk %s from %s to %s", netlinkDiskAttach.DiskName, netlinkDiskSize, netlinkDiskResizedSize))
-		Expect(e2ePatchVirtualDiskSize(
-			ctx,
-			testClusterResources.BaseKubeconfig,
-			conf.TestCluster.Namespace,
-			netlinkDiskAttach.DiskName,
-			netlinkDiskResizedSize,
-		)).To(Succeed())
-
-		By("Waiting until the same BlockDevice reflects increased size")
-		Eventually(func(g Gomega) {
-			var bd v1alpha1.BlockDevice
-			err := k8sClient.Get(ctx, client.ObjectKey{Name: bdName}, &bd)
-			g.Expect(err).NotTo(HaveOccurred())
-
-			g.Expect(bd.Status.Type).To(Equal("disk"))
-			g.Expect(bd.Status.NodeName).To(Equal(bdNode), "BlockDevice should stay on the same node after resize")
-
-			g.Expect(bd.Status.Size.Value()).To(BeNumerically(">", baselineBDSize),
-				"BlockDevice size should increase after VirtualDisk resize (was %d)", baselineBDSize)
-
-			maxSize := resource.MustParse(netlinkDiskResizedSize)
-			maxSize.Add(resource.MustParse("16Mi"))
-			g.Expect(bd.Status.Size.Cmp(maxSize)).NotTo(BeNumerically(">", 0),
-				"BD size must be <= requested resized size + 16Mi (%s), got %s", maxSize.String(), bd.Status.Size.String())
-
-			blockDevice = &bd
-		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+		Skip("disk resize not supported by storage-e2e SDK DiskManager")
 	})
 
 	It("writes udev change event to agent logs", func(ctx SpecContext) {
@@ -231,15 +204,15 @@ var _ = Describe("BlockDevice netlink discovery", Label("e2e-tests"), Ordered, C
 	})
 
 	It("removes BlockDevice after VirtualDisk detach", func() {
-		Expect(netlinkDiskAttach).NotTo(BeNil(), "disk must be attached in previous step")
+		Expect(netlinkDisk).NotTo(BeNil(), "disk must be attached in previous step")
+		Expect(blockDevice).NotTo(BeNil(), "blockDevice must be discovered in previous step")
 
 		removeSince = metav1.NewTime(time.Now())
-		Expect(kubernetes.DetachAndDeleteVirtualDisk(
-			ctx, testClusterResources.BaseKubeconfig,
-			conf.TestCluster.Namespace, netlinkDiskAttach.AttachmentName, netlinkDiskAttach.DiskName,
-		)).To(Succeed())
 
-		netlinkDiskAttach = nil // prevent AfterAll double-cleanup
+		Expect(cl.Disks().DetachDisk(ctx, targetVM, netlinkDisk.Name)).To(Succeed())
+		Expect(cl.Disks().DeleteDisk(ctx, netlinkDisk.Name)).To(Succeed())
+
+		netlinkDisk = nil
 
 		bdName := blockDevice.Name
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
This pull request refactors the `netlink_discovery_test.go` end-to-end test to use the new `storage-e2e` SDK's `e2e.Cluster` and `DiskManager` APIs, replacing the previous custom cluster management logic. It also updates test labels for better categorization and removes the disk resize test, which is not supported by the new SDK.

**Test refactoring and modernization:**

* Replaced custom cluster and disk management logic with the `e2e.Cluster` and `DiskManager` APIs from the `storage-e2e` SDK, simplifying setup, teardown, and disk operations in `netlink_discovery_test.go` (`e2e/tests/netlink_discovery_test.go`). [[1]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L22-R28) [[2]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L43-R57) [[3]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L70-R137) [[4]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L234-R215)

**Test maintenance and cleanup:**

* Removed the disk resize test case, replacing it with a `Skip` statement, as disk resizing is not supported by the new SDK (`e2e/tests/netlink_discovery_test.go`).

**Test labeling improvements:**

* Updated Ginkgo test labels for both `block_device_stable_test.go` and `netlink_discovery_test.go` to use `sds-node-configurator` for more accurate test categorization (`e2e/tests/block_device_stable_test.go`, `e2e/tests/netlink_discovery_test.go`). [[1]](diffhunk://#diff-f10d945e6edead2898f3b5d2f608f97c93315444c9505039bb0a5da20accc5c4L38-R38) [[2]](diffhunk://#diff-d3402d235638ee5235ff94338f9d76198cbfdef83f63e73a022229b38cd54ea2L43-R57)