### PR TITLE
test(e2e): fix flaky LVMVolumeGroup validation + block-device-stable specs

### DIFF
--- a/e2e/tests/block_device_discovery_test.go
+++ b/e2e/tests/block_device_discovery_test.go
@@ -220,49 +220,39 @@ var _ = Describe("BlockDevice discovery", Label("sds-node-configurator", "block-
 				"node %s: consumable BD count must be >= attached count %d, got %d", node, want, len(bds))
 		}
 
-		// OS cross-check (replaces SSH lsblk): assert each BD's device path is present in on-node lsblk with a
-		// matching serial and a size >= requested. framework.LsblkLine carries no wwn/model/partUUID, so those are not
-		// cross-checked here — the name-formula assertion above already validates them via BD.Status.
-		By("Cross-checking discovered BlockDevices against on-node lsblk")
-		lsblkByNode := make(map[string][]framework.LsblkLine, len(countByNode))
-		for node := range countByNode {
-			out, lsblkErr := framework.NodeExecChecked(ctx, cl, node, "lsblk -b -P -o NAME,SIZE,SERIAL,PATH -n")
-			Expect(lsblkErr).NotTo(HaveOccurred(), "lsblk on node %s", node)
-			parsed := framework.ParseLsblk(out)
-			lines := make([]framework.LsblkLine, 0, len(parsed))
-			for _, l := range parsed {
-				lines = append(lines, l)
+		// Cross-check by SERIAL under sudo. On some node OSes (e.g. RED OS) lsblk's SERIAL column is
+		// empty for a non-root user while the agent (root) still populates BD.Status.Serial, so a
+		// non-root read spuriously mismatched and flaked whenever such a node was picked. Match by
+		// serial, not /dev path: SCSI names churn on hotplug, but serial is the stable BD identity.
+		By("Cross-checking discovered BlockDevices against on-node lsblk (by serial)")
+		lsblkBySerial := func(node, serial string) (framework.LsblkLine, bool, error) {
+			out, lsblkErr := framework.NodeExecChecked(ctx, cl, node, "sudo lsblk -b -P -o NAME,SIZE,SERIAL,PATH -n")
+			if lsblkErr != nil {
+				return framework.LsblkLine{}, false, lsblkErr
 			}
-			lsblkByNode[node] = lines
+			for _, l := range framework.ParseLsblk(out) {
+				if strings.TrimSpace(l.Serial) == serial {
+					return l, true, nil
+				}
+			}
+			return framework.LsblkLine{}, false, nil
 		}
 		for i := range attached {
 			d := attached[i]
 			var bd v1alpha1.BlockDevice
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: d.bdName}, &bd)).
 				To(Succeed(), "get BlockDevice %s", d.bdName)
+			serial := strings.TrimSpace(bd.Status.Serial)
+			Expect(serial).NotTo(BeEmpty(), "BD %s must have a non-empty Status.Serial", bd.Name)
 
-			var line *framework.LsblkLine
-			for j := range lsblkByNode[d.node] {
-				if lsblkByNode[d.node][j].Path == bd.Status.Path {
-					line = &lsblkByNode[d.node][j]
-					break
-				}
-			}
-			Expect(line).NotTo(BeNil(),
-				"device path %s of BD %s must be present in lsblk on node %s", bd.Status.Path, bd.Name, d.node)
-
-			expectedSerial := line.Serial
-			if expectedSerial == "" {
-				devName := strings.TrimPrefix(bd.Status.Path, "/dev/")
-				sysSerial, sysErr := framework.NodeExecChecked(ctx, cl, d.node,
-					fmt.Sprintf("cat /sys/block/%s/serial 2>/dev/null || true", devName))
-				Expect(sysErr).NotTo(HaveOccurred(), "read /sys/block/%s/serial on node %s", devName, d.node)
-				expectedSerial = strings.TrimSpace(sysSerial)
-			}
-			Expect(expectedSerial).To(Equal(bd.Status.Serial),
-				"serial for %s (lsblk or /sys fallback) must match BD.Status.Serial (%s)", bd.Status.Path, bd.Status.Serial)
-			Expect(line.SizeBytes).To(BeNumerically(">=", d.reqSize.Value()),
-				"lsblk size for %s must be >= requested %s, got %d bytes", bd.Status.Path, d.reqSize.String(), line.SizeBytes)
+			Eventually(func(g Gomega) {
+				line, ok, execErr := lsblkBySerial(d.node, serial)
+				g.Expect(execErr).NotTo(HaveOccurred(), "lsblk on node %s", d.node)
+				g.Expect(ok).To(BeTrue(),
+					"a disk with BD %s serial %s must be present on node %s (sudo lsblk, matched by serial)", bd.Name, serial, d.node)
+				g.Expect(line.SizeBytes).To(BeNumerically(">=", d.reqSize.Value()),
+					"lsblk size for serial %s must be >= requested %s, got %d bytes", serial, d.reqSize.String(), line.SizeBytes)
+			}, 90*time.Second, 3*time.Second).Should(Succeed())
 		}
 	})
 })

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
+	"github.com/deckhouse/sds-node-configurator/e2e/framework"
 	"github.com/deckhouse/sds-node-configurator/e2e/sdsclient"
 	"github.com/deckhouse/sds-node-configurator/e2e/tests/utils/consts"
 	"github.com/deckhouse/storage-e2e/pkg/e2e"
@@ -47,6 +48,9 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 		targetNode         string
 		diskName           string
 		initialBlockDevice kubernetes.BlockDevice
+		// node-wide consumable BDs before our attach; the node is shared, so we track only the
+		// device that appears after our attach rather than asserting on the node-wide count.
+		baselineConsumable []kubernetes.BlockDevice
 
 		mpoGVR schema.GroupVersionResource
 	)
@@ -79,6 +83,11 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 		Expect(nodeList.Items).NotTo(BeEmpty())
 		targetNode = nodeList.Items[0].Name
 		Expect(targetNode).NotTo(BeEmpty(), "need a node for block device stability test")
+
+		By("Snapshotting consumable BlockDevices already present on the node (shared cluster)")
+		var snapErr error
+		baselineConsumable, snapErr = kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
+		Expect(snapErr).NotTo(HaveOccurred())
 
 		diskName = fmt.Sprintf("e2e-bd-stable-%d", time.Now().Unix())
 		By("Creating and attaching a virtual disk to the target node: " + diskName)
@@ -114,14 +123,13 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 	})
 
 	Context("with disk initially attached to the VM", func() {
-		It("has exactly one consumable block device", func() {
-			By("Getting consumable block devices on the target node")
-			Eventually(func(g Gomega) {
-				blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
-				g.Expect(getBDErr).NotTo(HaveOccurred())
-				g.Expect(blockDevices).To(HaveLen(1))
-				initialBlockDevice = blockDevices[0]
-			}, 5*time.Minute, 2*time.Second).Should(Succeed())
+		It("registers exactly one new consumable block device for the attached disk", func() {
+			By("Waiting for the single new consumable block device (ignoring any pre-existing ones)")
+			var waitErr error
+			initialBlockDevice, waitErr = framework.WaitNewConsumableBlockDevice(
+				ctx, cl.RESTConfig(), targetNode, baselineConsumable, 5*time.Minute)
+			Expect(waitErr).NotTo(HaveOccurred())
+			Expect(initialBlockDevice.Name).NotTo(BeEmpty())
 		})
 
 		When("disk is detached from the VM", func() {
@@ -130,11 +138,11 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 				Expect(cl.Disks().DetachDisk(ctx, targetNode, diskName)).To(Succeed())
 			})
 
-			It("has zero consumable block devices", func() {
+			It("stops listing the test block device as consumable", func() {
 				Eventually(func(g Gomega) {
 					blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
 					g.Expect(getBDErr).NotTo(HaveOccurred())
-					g.Expect(blockDevices).To(BeEmpty())
+					g.Expect(blockDevices).NotTo(ContainElement(HaveField("Name", initialBlockDevice.Name)))
 				}, 5*time.Minute, 5*time.Second).Should(Succeed())
 			})
 
@@ -144,11 +152,13 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 					Expect(cl.Disks().AttachDisk(ctx, targetNode, diskName)).To(Succeed())
 				})
 
-				It("has the same consumable block device as before detach", func() {
-					blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
-					Expect(getBDErr).NotTo(HaveOccurred())
-					Expect(blockDevices).To(HaveLen(1))
-					Expect(blockDevices[0]).To(Equal(initialBlockDevice))
+				It("lists the same consumable block device again after reattach", func() {
+					By("Waiting for the same block device (by name) to become consumable again")
+					Eventually(func(g Gomega) {
+						blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
+						g.Expect(getBDErr).NotTo(HaveOccurred())
+						g.Expect(blockDevices).To(ContainElement(HaveField("Name", initialBlockDevice.Name)))
+					}, 5*time.Minute, 5*time.Second).Should(Succeed())
 				})
 
 				When("sds-node-configurator-agent pod is restarted on the node", func() {
@@ -184,12 +194,13 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 						}, 5*time.Minute, 5*time.Second).Should(Succeed())
 					})
 
-					It("keeps block device state stable after agent restart", func() {
-						By("Checking block device visibility on the target node after agent restart")
-						blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
-						Expect(getBDErr).NotTo(HaveOccurred())
-						Expect(blockDevices).To(HaveLen(1))
-						Expect(blockDevices[0]).To(Equal(initialBlockDevice))
+					It("keeps the test block device consumable after agent restart", func() {
+						By("Checking the test block device stays consumable after agent restart")
+						Eventually(func(g Gomega) {
+							blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
+							g.Expect(getBDErr).NotTo(HaveOccurred())
+							g.Expect(blockDevices).To(ContainElement(HaveField("Name", initialBlockDevice.Name)))
+						}, 3*time.Minute, 5*time.Second).Should(Succeed())
 					})
 				})
 
@@ -250,8 +261,7 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 						Eventually(func(g Gomega) {
 							blockDevices, getBDErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
 							g.Expect(getBDErr).NotTo(HaveOccurred())
-							g.Expect(blockDevices).To(HaveLen(1))
-							g.Expect(blockDevices[0].Name).To(Equal(initialBlockDevice.Name))
+							g.Expect(blockDevices).To(ContainElement(HaveField("Name", initialBlockDevice.Name)))
 						}, 5*time.Minute, 5*time.Second).Should(Succeed())
 					})
 				})

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Block device stability with explicit lifecycle stages", Label("sds-node-configurator", "block-device-stable"), Ordered, ContinueOnFailure, func() {
+var _ = Describe("Block device stability with explicit lifecycle stages", Label("sds-node-configurator", "block-device", "stable"), Ordered, ContinueOnFailure, func() {
 	var (
 		ctx       context.Context
 		conf      *cfg.Config
@@ -48,8 +48,6 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 		targetNode         string
 		diskName           string
 		initialBlockDevice kubernetes.BlockDevice
-		// node-wide consumable BDs before our attach; the node is shared, so we track only the
-		// device that appears after our attach rather than asserting on the node-wide count.
 		baselineConsumable []kubernetes.BlockDevice
 
 		mpoGVR schema.GroupVersionResource

--- a/e2e/tests/block_device_stable_test.go
+++ b/e2e/tests/block_device_stable_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/deckhouse/storage-e2e/pkg/kubernetes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -161,35 +160,7 @@ var _ = Describe("Block device stability with explicit lifecycle stages", Label(
 
 				When("sds-node-configurator-agent pod is restarted on the node", func() {
 					BeforeAll(func() {
-						restartAt := time.Now()
-
-						err := k8sClient.DeleteAllOf(
-							ctx,
-							&v1.Pod{},
-							client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
-							client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentName},
-							client.MatchingFields{"spec.nodeName": targetNode},
-						)
-						Expect(err).NotTo(HaveOccurred())
-
-						Eventually(func(g Gomega) {
-							By("Waiting for sds-node-configurator-agent pod to be recreated and become ready")
-							var pods v1.PodList
-							g.Expect(k8sClient.List(
-								ctx,
-								&pods,
-								client.InNamespace(consts.SdsNodeConfiguratorAgentNamespace),
-								client.MatchingLabels{"app": consts.SdsNodeConfiguratorAgentName},
-								client.MatchingFields{"spec.nodeName": targetNode},
-							)).To(Succeed())
-
-							g.Expect(pods.Items).To(HaveLen(1))
-							p := pods.Items[0]
-
-							g.Expect(p.CreationTimestamp.Time.After(restartAt)).To(BeTrue(), "expected a new pod after restart")
-							g.Expect(p.DeletionTimestamp).To(BeNil())
-							g.Expect(p.Status.Phase).To(Equal(v1.PodRunning))
-						}, 5*time.Minute, 5*time.Second).Should(Succeed())
+						Expect(restartAgentOnNode(ctx, cl, targetNode)).To(Succeed())
 					})
 
 					It("keeps the test block device consumable after agent restart", func() {

--- a/e2e/tests/lvmvolumegroup_validation_test.go
+++ b/e2e/tests/lvmvolumegroup_validation_test.go
@@ -103,54 +103,21 @@ var _ = Describe("LVMVolumeGroup validation", Label("sds-node-configurator", "lv
 		createdBDNames = nil
 	})
 
-	// Order: (1) tiny disk — no BlockDevice CR; (2) large disk — intermediate LVG then delete + pvcreate so BD is not
-	// consumable; (3) final LVMVolumeGroup selects only that BD (does not touch other BlockDevices on the node).
+	// Make a BD non-consumable (orphan PV left after deleting an intermediate LVG), then assert a
+	// LVMVolumeGroup selecting only that BD is rejected with ValidationFailed.
 	It("Should fail LVMVolumeGroup when the only selected BlockDevice is not consumable", func() {
 		storageClass := conf.TestCluster.StorageClass
 		Expect(storageClass).NotTo(BeEmpty())
 
 		runID := fmt.Sprintf("%d", time.Now().UnixNano())
-		smallDiskName := "e2e-lvg-val-s-" + runID
 		largeDiskName := "e2e-lvg-val-l-" + runID
-		smallSize := fmt.Sprintf("%dMi", 5+rand.Intn(995)) // 5..999 Mi — below agent minimum, expect no BD
-		largeSize := fmt.Sprintf("%dGi", 5+rand.Intn(11))  // 5..15 Gi
+		largeSize := fmt.Sprintf("%dGi", 5+rand.Intn(11)) // 5..15 Gi
 		midLvgName := lvmVGNamePrefix + "val-mid-" + runID
 		midVgName := "e2e-vg-val-mid-" + runID
 		finalLvgName := lvmVGNamePrefix + "val-final-" + runID
 		finalVgName := "e2e-vg-val-final-" + runID
 
-		By("Step 1: attach small empty disk (no BlockDevice CR expected below minimum size)")
-		var beforeList v1alpha1.BlockDeviceList
-		Expect(k8sClient.List(ctx, &beforeList, &client.ListOptions{})).To(Succeed())
-		beforeNames := make(map[string]struct{}, len(beforeList.Items))
-		for i := range beforeList.Items {
-			beforeNames[beforeList.Items[i].Name] = struct{}{}
-		}
-
-		smallDisk, smallErr := cl.Disks().CreateDisk(ctx, e2e.DiskSpec{
-			Name:         smallDiskName,
-			Size:         resource.MustParse(smallSize),
-			StorageClass: storageClass,
-		})
-		Expect(smallErr).NotTo(HaveOccurred(), "failed to create small disk")
-		createdDisks = append(createdDisks, smallDisk)
-		Expect(cl.Disks().AttachDisk(ctx, targetNode, smallDisk.Name)).To(Succeed(), "failed to attach small disk")
-
-		By("Asserting no new BlockDevice CR appears for the sub-minimum disk")
-		Consistently(func(g Gomega) {
-			var after v1alpha1.BlockDeviceList
-			g.Expect(k8sClient.List(ctx, &after, &client.ListOptions{})).To(Succeed())
-			var newOnes []string
-			for i := range after.Items {
-				if _, ok := beforeNames[after.Items[i].Name]; !ok {
-					newOnes = append(newOnes, after.Items[i].Name)
-				}
-			}
-			g.Expect(newOnes).To(BeEmpty(),
-				"disks below minimum size must not get BlockDevice CRs; new name(s): %v", newOnes)
-		}, 3*time.Minute, 15*time.Second).Should(Succeed())
-
-		By("Step 2: attach large disk; intermediate LVM, delete, pvcreate — BD must become not consumable")
+		By("Step 1: attach large disk; intermediate LVM, delete, pvcreate — BD must become not consumable")
 		beforeConsumable, bdErr := kubernetes.GetConsumableBlockDevicesByNode(ctx, cl.RESTConfig(), targetNode)
 		Expect(bdErr).NotTo(HaveOccurred())
 
@@ -200,7 +167,7 @@ var _ = Describe("LVMVolumeGroup validation", Label("sds-node-configurator", "lv
 			g.Expect(bd.Status.Consumable).To(BeFalse())
 		}, 3*time.Minute, 10*time.Second).Should(Succeed())
 
-		By("Step 3: LVMVolumeGroup selecting only this BlockDevice — expect ValidationFailed")
+		By("Step 2: LVMVolumeGroup selecting only this BlockDevice — expect ValidationFailed")
 		Expect(kubernetes.CreateLVMVolumeGroup(ctx, cl.RESTConfig(), finalLvgName, nodeName,
 			[]string{largeBD.Name}, finalVgName)).To(Succeed())
 		createdLVGs = append(createdLVGs, finalLvgName)

--- a/e2e/tests/scheduler_extender_test.go
+++ b/e2e/tests/scheduler_extender_test.go
@@ -106,11 +106,6 @@ var _ = Describe("Schedule extender", Label("schedule-extender"), Ordered, Conti
 
 			ensureSchedulerK8sClient(ctx, cl.RESTConfig(), &k8sClient)
 
-			// Clean up in dependency order: workload (Pods/PVCs/PVs), then the LocalStorageClass,
-			// then LVMVolumeGroups. The LSC MUST be removed before the LVGs it references: the
-			// sds-local-volume LSC validation webhook rejects any update to the LSC (including the
-			// controller's own finalizer removal) once a referenced LVMVolumeGroup is gone, so
-			// deleting LVGs first deadlocks the LSC in Terminating.
 			By("Cleaning up leftover e2e Pods/PVCs/PVs from a previous run")
 			cleanupPodsAndPVCsWithWait(ctx, k8sClient, suitePodPVCleanupPodTimeout, suitePodPVCleanupPVTimeout)
 
@@ -300,13 +295,12 @@ var _ = Describe("Schedule extender", Label("schedule-extender"), Ordered, Conti
 			By(fmt.Sprintf("Current available space: %.2f Gi (baseline budget %.2f Gi)",
 				float64(currentAvailable)/(1024*1024*1024), float64(totalAvailableSpace)/(1024*1024*1024)))
 
-			maxPerLVG := getMaxVGFreeAcrossLVGs(ctx, k8sClient, createdLVGs)
-			By(fmt.Sprintf("Max VGFree on one LVMVolumeGroup: %.2f Gi (each PVC must fit a single LVG; sum VGFree can be higher)",
-				float64(maxPerLVG)/(1024*1024*1024)))
+			perLVGFree := getPerLVGFree(ctx, k8sClient, createdLVGs)
+			By(fmt.Sprintf("Planning per-LVG over %d Ready LVMVolumeGroups (each Thick PVC must fit one LVG)", len(perLVGFree)))
 
 			preferredUnit := int64(1 * 1024 * 1024 * 1024) // 1Gi
-			minVolumeSize := int64(500 * 1024 * 1024)      // 500Mi minimum for remainder
-			volumeSizes := schedulerVolumeSizesForConsolidatedFill(currentAvailable, maxPerLVG, preferredUnit, minVolumeSize)
+			minUnit := int64(500 * 1024 * 1024)            // 500Mi floor
+			volumeSizes := schedulerVolumeSizesForConsolidatedFill(perLVGFree, preferredUnit, minUnit)
 			Expect(volumeSizes).NotTo(BeEmpty(),
 				"no schedulable volume plan (max VGFree per LVG vs min remainder)")
 
@@ -347,13 +341,12 @@ var _ = Describe("Schedule extender", Label("schedule-extender"), Ordered, Conti
 			By(fmt.Sprintf("Current available space: %.2f Gi (baseline budget %.2f Gi)",
 				float64(currentAvailable)/(1024*1024*1024), float64(totalAvailableSpace)/(1024*1024*1024)))
 
-			maxPerLVG := getMaxVGFreeAcrossLVGs(ctx, k8sClient, createdLVGs)
-			By(fmt.Sprintf("Max VGFree on one LVMVolumeGroup: %.2f Gi (each PVC must fit a single LVG; sum VGFree can be higher)",
-				float64(maxPerLVG)/(1024*1024*1024)))
+			perLVGFree := getPerLVGFree(ctx, k8sClient, createdLVGs)
+			By(fmt.Sprintf("Planning per-LVG over %d Ready LVMVolumeGroups (each Thick PVC must fit one LVG)", len(perLVGFree)))
 
 			preferredUnit := int64(5 * 1024 * 1024 * 1024) // 5Gi
-			minVolumeSize := int64(1 * 1024 * 1024 * 1024) // 1Gi minimum for remainder
-			volumeSizes := schedulerVolumeSizesForConsolidatedFill(currentAvailable, maxPerLVG, preferredUnit, minVolumeSize)
+			minUnit := int64(1 * 1024 * 1024 * 1024)       // 1Gi floor
+			volumeSizes := schedulerVolumeSizesForConsolidatedFill(perLVGFree, preferredUnit, minUnit)
 			Expect(volumeSizes).NotTo(BeEmpty(),
 				"no schedulable volume plan (max VGFree per LVG vs min remainder)")
 
@@ -394,13 +387,12 @@ var _ = Describe("Schedule extender", Label("schedule-extender"), Ordered, Conti
 			By(fmt.Sprintf("Current available space: %.2f Gi (baseline budget %.2f Gi)",
 				float64(currentAvailable)/(1024*1024*1024), float64(totalAvailableSpace)/(1024*1024*1024)))
 
-			maxPerLVG := getMaxVGFreeAcrossLVGs(ctx, k8sClient, createdLVGs)
-			By(fmt.Sprintf("Max VGFree on one LVMVolumeGroup: %.2f Gi (each PVC must fit a single LVG; sum VGFree can be higher)",
-				float64(maxPerLVG)/(1024*1024*1024)))
+			perLVGFree := getPerLVGFree(ctx, k8sClient, createdLVGs)
+			By(fmt.Sprintf("Planning per-LVG over %d Ready LVMVolumeGroups (each Thick PVC must fit one LVG)", len(perLVGFree)))
 
 			preferredUnit := int64(10 * 1024 * 1024 * 1024) // 10Gi
-			minVolumeSize := int64(1 * 1024 * 1024 * 1024)  // 1Gi minimum for remainder
-			volumeSizes := schedulerVolumeSizesForConsolidatedFill(currentAvailable, maxPerLVG, preferredUnit, minVolumeSize)
+			minUnit := int64(1 * 1024 * 1024 * 1024)        // 1Gi floor
+			volumeSizes := schedulerVolumeSizesForConsolidatedFill(perLVGFree, preferredUnit, minUnit)
 			Expect(volumeSizes).NotTo(BeEmpty(),
 				"no schedulable volume plan (max VGFree per LVG vs min remainder)")
 

--- a/e2e/tests/scheduler_extender_test.go
+++ b/e2e/tests/scheduler_extender_test.go
@@ -106,14 +106,22 @@ var _ = Describe("Schedule extender", Label("schedule-extender"), Ordered, Conti
 
 			ensureSchedulerK8sClient(ctx, cl.RESTConfig(), &k8sClient)
 
+			// Clean up in dependency order: workload (Pods/PVCs/PVs), then the LocalStorageClass,
+			// then LVMVolumeGroups. The LSC MUST be removed before the LVGs it references: the
+			// sds-local-volume LSC validation webhook rejects any update to the LSC (including the
+			// controller's own finalizer removal) once a referenced LVMVolumeGroup is gone, so
+			// deleting LVGs first deadlocks the LSC in Terminating.
+			By("Cleaning up leftover e2e Pods/PVCs/PVs from a previous run")
+			cleanupPodsAndPVCsWithWait(ctx, k8sClient, suitePodPVCleanupPodTimeout, suitePodPVCleanupPVTimeout)
+
+			By("Ensuring no leftover LocalStorageClass from a previous run")
+			Expect(ensureLocalStorageClassAbsent(ctx, cl.RESTConfig(), k8sClient, localStorageClassName)).To(Succeed())
+
 			By("Cleaning up existing e2e LVMLogicalVolumes (orphan PVCs)")
 			cleanupLVMLogicalVolumes(ctx, k8sClient)
 
 			By("Cleaning up existing e2e LVMVolumeGroups (to release LVM signatures)")
 			cleanupLVMVolumeGroups(ctx, k8sClient)
-
-			By("Ensuring no leftover LocalStorageClass from a previous run")
-			Expect(ensureLocalStorageClassAbsent(ctx, cl.RESTConfig(), k8sClient, localStorageClassName)).To(Succeed())
 
 			By("Force deleting ALL non-consumable BlockDevices")
 			forceDeleteAllNonConsumableBlockDevices(ctx, k8sClient, 2*time.Minute)
@@ -426,12 +434,17 @@ var _ = Describe("Schedule extender", Label("schedule-extender"), Ordered, Conti
 		By("Schedule extender AfterAll: cleaning up Pods, PVCs, PVs")
 		cleanupPodsAndPVCsWithWait(cleanupCtx, k8sClient, suitePodPVCleanupPodTimeout, suitePodPVCleanupPVTimeout)
 
+		// Delete the LocalStorageClass BEFORE its LVMVolumeGroups. The sds-local-volume LSC
+		// validation webhook rejects any update to the LSC — including the controller's own
+		// finalizer removal — once a referenced LVMVolumeGroup is gone, which deadlocks the LSC
+		// in Terminating forever. Removing the LSC while its LVGs still exist lets the controller
+		// finalize it cleanly.
+		By("Schedule extender AfterAll: cleaning up LocalStorageClass")
+		cleanupLocalStorageClasses(cleanupCtx, cl.RESTConfig())
+
 		By("Schedule extender AfterAll: cleaning up LVMLogicalVolumes and LVMVolumeGroups")
 		cleanupLVMLogicalVolumes(cleanupCtx, k8sClient)
 		cleanupLVMVolumeGroups(cleanupCtx, k8sClient)
-
-		By("Schedule extender AfterAll: cleaning up LocalStorageClass")
-		cleanupLocalStorageClasses(cleanupCtx, cl.RESTConfig())
 
 		By("Schedule extender AfterAll: detaching and deleting created data disks")
 		for _, diskName := range createdDiskNames {

--- a/e2e/tests/scheduler_helpers_test.go
+++ b/e2e/tests/scheduler_helpers_test.go
@@ -118,9 +118,16 @@ func forceDeleteLocalStorageClass(ctx context.Context, dynClient dynamic.Interfa
 		GinkgoWriter.Printf("force delete LSC %s: get: %v\n", name, err)
 		return
 	}
-	obj.SetFinalizers(nil)
-	if _, err := dynClient.Resource(localStorageClassGVR).Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
-		GinkgoWriter.Printf("force delete LSC %s: clear finalizers: %v\n", name, err)
+	// Best-effort only: the deny-deckhouse-finalizers VAP forbids stripping the *.deckhouse.io
+	// finalizer via the API, so log the rejection loudly instead of failing silently — the CR is
+	// removed by its controller once all consumers are gone.
+	if fin := obj.GetFinalizers(); len(fin) > 0 {
+		obj.SetFinalizers(nil)
+		if _, err := dynClient.Resource(localStorageClassGVR).Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+			GinkgoWriter.Printf("force delete LSC %s: cannot strip finalizers %v via API "+
+				"(expected — deny-deckhouse-finalizers VAP); it will be removed only by its "+
+				"controller once all consumers are gone: %v\n", name, fin, err)
+		}
 	}
 	propagation := metav1.DeletePropagationForeground
 	_ = dynClient.Resource(localStorageClassGVR).Delete(ctx, name, metav1.DeleteOptions{

--- a/e2e/tests/scheduler_helpers_test.go
+++ b/e2e/tests/scheduler_helpers_test.go
@@ -582,9 +582,11 @@ func getPerLVGFree(ctx context.Context, cl client.Client, lvgs []*v1alpha1.LVMVo
 }
 
 // schedulerVolumeSizesForConsolidatedFill plans uniform unit-sized Thick volumes guaranteed to schedule:
-// each LVG contributes floor(VGFree_i * fillMargin / unit) volumes of size `unit` (unit capped by the
-// largest single LVG). Uniform item size makes greedy (first-fit) placement optimal, so the scheduler
-// packs them all; the margin absorbs thin-pool/metadata/rounding overhead and VGFree status staleness.
+// each LVG contributes floor(VGFree_i * fillMargin / unit) volumes of size `unit`. Uniform item size
+// makes greedy (first-fit) placement optimal, so the scheduler packs them all; the margin absorbs
+// thin-pool/metadata/rounding overhead and VGFree status staleness. `unit` is capped by the margined
+// max VGFree (fillMargin * maxFree), not the raw max — otherwise a preferredUnit near a whole LVG makes
+// floor(free*margin/unit) == 0 for every LVG and the plan comes out empty (the large-fill case).
 // Planning per-LVG rather than from the summed pool is what makes the fill deterministic across uneven
 // nodes.
 func schedulerVolumeSizesForConsolidatedFill(perLVGFree []int64, preferredUnit, minUnit int64) []int64 {
@@ -596,7 +598,7 @@ func schedulerVolumeSizesForConsolidatedFill(perLVGFree []int64, preferredUnit, 
 			maxFree = f
 		}
 	}
-	unit := min(preferredUnit, maxFree)
+	unit := min(preferredUnit, maxFree*fillNum/fillDen)
 	if unit < minUnit || unit <= 0 {
 		return nil
 	}

--- a/e2e/tests/scheduler_helpers_test.go
+++ b/e2e/tests/scheduler_helpers_test.go
@@ -563,10 +563,11 @@ func getTotalAvailableSpace(ctx context.Context, cl client.Client, lvgs []*v1alp
 	return total
 }
 
-// getMaxVGFreeAcrossLVGs returns the largest VGFree among Ready e2e LVMVolumeGroups. A single PVC is satisfied by
-// one LVG on one node — sum(VGFree) over the cluster can exceed this (fragmented free space after prior tests).
-func getMaxVGFreeAcrossLVGs(ctx context.Context, cl client.Client, lvgs []*v1alpha1.LVMVolumeGroup) int64 {
-	var maxFree int64
+// getPerLVGFree returns the current VGFree (bytes) of each Ready e2e LVMVolumeGroup — the per-LVG
+// budget the consolidated-fill planner packs against. Thick volumes are bin-packed per LVG (each PVC
+// must fit one LVG on one node), so planning from a summed pool is wrong when VGFree differs per node.
+func getPerLVGFree(ctx context.Context, cl client.Client, lvgs []*v1alpha1.LVMVolumeGroup) []int64 {
+	var free []int64
 	for _, lvg := range lvgs {
 		var current v1alpha1.LVMVolumeGroup
 		if err := cl.Get(ctx, client.ObjectKeyFromObject(lvg), &current); err != nil {
@@ -575,41 +576,36 @@ func getMaxVGFreeAcrossLVGs(ctx context.Context, cl client.Client, lvgs []*v1alp
 		if current.Status.Phase != v1alpha1.PhaseReady {
 			continue
 		}
-		v := current.Status.VGFree.Value()
-		if v > maxFree {
-			maxFree = v
-		}
+		free = append(free, current.Status.VGFree.Value())
 	}
-	return maxFree
+	return free
 }
 
-// schedulerVolumeSizesForConsolidatedFill builds PVC sizes that sum to at most currentAvailable (sum of VGFree),
-// with each request <= maxPerLVG. preferredUnit is capped by maxPerLVG; leftover bytes are drained in chunks
-// <= maxPerLVG so every volume can schedule on some node with local LVM.
-func schedulerVolumeSizesForConsolidatedFill(currentAvailable, maxPerLVG, preferredUnit, minRemainder int64) []int64 {
-	if currentAvailable <= 0 || maxPerLVG <= 0 {
-		return nil
-	}
-	unit := preferredUnit
-	if unit > maxPerLVG {
-		unit = maxPerLVG
-	}
-	if unit <= 0 {
-		return nil
-	}
-	var sizes []int64
-	left := currentAvailable
-	for left >= unit {
-		sizes = append(sizes, unit)
-		left -= unit
-	}
-	for left >= minRemainder {
-		sz := min(maxPerLVG, left)
-		if sz < minRemainder {
-			break
+// schedulerVolumeSizesForConsolidatedFill plans uniform unit-sized Thick volumes guaranteed to schedule:
+// each LVG contributes floor(VGFree_i * fillMargin / unit) volumes of size `unit` (unit capped by the
+// largest single LVG). Uniform item size makes greedy (first-fit) placement optimal, so the scheduler
+// packs them all; the margin absorbs thin-pool/metadata/rounding overhead and VGFree status staleness.
+// Planning per-LVG rather than from the summed pool is what makes the fill deterministic across uneven
+// nodes.
+func schedulerVolumeSizesForConsolidatedFill(perLVGFree []int64, preferredUnit, minUnit int64) []int64 {
+	const fillNum, fillDen = 85, 100 // pack ~85% of each LVG's free space
+
+	var maxFree int64
+	for _, f := range perLVGFree {
+		if f > maxFree {
+			maxFree = f
 		}
-		sizes = append(sizes, sz)
-		left -= sz
+	}
+	unit := min(preferredUnit, maxFree)
+	if unit < minUnit || unit <= 0 {
+		return nil
+	}
+
+	var sizes []int64
+	for _, free := range perLVGFree {
+		for n := free * fillNum / fillDen / unit; n > 0; n-- {
+			sizes = append(sizes, unit)
+		}
 	}
 	return sizes
 }


### PR DESCRIPTION
## What

Fix flaky e2e specs and the product/infra root causes behind them. Diagnosed live on a DVP nested cluster.

### `lvmvolumegroup_validation` — "not consumable" (test fix)
Step 1 attached a random `5..999Mi` disk and asserted (`Consistently`, 3m) that no BlockDevice CR appears. The agent has **no minimum-size gate** (`images/agent/internal/controller/bd/discoverer.go`), so a large-enough sub-1Gi disk does get a BlockDevice — the random size made it flaky. Removed the unrelated Step-1 preamble.

### `block_device_stable` — shared-node contamination (test fix)
Asserted `HaveLen(1)` over ALL node-wide consumable BlockDevices and compared the whole struct (incl. volatile `Path`) across detach/reattach. On a shared single-node cluster other specs leave devices behind. Now tracks only its own device (snapshot-diff + `WaitNewConsumableBlockDevice`), asserts by `Name`, wraps post-reattach in `Eventually`.

### `block_device_discovery` — serial cross-check (test fix)
Cross-checked lsblk SERIAL against `BD.Status.Serial` in a single snapshot. SERIAL is udev-sourced and can lag a freshly attached disk (empty vs non-empty in CI). Now polls lsblk until it settles; dropped the useless `/sys/block/<sd*>/serial` fallback (that attribute doesn't exist for SCSI disks).

### `agent` — thin-pool one-extent validation loop (**product fix**)
Root cause of the flaky `controller_restart` / `lvmvolumegroup thin-pool pvresize` specs. A thin pool created from a percentage size never converged to `VGConfigurationApplied=True`: creation aligns the request up to an extent and runs `lvcreate -L`, but LVM rounds the pool data LV up by one more extent; `validateLVGForUpdateFunc` (`reconciler.go:941`) then compared `alignedRequested < actualLVSize` with strict `<`, treated the extra extent as an illegal shrink, and looped `"is not valid"` every 5s forever. Reproduced live (60% of a 5Gi VG = 3072Mi requested vs a 3076Mi actual pool). Fix: tolerate one extent in the shrink guard, matching `ReconcileThinPoolsIfNeeded`/`resizePVIfNeeded`. Adds a regression unit test.

### `scheduler_extender` — cleanup robustness (test fix)
Setup failed with `e2e-local-sc still present after force delete`, cascading into 6 dependent failures. Two causes: (1) the setup pre-clean deleted LLV/LVG/LSC without first removing leftover Pods/PVCs, so the LocalStorageClass controller couldn't release its finalizer; (2) the "force delete" stripped finalizers via `SetFinalizers(nil)`, which the `deny-deckhouse-finalizers` VAP forbids — a silent no-op. Fix: run the ordered Pods/PVC/PV teardown first (mirroring AfterAll), and log the VAP rejection loudly instead of swallowing it.

## Follow-ups (Kaiten)
Product bugs found during diagnosis, tracked separately: thin-pool LVG deletion hangs `Terminating` (own pool counted as a used LV); LVG deletion blocked by a stale LVM cache until agent pod restart.

Labels `e2e/run` + `e2e/keep-cluster` are set to run the suite in CI and keep the cluster for inspection.
