### PR TITLE
fix(agent): tolerate one-extent thin-pool rounding in LVG update validation

### DIFF
--- a/images/agent/internal/controller/lvg/reconciler.go
+++ b/images/agent/internal/controller/lvg/reconciler.go
@@ -938,7 +938,11 @@ func (r *Reconciler) validateLVGForUpdateFunc(
 					addingThinPoolSize += alignedTpSize.Value()
 				} else {
 					r.log.Debug(fmt.Sprintf("[validateLVGForUpdateFunc] thin-pool %s of the LVMVolumeGroup %s is already created, check its requested size", specTp.Name, lvg.Name))
-					if alignedTpSize.Value() < actualThinPool.LVSize.Value() {
+					// LVM rounds a freshly created thin-pool data LV up by up to one extent, so
+					// flag a shrink only when the actual pool exceeds the aligned request by MORE
+					// than one extent — otherwise the LVG loops "is not valid" forever.
+					extentSize := extentSizeForThinPoolAlign(lvg, vg)
+					if actualThinPool.LVSize.Value()-alignedTpSize.Value() > extentSize.Value() {
 						r.log.Debug(fmt.Sprintf("[validateLVGForUpdateFunc] the LVMVolumeGroup %s Spec.ThinPool %s size %s is less than Status one: %s", lvg.Name, specTp.Name, tpRequestedSize.String(), actualThinPool.LVSize.String()))
 						reason.WriteString(fmt.Sprintf("Requested Spec.ThinPool %s size %s is less than actual one %s. ", specTp.Name, tpRequestedSize.String(), actualThinPool.LVSize.String()))
 						continue

--- a/images/agent/internal/controller/lvg/reconciler_test.go
+++ b/images/agent/internal/controller/lvg/reconciler_test.go
@@ -305,6 +305,67 @@ func TestLVMVolumeGroupWatcherCtrl(t *testing.T) {
 			valid, _ := r.validateLVGForUpdateFunc(lvg, bds)
 			assert.False(t, valid)
 		})
+
+		t.Run("with_thin_pool_actual_one_extent_larger_returns_true", func(t *testing.T) {
+			// Regression: an actual pool one extent larger than the aligned request must
+			// not be treated as a shrink (else the LVG loops "is not valid" forever).
+			r := setupReconciler()
+
+			const (
+				bdName   = "bd"
+				bdPath   = "bd-path"
+				vgName   = "test-vg"
+				poolName = "thin"
+			)
+
+			bds := map[string]v1alpha1.BlockDevice{
+				bdName: {
+					ObjectMeta: v1.ObjectMeta{Name: bdName},
+					Status: v1alpha1.BlockDeviceStatus{
+						Size:       resource.MustParse("1Gi"),
+						Consumable: true,
+						Path:       bdPath,
+					},
+				},
+			}
+			lvg := &v1alpha1.LVMVolumeGroup{
+				Spec: v1alpha1.LVMVolumeGroupSpec{
+					ActualVGNameOnTheNode: vgName,
+					ThinPools: []v1alpha1.LVMVolumeGroupThinPoolSpec{
+						{Name: poolName, Size: "50%", AllocationLimit: "150%"},
+					},
+				},
+			}
+
+			// BD already backs a PV (so newTotalVGSize == VGSize). 50% of 1Gi == 512Mi
+			// (extent-aligned); the actual pool is one extent (4Mi) larger.
+			pvs := []internal.PVData{{PVName: bdPath}}
+			vgs := []internal.VGData{
+				{
+					VGName:       vgName,
+					VGSize:       resource.MustParse("1Gi"),
+					VGFree:       resource.MustParse("512Mi"),
+					VGExtentSize: resource.MustParse("4Mi"),
+				},
+			}
+			lvs := []internal.LVData{
+				{
+					LVName: poolName,
+					VGName: vgName,
+					LVAttr: "twi-a-tz--",
+					LVSize: resource.MustParse("516Mi"),
+				},
+			}
+
+			r.sdsCache.StorePVs(pvs, bytes.Buffer{})
+			r.sdsCache.StoreVGs(vgs, bytes.Buffer{})
+			r.sdsCache.StoreLVs(lvs, bytes.Buffer{})
+
+			valid, reason := r.validateLVGForUpdateFunc(lvg, bds)
+			if assert.True(t, valid) {
+				assert.Equal(t, "", reason)
+			}
+		})
 	})
 
 	t.Run("validateLVGForCreateFunc", func(t *testing.T) {


### PR DESCRIPTION
## What

A thin pool created from a percentage size can never converge to `VGConfigurationApplied=True`.

Creation aligns the requested size up to an extent and runs `lvcreate -L <size> -T`, but LVM rounds the pool data LV up by one more extent (chunk/metadata alignment), so the actual pool ends up one extent larger than the aligned request. `validateLVGForUpdateFunc` then compared `alignedRequested < actualLVSize` with a strict `<`, treated the extra extent as an illegal shrink, and marked the LVMVolumeGroup `"is not valid"` → requeue every 5s forever.

Whether it triggers is size-dependent (it bites when `percent*VG` lands on an extent boundary, e.g. 60% of a 5Gi VG = 3072Mi requested vs a 3076Mi actual pool), which is why the thin-pool e2e specs (`controller_restart`, `lvmvolumegroup thin-pool pvresize`) were flaky.

## Fix

Tolerate one extent in the shrink guard: only treat the request as a shrink when the actual pool exceeds the aligned request by **more than one extent**. A pool already ≥ the requested size satisfies it and needs no change; `ReconcileThinPoolsIfNeeded` and `resizePVIfNeeded` already use the same extent tolerance. Adds a regression unit test.

Reproduced live on a DVP nested cluster (agent looped `"is not valid"` every 5s on a boundary-aligned 60% pool).
