### PR TITLE
feat(scheduler-extender): take Pod PVCs from the extra-pvcs annotation

### DIFF
--- a/images/sds-common-scheduler-extender/pkg/consts/consts.go
+++ b/images/sds-common-scheduler-extender/pkg/consts/consts.go
@@ -23,6 +23,14 @@ const (
 	LvmTypeParamKey         = "local.csi.storage.deckhouse.io/lvm-type"
 	LVMVolumeGroupsParamKey = "local.csi.storage.deckhouse.io/lvm-volume-groups"
 
+	// PodExtraPVCsAnnotation lists, as a comma-separated value, the names of
+	// PersistentVolumeClaims a Pod needs taken into account when scheduling but
+	// does not mount itself (e.g. a KubeVirt hotplug disk, which is attached by a
+	// separate attachment Pod pinned to the launcher's node). The PVCs are always
+	// looked up in the Pod's own namespace. It is a best-effort scheduling hint:
+	// unknown or foreign-provisioner names are ignored.
+	PodExtraPVCsAnnotation = "scheduler.deckhouse.io/extra-pvcs"
+
 	Thick = "Thick"
 	Thin  = "Thin"
 )

--- a/images/sds-common-scheduler-extender/pkg/consts/consts.go
+++ b/images/sds-common-scheduler-extender/pkg/consts/consts.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2025 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package consts

--- a/images/sds-common-scheduler-extender/pkg/consts/consts.go
+++ b/images/sds-common-scheduler-extender/pkg/consts/consts.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package consts
@@ -29,6 +29,12 @@ const (
 	// separate attachment Pod pinned to the launcher's node). The PVCs are always
 	// looked up in the Pod's own namespace. It is a best-effort scheduling hint:
 	// unknown or foreign-provisioner names are ignored.
+	//
+	// Contract for the producer: every PVC named here MUST already exist by the
+	// time the Pod is created. The extender resolves the names once, while running
+	// filter/prioritize for this Pod; a name that does not resolve is skipped and
+	// there is no second attempt — the hint is silently lost and the Pod is
+	// scheduled as blindly as it was before this annotation existed.
 	PodExtraPVCsAnnotation = "scheduler.deckhouse.io/extra-pvcs"
 
 	Thick = "Thick"

--- a/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/consts"
+)
+
+func TestPodExtraPVCsAnnotationKey(t *testing.T) {
+	// The key is a cross-module contract (producer lives in the virtualization
+	// module). Pin the exact string so a rename cannot happen silently.
+	assert.Equal(t, "scheduler.deckhouse.io/extra-pvcs", consts.PodExtraPVCsAnnotation)
+}
+
+func TestParseExtraPVCNames(t *testing.T) {
+	tt := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{name: "empty value", value: "", want: nil},
+		{name: "single name", value: "pvc-a", want: []string{"pvc-a"}},
+		{name: "two names", value: "pvc-a,pvc-b", want: []string{"pvc-a", "pvc-b"}},
+		{name: "surrounding spaces are trimmed", value: " pvc-a , pvc-b ", want: []string{"pvc-a", "pvc-b"}},
+		{name: "empty entries are ignored", value: ",,pvc-a,,pvc-b,", want: []string{"pvc-a", "pvc-b"}},
+		{name: "only separators and spaces", value: " , , ", want: nil},
+		{name: "order is preserved", value: "b,a,c", want: []string{"b", "a", "c"}},
+		{name: "duplicates are kept (dedup happens later)", value: "pvc-a,pvc-a", want: []string{"pvc-a", "pvc-a"}},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseExtraPVCNames(tc.value))
+		})
+	}
+}

--- a/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
@@ -17,19 +17,27 @@ limitations under the License.
 package scheduler
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	d8commonapi "github.com/deckhouse/sds-common-lib/api/v1alpha1"
 	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/consts"
 	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/logger"
+	srv "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 )
 
 func TestPodExtraPVCsAnnotationKey(t *testing.T) {
@@ -222,4 +230,168 @@ func TestGetManagedPVCsFromPod_ExtraPVCsAnnotation(t *testing.T) {
 			assert.Equal(t, want, got)
 		})
 	}
+}
+
+const (
+	extraPVCsTestTenGiB     = int64(10 * 1024 * 1024 * 1024)
+	extraPVCsTestHundredGiB = int64(100 * 1024 * 1024 * 1024)
+	extraPVCsTestOneGiB     = int64(1024 * 1024 * 1024)
+)
+
+// pendingPVCWithSize is testPendingPVC with a caller-chosen request size.
+func pendingPVCWithSize(name, namespace, scName string, size int64) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *resource.NewQuantity(size, resource.BinarySI),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+}
+
+// callFilter posts args to the /filter handler and returns the decoded result.
+func callFilter(t *testing.T, s *scheduler, args ExtenderArgs) ExtenderFilterResult {
+	t.Helper()
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/scheduler/filter", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.filter(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "filter must answer 200; body: %s", w.Body.String())
+	var result ExtenderFilterResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	return result
+}
+
+// TestFilter_AnnotationPVC_LocalRejectsNodeWithoutSpace is the core proof of the
+// feature: a Pod with an EMPTY spec.volumes (the virt-launcher shape) and only the
+// extra-pvcs annotation must still be filtered by free space, and must get a
+// reservation on the surviving node.
+func TestFilter_AnnotationPVC_LocalRejectsNodeWithoutSpace(t *testing.T) {
+	const scName = "local-sc"
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scName},
+		Provisioner: consts.SdsLocalVolumeProvisioner,
+		Parameters: map[string]string{
+			consts.LvmTypeParamKey:         consts.Thick,
+			consts.LVMVolumeGroupsParamKey: "- name: lvg-a\n- name: lvg-b\n",
+		},
+	}
+
+	cl := newFakeClient(
+		sc,
+		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),
+		readyLVGOnNode("lvg-a", "node-a", extraPVCsTestHundredGiB, extraPVCsTestHundredGiB),
+		readyLVGOnNode("lvg-b", "node-b", extraPVCsTestHundredGiB, extraPVCsTestOneGiB),
+	)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node-a", "node-b"}
+	result := callFilter(t, s, ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "virt-launcher",
+				Namespace:   "default",
+				Annotations: map[string]string{consts.PodExtraPVCsAnnotation: "pvc-hotplug"},
+			},
+			// No Volumes on purpose: KubeVirt keeps hotplug disks out of the launcher spec.
+		},
+		NodeNames: &nodeNames,
+	})
+
+	require.NotNil(t, result.NodeNames)
+	assert.Equal(t, []string{"node-a"}, *result.NodeNames, "only the node with free space must survive")
+	assert.Contains(t, result.FailedNodes["node-b"], "does not have enough space for PVC",
+		"the rejection reason must name the space problem so it surfaces in the Pod's FailedScheduling event")
+
+	assert.True(t, c.HasReservation("default/pvc-hotplug"),
+		"the annotation PVC must get the same 60s reservation a spec PVC gets (spec section 4)")
+}
+
+// TestFilter_NoAnnotation_PodWithoutPVCsIsNoOp pins backward compatibility at the
+// handler level: without the annotation, a Pod with no PVCs gets every node back
+// and no reservation is created.
+func TestFilter_NoAnnotation_PodWithoutPVCsIsNoOp(t *testing.T) {
+	const scName = "local-sc"
+
+	cl := newFakeClient(
+		testLocalSC(scName, "lvg-a"),
+		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),
+		readyLVGOnNode("lvg-a", "node-a", extraPVCsTestHundredGiB, extraPVCsTestHundredGiB),
+		readyLVGOnNode("lvg-b", "node-b", extraPVCsTestHundredGiB, extraPVCsTestOneGiB),
+	)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node-a", "node-b"}
+	result := callFilter(t, s, ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "virt-launcher", Namespace: "default"},
+		},
+		NodeNames: &nodeNames,
+	})
+
+	require.NotNil(t, result.NodeNames)
+	assert.ElementsMatch(t, nodeNames, *result.NodeNames, "without the annotation the extender must stay a no-op")
+	assert.Empty(t, result.FailedNodes)
+	assert.False(t, c.HasReservation("default/pvc-hotplug"))
+}
+
+// TestFilter_AnnotationPVC_ReplicatedLocalAccess covers the replicated cell of the
+// coverage matrix (spec section 2.3): unbound replicated PVC with
+// volumeAccess=Local must space-reject nodes that carry no LVG from the pool.
+// The e2e stand has no sds-replicated-volume module, so this is the coverage for
+// that path.
+func TestFilter_AnnotationPVC_ReplicatedLocalAccess(t *testing.T) {
+	const (
+		scName  = "repl-sc"
+		rspName = "repl-pool"
+	)
+
+	cl := newFakeClient(
+		testSC(scName, consts.SdsReplicatedVolumeProvisioner),
+		testRSC(scName, srv.VolumeAccessLocal, rspName),
+		testRSP(rspName, srv.ReplicatedStoragePoolTypeLVM, "lvg-a"),
+		readyLVGOnNode("lvg-a", "node-a", extraPVCsTestHundredGiB, extraPVCsTestHundredGiB),
+		testNode("node-a", true),
+		testNode("node-b", true),
+		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),
+		&d8commonapi.ModuleConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "sds-replicated-volume"},
+			Spec: d8commonapi.ModuleConfigSpec{
+				Settings: d8commonapi.SettingsValues{"newControlPlane": true},
+			},
+		},
+	)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsReplicatedVolumeProvisioner}
+
+	nodeNames := []string{"node-a", "node-b"}
+	result := callFilter(t, s, ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "virt-launcher",
+				Namespace:   "default",
+				Annotations: map[string]string{consts.PodExtraPVCsAnnotation: "pvc-hotplug"},
+			},
+		},
+		NodeNames: &nodeNames,
+	})
+
+	require.NotNil(t, result.NodeNames)
+	assert.Equal(t, []string{"node-a"}, *result.NodeNames,
+		"only the node carrying an LVG of the replicated storage pool must survive")
+	assert.Contains(t, result.FailedNodes["node-b"], "no LVG from RSP repl-pool found on node node-b")
 }

--- a/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
@@ -17,11 +17,19 @@ limitations under the License.
 package scheduler
 
 import (
+	"context"
+	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/consts"
+	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/logger"
 )
 
 func TestPodExtraPVCsAnnotationKey(t *testing.T) {
@@ -49,6 +57,169 @@ func TestParseExtraPVCNames(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, parseExtraPVCNames(tc.value))
+		})
+	}
+}
+
+// podWithPVCs builds a Pod whose spec.volumes reference specPVCs and whose
+// extra-pvcs annotation is set to annotation (omitted entirely when empty).
+func podWithPVCs(annotation string, specPVCs ...string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+	for i, name := range specPVCs {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: fmt.Sprintf("v%d", i),
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: name},
+			},
+		})
+	}
+	if annotation != "" {
+		pod.Annotations = map[string]string{consts.PodExtraPVCsAnnotation: annotation}
+	}
+	return pod
+}
+
+func TestPodPVCNames(t *testing.T) {
+	t.Run("no annotation returns only spec volumes", func(t *testing.T) {
+		names, fromSpec := podPVCNames(podWithPVCs("", "pvc-a", "pvc-b"))
+		assert.Equal(t, []string{"pvc-a", "pvc-b"}, names)
+		assert.Equal(t, map[string]bool{"pvc-a": true, "pvc-b": true}, fromSpec)
+	})
+
+	t.Run("annotation names are appended after spec names", func(t *testing.T) {
+		names, fromSpec := podPVCNames(podWithPVCs("pvc-x,pvc-y", "pvc-a"))
+		assert.Equal(t, []string{"pvc-a", "pvc-x", "pvc-y"}, names)
+		assert.True(t, fromSpec["pvc-a"])
+		assert.False(t, fromSpec["pvc-x"])
+	})
+
+	t.Run("a name in both sources appears once and counts as spec-sourced", func(t *testing.T) {
+		names, fromSpec := podPVCNames(podWithPVCs("pvc-a", "pvc-a"))
+		assert.Equal(t, []string{"pvc-a"}, names)
+		assert.True(t, fromSpec["pvc-a"], "spec origin must win: a missing spec PVC still has to fail the request")
+	})
+
+	t.Run("non-PVC volumes are ignored", func(t *testing.T) {
+		pod := podWithPVCs("", "pvc-a")
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name:         "scratch",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+		names, _ := podPVCNames(pod)
+		assert.Equal(t, []string{"pvc-a"}, names)
+	})
+}
+
+func TestGetManagedPVCsFromPod_ExtraPVCsAnnotation(t *testing.T) {
+	log, err := logger.NewLogger("0")
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	const (
+		localSCName   = "e2e-local-sc"
+		foreignSCName = "foreign-sc"
+	)
+
+	// Objects shared by every case: a local SC our extender manages, a foreign SC
+	// it must ignore, and one PVC for each.
+	objects := func() []client.Object {
+		return []client.Object{
+			testLocalSC(localSCName, "lvg1"),
+			testSC(foreignSCName, "foreign.csi.example.com"),
+			testPendingPVC("pvc-spec", "default", localSCName),
+			testPendingPVC("pvc-hint", "default", localSCName),
+			testPendingPVC("pvc-hint-2", "default", localSCName),
+			testPendingPVC("pvc-foreign", "default", foreignSCName),
+		}
+	}
+
+	tt := []struct {
+		name      string
+		pod       *corev1.Pod
+		want      []string
+		wantError bool
+	}{
+		{
+			name: "no annotation: only spec volumes (backward compatibility)",
+			pod:  podWithPVCs("", "pvc-spec"),
+			want: []string{"pvc-spec"},
+		},
+		{
+			name: "empty annotation value: only spec volumes",
+			pod:  podWithPVCs("   ", "pvc-spec"),
+			want: []string{"pvc-spec"},
+		},
+		{
+			name: "one annotation PVC, no spec volumes (the virt-launcher case)",
+			pod:  podWithPVCs("pvc-hint"),
+			want: []string{"pvc-hint"},
+		},
+		{
+			name: "several annotation PVCs",
+			pod:  podWithPVCs("pvc-hint,pvc-hint-2"),
+			want: []string{"pvc-hint", "pvc-hint-2"},
+		},
+		{
+			name: "spec and annotation combined",
+			pod:  podWithPVCs("pvc-hint", "pvc-spec"),
+			want: []string{"pvc-spec", "pvc-hint"},
+		},
+		{
+			name: "duplicate between spec and annotation is deduplicated",
+			pod:  podWithPVCs("pvc-spec", "pvc-spec"),
+			want: []string{"pvc-spec"},
+		},
+		{
+			name: "annotation PVC that does not exist is skipped without error",
+			pod:  podWithPVCs("pvc-hint,pvc-does-not-exist"),
+			want: []string{"pvc-hint"},
+		},
+		{
+			name: "annotation PVC of a foreign provisioner is filtered out",
+			pod:  podWithPVCs("pvc-foreign"),
+			want: nil,
+		},
+		{
+			name: "malformed annotation value does not panic and adds nothing",
+			pod:  podWithPVCs(",, ,", "pvc-spec"),
+			want: []string{"pvc-spec"},
+		},
+		{
+			name:      "missing spec PVC still fails the request (unchanged behavior)",
+			pod:       podWithPVCs("", "pvc-does-not-exist"),
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := newFakeClient(objects()...)
+			managed, err := getManagedPVCsFromPod(ctx, cl, log, tc.pod,
+				[]string{consts.SdsLocalVolumeProvisioner})
+
+			if tc.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			got := make([]string, 0, len(managed))
+			for name := range managed {
+				got = append(got, name)
+			}
+			sort.Strings(got)
+
+			// got is always non-nil (make with len 0), so compare emptiness
+			// explicitly instead of letting assert.Equal see []string{} vs nil.
+			if len(tc.want) == 0 {
+				assert.Empty(t, got)
+				return
+			}
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			assert.Equal(t, want, got)
 		})
 	}
 }

--- a/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
@@ -311,7 +311,8 @@ func TestFilter_AnnotationPVC_LocalRejectsNodeWithoutSpace(t *testing.T) {
 		"the rejection reason must name the space problem so it surfaces in the Pod's FailedScheduling event")
 
 	assert.True(t, c.HasReservation("default/pvc-hotplug"),
-		"the annotation PVC must get the same 60s reservation a spec PVC gets (spec section 4)")
+		"the annotation PVC must get the same 60s reservation a spec PVC gets: reservation is built "+
+			"into filter (createReservations), so it follows automatically once the PVC is managed")
 }
 
 // TestFilter_NoAnnotation_PodWithoutPVCsIsNoOp pins backward compatibility at the
@@ -344,11 +345,10 @@ func TestFilter_NoAnnotation_PodWithoutPVCsIsNoOp(t *testing.T) {
 	assert.False(t, c.HasReservation("default/pvc-hotplug"))
 }
 
-// TestFilter_AnnotationPVC_ReplicatedLocalAccess covers the replicated cell of the
-// coverage matrix (spec section 2.3): unbound replicated PVC with
-// volumeAccess=Local must space-reject nodes that carry no LVG from the pool.
-// The e2e stand has no sds-replicated-volume module, so this is the coverage for
-// that path.
+// TestFilter_AnnotationPVC_ReplicatedLocalAccess covers the replicated side of the
+// feature: an unbound replicated PVC with volumeAccess=Local must space-reject nodes
+// that carry no LVG from the storage pool. The e2e stand installs only
+// sds-local-volume, so this handler-level test is the only coverage of that path.
 func TestFilter_AnnotationPVC_ReplicatedLocalAccess(t *testing.T) {
 	const (
 		scName  = "repl-sc"

--- a/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package scheduler
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -144,10 +143,11 @@ func TestGetManagedPVCsFromPod_ExtraPVCsAnnotation(t *testing.T) {
 	}
 
 	tt := []struct {
-		name      string
-		pod       *corev1.Pod
-		want      []string
-		wantError bool
+		name         string
+		pod          *corev1.Pod
+		want         []string
+		wantHintOnly []string
+		wantError    bool
 	}{
 		{
 			name: "no annotation: only spec volumes (backward compatibility)",
@@ -160,29 +160,33 @@ func TestGetManagedPVCsFromPod_ExtraPVCsAnnotation(t *testing.T) {
 			want: []string{"pvc-spec"},
 		},
 		{
-			name: "one annotation PVC, no spec volumes (the virt-launcher case)",
-			pod:  podWithPVCs("pvc-hint"),
-			want: []string{"pvc-hint"},
+			name:         "one annotation PVC, no spec volumes (the virt-launcher case)",
+			pod:          podWithPVCs("pvc-hint"),
+			want:         []string{"pvc-hint"},
+			wantHintOnly: []string{"pvc-hint"},
 		},
 		{
-			name: "several annotation PVCs",
-			pod:  podWithPVCs("pvc-hint,pvc-hint-2"),
-			want: []string{"pvc-hint", "pvc-hint-2"},
+			name:         "several annotation PVCs",
+			pod:          podWithPVCs("pvc-hint,pvc-hint-2"),
+			want:         []string{"pvc-hint", "pvc-hint-2"},
+			wantHintOnly: []string{"pvc-hint", "pvc-hint-2"},
 		},
 		{
-			name: "spec and annotation combined",
-			pod:  podWithPVCs("pvc-hint", "pvc-spec"),
-			want: []string{"pvc-spec", "pvc-hint"},
+			name:         "spec and annotation combined",
+			pod:          podWithPVCs("pvc-hint", "pvc-spec"),
+			want:         []string{"pvc-spec", "pvc-hint"},
+			wantHintOnly: []string{"pvc-hint"},
 		},
 		{
-			name: "duplicate between spec and annotation is deduplicated",
+			name: "duplicate between spec and annotation is deduplicated and counts as spec-sourced",
 			pod:  podWithPVCs("pvc-spec", "pvc-spec"),
 			want: []string{"pvc-spec"},
 		},
 		{
-			name: "annotation PVC that does not exist is skipped without error",
-			pod:  podWithPVCs("pvc-hint,pvc-does-not-exist"),
-			want: []string{"pvc-hint"},
+			name:         "annotation PVC that does not exist is skipped without error",
+			pod:          podWithPVCs("pvc-hint,pvc-does-not-exist"),
+			want:         []string{"pvc-hint"},
+			wantHintOnly: []string{"pvc-hint"},
 		},
 		{
 			name: "annotation PVC of a foreign provisioner is filtered out",
@@ -204,7 +208,7 @@ func TestGetManagedPVCsFromPod_ExtraPVCsAnnotation(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			cl := newFakeClient(objects()...)
-			managed, err := getManagedPVCsFromPod(ctx, cl, log, tc.pod,
+			managed, hintOnly, err := getManagedPVCsFromPod(ctx, cl, log, tc.pod,
 				[]string{consts.SdsLocalVolumeProvisioner})
 
 			if tc.wantError {
@@ -219,6 +223,20 @@ func TestGetManagedPVCsFromPod_ExtraPVCsAnnotation(t *testing.T) {
 			}
 			sort.Strings(got)
 
+			gotHintOnly := make([]string, 0, len(hintOnly))
+			for name := range hintOnly {
+				gotHintOnly = append(gotHintOnly, name)
+			}
+			sort.Strings(gotHintOnly)
+
+			if len(tc.wantHintOnly) == 0 {
+				assert.Empty(t, gotHintOnly, "no PVC should be marked annotation-only")
+			} else {
+				wantHintOnly := append([]string(nil), tc.wantHintOnly...)
+				sort.Strings(wantHintOnly)
+				assert.Equal(t, wantHintOnly, gotHintOnly)
+			}
+
 			// got is always non-nil (make with len 0), so compare emptiness
 			// explicitly instead of letting assert.Equal see []string{} vs nil.
 			if len(tc.want) == 0 {
@@ -229,24 +247,6 @@ func TestGetManagedPVCsFromPod_ExtraPVCsAnnotation(t *testing.T) {
 			sort.Strings(want)
 			assert.Equal(t, want, got)
 		})
-	}
-}
-
-const extraPVCsTestTenGiB = int64(10 * 1024 * 1024 * 1024)
-
-// pendingPVCWithSize is testPendingPVC with a caller-chosen request size.
-func pendingPVCWithSize(name, namespace, scName string, size int64) *corev1.PersistentVolumeClaim {
-	return &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			StorageClassName: &scName,
-			Resources: corev1.VolumeResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: *resource.NewQuantity(size, resource.BinarySI),
-				},
-			},
-		},
-		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
 	}
 }
 
@@ -284,7 +284,7 @@ func TestFilter_AnnotationPVC_LocalRejectsNodeWithoutSpace(t *testing.T) {
 
 	cl := newFakeClient(
 		sc,
-		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),
+		pendingPVCWithSize("pvc-hotplug", "default", scName, tenGiB),
 		readyLVGOnNode("lvg-a", "node-a", hundredGiB, hundredGiB),
 		readyLVGOnNode("lvg-b", "node-b", hundredGiB, oneGiB),
 	)
@@ -323,7 +323,7 @@ func TestFilter_NoAnnotation_PodWithoutPVCsIsNoOp(t *testing.T) {
 
 	cl := newFakeClient(
 		testLocalSC(scName, "lvg-a"),
-		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),
+		pendingPVCWithSize("pvc-hotplug", "default", scName, tenGiB),
 		readyLVGOnNode("lvg-a", "node-a", hundredGiB, hundredGiB),
 		readyLVGOnNode("lvg-b", "node-b", hundredGiB, oneGiB),
 	)
@@ -362,7 +362,7 @@ func TestFilter_AnnotationPVC_ReplicatedLocalAccess(t *testing.T) {
 		readyLVGOnNode("lvg-a", "node-a", hundredGiB, hundredGiB),
 		testNode("node-a", true),
 		testNode("node-b", true),
-		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),
+		pendingPVCWithSize("pvc-hotplug", "default", scName, tenGiB),
 		&d8commonapi.ModuleConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "sds-replicated-volume"},
 			Spec: d8commonapi.ModuleConfigSpec{
@@ -390,4 +390,132 @@ func TestFilter_AnnotationPVC_ReplicatedLocalAccess(t *testing.T) {
 	assert.Equal(t, []string{"node-a"}, *result.NodeNames,
 		"only the node carrying an LVG of the replicated storage pool must survive")
 	assert.Contains(t, result.FailedNodes["node-b"], "no LVG from RSP repl-pool found on node node-b")
+}
+
+// TestFilter_AnnotationPVC_UnresolvableIsIgnored is the counterpart of the core
+// test: the annotation is a hint, so a PVC the extender cannot resolve must never
+// cost the Pod its nodes. Here the SC lacks the lvm-type parameter, which makes
+// extractRequestedSize fail; before the hint origin was propagated that error
+// reached writeFailAllNodesResponse and left the launcher unschedulable forever.
+func TestFilter_AnnotationPVC_UnresolvableIsIgnored(t *testing.T) {
+	const scName = "local-sc-no-lvm-type"
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scName},
+		Provisioner: consts.SdsLocalVolumeProvisioner,
+		Parameters: map[string]string{
+			// No LvmTypeParamKey on purpose.
+			consts.LVMVolumeGroupsParamKey: "- name: lvg-a\n",
+		},
+	}
+
+	cl := newFakeClient(
+		sc,
+		pendingPVCWithSize("pvc-hotplug", "default", scName, tenGiB),
+		readyLVGOnNode("lvg-a", "node-a", hundredGiB, hundredGiB),
+		readyLVGOnNode("lvg-b", "node-b", hundredGiB, hundredGiB),
+	)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node-a", "node-b"}
+	result := callFilter(t, s, ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "virt-launcher",
+				Namespace:   "default",
+				Annotations: map[string]string{consts.PodExtraPVCsAnnotation: "pvc-hotplug"},
+			},
+		},
+		NodeNames: &nodeNames,
+	})
+
+	require.NotNil(t, result.NodeNames)
+	assert.ElementsMatch(t, nodeNames, *result.NodeNames,
+		"an unresolvable hint PVC must degrade to the pre-annotation behavior, not reject every node")
+	assert.Empty(t, result.FailedNodes)
+	assert.False(t, c.HasReservation("default/pvc-hotplug"),
+		"a dropped hint PVC must not hold space in the cache")
+}
+
+// callPrioritize posts args to the /prioritize handler and returns the decoded result.
+func callPrioritize(t *testing.T, s *scheduler, args ExtenderArgs) HostPriorityList {
+	t.Helper()
+	body, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/scheduler/prioritize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.prioritize(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "prioritize must answer 200; body: %s", w.Body.String())
+	var result HostPriorityList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	return result
+}
+
+// TestPrioritize_AnnotationPVC_ScoresNodes covers the second handler: the PR claims
+// prioritize inherits the annotation "for free", and unlike filter it has its own
+// error branch and its own cache step (narrowReservationsToFinalNodes).
+func TestPrioritize_AnnotationPVC_ScoresNodes(t *testing.T) {
+	const scName = "local-sc"
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scName},
+		Provisioner: consts.SdsLocalVolumeProvisioner,
+		Parameters: map[string]string{
+			consts.LvmTypeParamKey:         consts.Thick,
+			consts.LVMVolumeGroupsParamKey: "- name: lvg-a\n- name: lvg-b\n",
+		},
+	}
+
+	cl := newFakeClient(
+		sc,
+		pendingPVCWithSize("pvc-hotplug", "default", scName, tenGiB),
+		readyLVGOnNode("lvg-a", "node-a", hundredGiB, hundredGiB),
+		readyLVGOnNode("lvg-b", "node-b", hundredGiB, 20*oneGiB),
+	)
+	c := newTestCache()
+	s := newTestScheduler(cl, c)
+	s.targetProvisioners = []string{consts.SdsLocalVolumeProvisioner}
+
+	nodeNames := []string{"node-a", "node-b"}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "virt-launcher",
+			Namespace:   "default",
+			Annotations: map[string]string{consts.PodExtraPVCsAnnotation: "pvc-hotplug"},
+		},
+	}
+
+	// filter runs first in a real scheduling cycle and is what creates the
+	// reservation; prioritize only scores and narrows it.
+	filtered := callFilter(t, s, ExtenderArgs{Pod: pod, NodeNames: &nodeNames})
+	require.NotNil(t, filtered.NodeNames)
+	require.ElementsMatch(t, nodeNames, *filtered.NodeNames)
+	_, pools, ok := c.GetReservation("default/pvc-hotplug")
+	require.True(t, ok, "filter must reserve for the annotation PVC")
+	require.Len(t, pools, 2, "the reservation starts spread over every surviving node")
+
+	scores := callPrioritize(t, s, ExtenderArgs{Pod: pod, NodeNames: &nodeNames})
+
+	require.Len(t, scores, 2, "both nodes must be scored")
+	byNode := make(map[string]int, len(scores))
+	for _, s := range scores {
+		byNode[s.Host] = s.Score
+	}
+	require.Contains(t, byNode, "node-a")
+	require.Contains(t, byNode, "node-b")
+	assert.GreaterOrEqual(t, byNode["node-a"], byNode["node-b"],
+		"the node with more free space must not score lower")
+
+	// narrowReservationsToFinalNodes must work for an annotation PVC too. It only
+	// ever narrows down to the final node list — narrowing to the single chosen
+	// node needs selected-node, which a Pod that does not mount the PVC never gets.
+	oneNode := []string{"node-a"}
+	callPrioritize(t, s, ExtenderArgs{Pod: pod, NodeNames: &oneNode})
+	_, pools, ok = c.GetReservation("default/pvc-hotplug")
+	require.True(t, ok, "narrowing must not drop the reservation")
+	assert.Len(t, pools, 1, "the reservation must follow the final node list")
 }

--- a/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2026 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package scheduler

--- a/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/extra_pvcs_test.go
@@ -232,11 +232,7 @@ func TestGetManagedPVCsFromPod_ExtraPVCsAnnotation(t *testing.T) {
 	}
 }
 
-const (
-	extraPVCsTestTenGiB     = int64(10 * 1024 * 1024 * 1024)
-	extraPVCsTestHundredGiB = int64(100 * 1024 * 1024 * 1024)
-	extraPVCsTestOneGiB     = int64(1024 * 1024 * 1024)
-)
+const extraPVCsTestTenGiB = int64(10 * 1024 * 1024 * 1024)
 
 // pendingPVCWithSize is testPendingPVC with a caller-chosen request size.
 func pendingPVCWithSize(name, namespace, scName string, size int64) *corev1.PersistentVolumeClaim {
@@ -289,8 +285,8 @@ func TestFilter_AnnotationPVC_LocalRejectsNodeWithoutSpace(t *testing.T) {
 	cl := newFakeClient(
 		sc,
 		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),
-		readyLVGOnNode("lvg-a", "node-a", extraPVCsTestHundredGiB, extraPVCsTestHundredGiB),
-		readyLVGOnNode("lvg-b", "node-b", extraPVCsTestHundredGiB, extraPVCsTestOneGiB),
+		readyLVGOnNode("lvg-a", "node-a", hundredGiB, hundredGiB),
+		readyLVGOnNode("lvg-b", "node-b", hundredGiB, oneGiB),
 	)
 	c := newTestCache()
 	s := newTestScheduler(cl, c)
@@ -327,8 +323,8 @@ func TestFilter_NoAnnotation_PodWithoutPVCsIsNoOp(t *testing.T) {
 	cl := newFakeClient(
 		testLocalSC(scName, "lvg-a"),
 		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),
-		readyLVGOnNode("lvg-a", "node-a", extraPVCsTestHundredGiB, extraPVCsTestHundredGiB),
-		readyLVGOnNode("lvg-b", "node-b", extraPVCsTestHundredGiB, extraPVCsTestOneGiB),
+		readyLVGOnNode("lvg-a", "node-a", hundredGiB, hundredGiB),
+		readyLVGOnNode("lvg-b", "node-b", hundredGiB, oneGiB),
 	)
 	c := newTestCache()
 	s := newTestScheduler(cl, c)
@@ -363,7 +359,7 @@ func TestFilter_AnnotationPVC_ReplicatedLocalAccess(t *testing.T) {
 		testSC(scName, consts.SdsReplicatedVolumeProvisioner),
 		testRSC(scName, srv.VolumeAccessLocal, rspName),
 		testRSP(rspName, srv.ReplicatedStoragePoolTypeLVM, "lvg-a"),
-		readyLVGOnNode("lvg-a", "node-a", extraPVCsTestHundredGiB, extraPVCsTestHundredGiB),
+		readyLVGOnNode("lvg-a", "node-a", hundredGiB, hundredGiB),
 		testNode("node-a", true),
 		testNode("node-b", true),
 		pendingPVCWithSize("pvc-hotplug", "default", scName, extraPVCsTestTenGiB),

--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
@@ -127,12 +127,32 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	servingLog.Debug("starts to extract PVC requested sizes")
-	pvcRequests, err := extractRequestedSize(ctx, s.client, servingLog, managedPVCs, scUsedByPVCs, hintOnlyPVCs)
+	pvcRequests, droppedHints, err := extractRequestedSize(ctx, s.client, servingLog, managedPVCs, scUsedByPVCs, hintOnlyPVCs)
 	if err != nil {
 		servingLog.Error(err, "unable to extract request size")
 		writeFailAllNodesResponse(w, servingLog, nodeNames, fmt.Sprintf("unable to extract request size: %s", err))
 		return
 	}
+
+	// A PVC named only in the annotation that the extender cannot resolve is a
+	// hint that failed to materialize, not a requirement. Drop it so neither the
+	// node filter nor the reservation step keeps accounting for it; the Pod then
+	// degrades to its pre-annotation behavior instead of losing every node.
+	if len(droppedHints) > 0 {
+		for _, name := range droppedHints {
+			delete(managedPVCs, name)
+		}
+		servingLog.Warning(fmt.Sprintf("dropping unresolvable PVCs listed only in the %s annotation: %v", consts.PodExtraPVCsAnnotation, droppedHints))
+	}
+	if len(managedPVCs) == 0 {
+		servingLog.Debug("After dropping unresolvable annotation PVCs, no managed PVCs left. Return the same nodes")
+		if err := writeNodeNamesResponse(w, servingLog, nodeNames); err != nil {
+			servingLog.Error(err, "unable to write node names response")
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}
+		return
+	}
+
 	// NB: we intentionally do not short-circuit here when len(pvcRequests) == 0.
 	// For local PVCs, returning all incoming nodes would be unsafe: kube-scheduler
 	// could pick a node without a matching LVMVolumeGroup and the CSI provisioner

--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package scheduler
@@ -74,7 +74,7 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 	}
 	servingLog.Trace(fmt.Sprintf("NodeNames from the request: %+v", nodeNames))
 
-	managedPVCs, err := getManagedPVCsFromPod(ctx, s.client, servingLog, inputData.Pod, s.targetProvisioners)
+	managedPVCs, hintOnlyPVCs, err := getManagedPVCsFromPod(ctx, s.client, servingLog, inputData.Pod, s.targetProvisioners)
 	if err != nil {
 		servingLog.Error(err, "unable to get managed PVCs from the Pod")
 		writeFailAllNodesResponse(w, servingLog, nodeNames, fmt.Sprintf("unable to get managed PVCs: %s", err))
@@ -127,7 +127,7 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	servingLog.Debug("starts to extract PVC requested sizes")
-	pvcRequests, err := extractRequestedSize(ctx, s.client, servingLog, managedPVCs, scUsedByPVCs)
+	pvcRequests, err := extractRequestedSize(ctx, s.client, servingLog, managedPVCs, scUsedByPVCs, hintOnlyPVCs)
 	if err != nil {
 		servingLog.Error(err, "unable to extract request size")
 		writeFailAllNodesResponse(w, servingLog, nodeNames, fmt.Sprintf("unable to extract request size: %s", err))
@@ -400,6 +400,13 @@ func filterNodeForLocalPVCs(
 }
 
 // createReservations creates reservations for each PVC across all filtered nodes.
+//
+// The reservation is deliberately spread over every surviving node and narrowed
+// later — by narrowReservationsToFinalNodes in prioritize, and down to a single
+// node by the PVC watcher once VolumeBinding stamps selected-node on the PVC.
+// That last step never happens for a PVC known only from PodExtraPVCsAnnotation:
+// the Pod does not mount it, so no binding cycle touches it and the reservation
+// stays spread across all candidate nodes until the TTL expires.
 func createReservations(
 	ctx context.Context,
 	log logger.Logger,

--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2025 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package scheduler

--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter_test.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2025 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package scheduler

--- a/images/sds-common-scheduler-extender/pkg/scheduler/filter_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/filter_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package scheduler
@@ -129,7 +129,7 @@ func TestFilter(t *testing.T) {
 
 		cl := fake.NewFakeClient(objects...)
 		targetProvisioners := []string{consts.SdsLocalVolumeProvisioner}
-		filtered, err := getManagedPVCsFromPod(ctx, cl, log, pod, targetProvisioners)
+		filtered, _, err := getManagedPVCsFromPod(ctx, cl, log, pod, targetProvisioners)
 
 		assert.NoError(t, err)
 		if assert.Equal(t, 2, len(filtered)) {

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -447,50 +447,94 @@ func parseExtraPVCNames(value string) []string {
 	return names
 }
 
+// podPVCNames returns the names of the PVCs relevant for scheduling this Pod:
+// the ones mounted through pod.Spec.Volumes plus the ones listed in the
+// PodExtraPVCsAnnotation annotation. Hotplug volumes are deliberately kept out
+// of the launcher Pod's spec.volumes by KubeVirt, so the annotation is the only
+// way the extender learns about them.
+//
+// Names are deduplicated, spec-volume order first. fromSpec marks the names that
+// came from pod.Spec.Volumes: for those a missing PVC keeps failing the whole
+// scheduling request (unchanged behavior), while a missing annotation-only PVC
+// is skipped.
+func podPVCNames(pod *corev1.Pod) (names []string, fromSpec map[string]bool) {
+	fromSpec = make(map[string]bool, len(pod.Spec.Volumes))
+	seen := make(map[string]struct{}, len(pod.Spec.Volumes))
+
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			continue
+		}
+		name := volume.PersistentVolumeClaim.ClaimName
+		fromSpec[name] = true
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+
+	for _, name := range parseExtraPVCNames(pod.Annotations[consts.PodExtraPVCsAnnotation]) {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+
+	return names, fromSpec
+}
+
 // Get all PVCs from the Pod which are managed by our modules
 func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Logger, pod *corev1.Pod, targetProvisioners []string) (map[string]*corev1.PersistentVolumeClaim, error) {
-	var discoveredProvisioner string
-	managedPVCs := make(map[string]*corev1.PersistentVolumeClaim, len(pod.Spec.Volumes))
+	pvcNames, fromSpec := podPVCNames(pod)
+	managedPVCs := make(map[string]*corev1.PersistentVolumeClaim, len(pvcNames))
 	var newControlPlane *bool
-	for _, volume := range pod.Spec.Volumes {
-		if volume.PersistentVolumeClaim != nil {
-			pvcName := volume.PersistentVolumeClaim.ClaimName
-			log = log.WithValues("PVC", pvcName)
 
-			pvc := &corev1.PersistentVolumeClaim{}
-			err := cl.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pvcName}, pvc)
-			if err != nil {
-				return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting PVC: %v", err)
-			}
+	for _, pvcName := range pvcNames {
+		pvcLog := log.WithValues("PVC", pvcName)
 
-			discoveredProvisioner, err = discoverProvisionerForPVC(ctx, cl, log, pvc)
-			if err != nil {
-				return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting provisioner: %v", err)
-			}
-			log.Trace(fmt.Sprintf("[getManagedPVCsFromPod] discovered provisioner: %s", discoveredProvisioner))
-
-			if !slices.Contains(targetProvisioners, discoveredProvisioner) {
-				log.Debug(fmt.Sprintf("[getManagedPVCsFromPod] provisioner not matches targetProvisioners %+v", targetProvisioners))
+		pvc := &corev1.PersistentVolumeClaim{}
+		err := cl.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pvcName}, pvc)
+		if err != nil {
+			// A PVC named only in the annotation is a hint, not a mount: it may
+			// legitimately not exist yet. Skip it instead of failing the whole
+			// scheduling request. A PVC from pod.Spec.Volumes keeps the previous
+			// fail-the-request behavior.
+			if apierrors.IsNotFound(err) && !fromSpec[pvcName] {
+				pvcLog.Warning(fmt.Sprintf("[getManagedPVCsFromPod] PVC listed in the %s annotation does not exist, skipping it", consts.PodExtraPVCsAnnotation))
 				continue
 			}
+			return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting PVC: %v", err)
+		}
 
-			if discoveredProvisioner == consts.SdsReplicatedVolumeProvisioner {
-				if newControlPlane == nil {
-					newControlPlane, err = getNewControlPlane(ctx, cl, log)
-					if err != nil {
-						return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting newControlPlane: %v", err)
-					}
-				}
+		discoveredProvisioner, err := discoverProvisionerForPVC(ctx, cl, pvcLog, pvc)
+		if err != nil {
+			return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting provisioner: %v", err)
+		}
+		pvcLog.Trace(fmt.Sprintf("[getManagedPVCsFromPod] discovered provisioner: %s", discoveredProvisioner))
 
-				if !*newControlPlane {
-					log.Debug("[getManagedPVCsFromPod] filter out PVC due to used provisioner is managed by the Linstor")
-					continue
+		if !slices.Contains(targetProvisioners, discoveredProvisioner) {
+			pvcLog.Debug(fmt.Sprintf("[getManagedPVCsFromPod] provisioner not matches targetProvisioners %+v", targetProvisioners))
+			continue
+		}
+
+		if discoveredProvisioner == consts.SdsReplicatedVolumeProvisioner {
+			if newControlPlane == nil {
+				newControlPlane, err = getNewControlPlane(ctx, cl, pvcLog)
+				if err != nil {
+					return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting newControlPlane: %v", err)
 				}
 			}
 
-			log.Debug("[getManagedPVCsFromPod] add PVC to the managed PVCs")
-			managedPVCs[pvcName] = pvc
+			if !*newControlPlane {
+				pvcLog.Debug("[getManagedPVCsFromPod] filter out PVC due to used provisioner is managed by the Linstor")
+				continue
+			}
 		}
+
+		pvcLog.Debug("[getManagedPVCsFromPod] add PVC to the managed PVCs")
+		managedPVCs[pvcName] = pvc
 	}
 
 	return managedPVCs, nil

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -490,6 +490,7 @@ func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Log
 	pvcNames, fromSpec := podPVCNames(pod)
 	managedPVCs := make(map[string]*corev1.PersistentVolumeClaim, len(pvcNames))
 	var newControlPlane *bool
+	var missingAnnotationPVCs []string
 
 	for _, pvcName := range pvcNames {
 		pvcLog := log.WithValues("PVC", pvcName)
@@ -500,9 +501,14 @@ func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Log
 			// A PVC named only in the annotation is a hint, not a mount: it may
 			// legitimately not exist yet. Skip it instead of failing the whole
 			// scheduling request. A PVC from pod.Spec.Volumes keeps the previous
-			// fail-the-request behavior.
+			// fail-the-request behavior. Names are collected and reported in a
+			// single aggregated Warning after the loop (see below) instead of one
+			// Warning per PVC, so a stale/mistyped annotation on a Pod that gets
+			// retried by kube-scheduler doesn't flood the logs at the default
+			// (INFO) log level.
 			if apierrors.IsNotFound(err) && !fromSpec[pvcName] {
-				pvcLog.Warning(fmt.Sprintf("[getManagedPVCsFromPod] PVC listed in the %s annotation does not exist, skipping it", consts.PodExtraPVCsAnnotation))
+				pvcLog.Debug(fmt.Sprintf("[getManagedPVCsFromPod] PVC listed in the %s annotation does not exist, skipping it", consts.PodExtraPVCsAnnotation))
+				missingAnnotationPVCs = append(missingAnnotationPVCs, pvcName)
 				continue
 			}
 			return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting PVC: %v", err)
@@ -535,6 +541,10 @@ func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Log
 
 		pvcLog.Debug("[getManagedPVCsFromPod] add PVC to the managed PVCs")
 		managedPVCs[pvcName] = pvc
+	}
+
+	if len(missingAnnotationPVCs) > 0 {
+		log.Warning(fmt.Sprintf("[getManagedPVCsFromPod] PVC name(s) listed in the %s annotation do not exist and were skipped (the annotation is a scheduling hint, not a guarantee): %v", consts.PodExtraPVCsAnnotation, missingAnnotationPVCs))
 	}
 
 	return managedPVCs, nil

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -687,10 +687,15 @@ func getNewControlPlane(ctx context.Context, cl client.Client, log logger.Logger
 // uses to decide whether a PVC is bound.
 //
 // hintOnly (from getManagedPVCsFromPod) marks PVCs known only from the
-// PodExtraPVCsAnnotation annotation. Failing to resolve one of those drops that
-// single PVC instead of the whole request: the caller turns an error here into a
-// rejection of every node, which for a Pod that does not mount the volume means
-// it never schedules at all.
+// PodExtraPVCsAnnotation annotation. A hint the extender cannot resolve must not
+// cost the Pod its nodes, so instead of failing the whole request its name is
+// returned in dropped and the caller removes it from its own PVC map. The
+// asymmetry is deliberate: an unresolvable PVC from pod.Spec.Volumes keeps
+// failing the request, because the Pod genuinely cannot run without that mount.
+//
+// The caller owns the removal (same shape as dropPVCsWithMissingSC) rather than
+// this function mutating pvcs behind its back — filter/prioritize both guard on
+// len(managedPVCs) after each such step.
 func extractRequestedSize(
 	ctx context.Context,
 	cl client.Client,
@@ -698,96 +703,96 @@ func extractRequestedSize(
 	pvcs map[string]*corev1.PersistentVolumeClaim,
 	scs map[string]*storagev1.StorageClass,
 	hintOnly map[string]bool,
-) (map[string]PVCRequest, error) {
+) (map[string]PVCRequest, []string, error) {
 	pvcRequests := make(map[string]PVCRequest, len(pvcs))
-	for _, pvc := range pvcs {
-		sc := scs[*pvc.Spec.StorageClassName]
+	var dropped []string
+
+	for name, pvc := range pvcs {
 		log.Debug(fmt.Sprintf("[extractRequestedSize] PVC %s/%s has status phase: %q, spec.volumeName: %q", pvc.Namespace, pvc.Name, pvc.Status.Phase, pvc.Spec.VolumeName))
 
-		// skipHint reports whether err may be downgraded to "drop this PVC". The
-		// PVC is removed from pvcs as well, so the downstream node filter does not
-		// keep checking it with a zero-value PVCRequest (deleting during range is
-		// safe, and dropPVCsWithMissingSC mutates the same map the same way).
-		skipHint := func(err error) bool {
-			if !hintOnly[pvc.Name] {
-				return false
+		req, err := requestForPVC(ctx, cl, pvc, scs[*pvc.Spec.StorageClassName])
+		if err != nil {
+			if !hintOnly[name] {
+				return nil, nil, err
 			}
 			log.Warning(fmt.Sprintf("[extractRequestedSize] skipping PVC %s/%s listed only in the %s annotation: %v", pvc.Namespace, pvc.Name, consts.PodExtraPVCsAnnotation, err))
-			delete(pvcs, pvc.Name)
-			return true
+			dropped = append(dropped, name)
+			continue
 		}
 
-		var deviceType string
-		isReplicated := sc.Provisioner == consts.SdsReplicatedVolumeProvisioner
-
-		if isReplicated {
-			rsc, err := getReplicatedStorageClassForExtract(ctx, cl, sc.Name)
-			if err != nil {
-				err = fmt.Errorf("[extractRequestedSize] unable to get RSC for SC %s: %w", sc.Name, err)
-				if skipHint(err) {
-					continue
-				}
-				return nil, err
-			}
-			rspName := rscStoragePoolName(rsc)
-			rsp, err := getReplicatedStoragePoolForExtract(ctx, cl, rspName)
-			if err != nil {
-				err = fmt.Errorf("[extractRequestedSize] unable to get RSP %s: %w", rspName, err)
-				if skipHint(err) {
-					continue
-				}
-				return nil, err
-			}
-			switch rsp.Spec.Type {
-			case srv.ReplicatedStoragePoolTypeLVM:
-				deviceType = consts.Thick
-			case srv.ReplicatedStoragePoolTypeLVMThin:
-				deviceType = consts.Thin
-			default:
-				deviceType = consts.Thick
-			}
-		} else {
-			deviceType = sc.Parameters[consts.LvmTypeParamKey]
-		}
-
-		if deviceType == "" {
-			err := fmt.Errorf("[extractRequestedSize] unable to determine device type for PVC %s/%s", pvc.Namespace, pvc.Name)
-			if skipHint(err) {
-				continue
-			}
-			return nil, err
-		}
-
-		var requestedSize int64
-		if pvc.Spec.VolumeName == "" {
-			requestedSize = pvc.Spec.Resources.Requests.Storage().Value()
-		} else {
-			pv := &corev1.PersistentVolume{}
-			if err := cl.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv); err != nil {
-				err = fmt.Errorf("[extractRequestedSize] error getting PV %s: %v", pvc.Spec.VolumeName, err)
-				if skipHint(err) {
-					continue
-				}
-				return nil, err
-			}
-			requestedSize = pvc.Spec.Resources.Requests.Storage().Value() - pv.Spec.Capacity.Storage().Value()
-			if requestedSize < 0 {
-				// LVM rounds an LV up to the extent boundary, so a PV backing a
-				// decimal-unit request ("10G") is larger than the request itself.
-				// A negative size would be summed into GetReservedSpace and, via
-				// getAvailableSpace's baseFree-reserved, inflate the pool's free
-				// space for every other Pod scheduled in the same window.
-				requestedSize = 0
-			}
-		}
-
-		pvcRequests[pvc.Name] = PVCRequest{
-			DeviceType:    deviceType,
-			RequestedSize: requestedSize,
-		}
+		pvcRequests[name] = req
 	}
 
-	return pvcRequests, nil
+	return pvcRequests, dropped, nil
+}
+
+// requestForPVC resolves the device type of a PVC and how much space it still
+// needs from its pool. It is pure resolution: what to do with a failure (fail
+// the whole scheduling request, or drop an annotation-only hint) is the caller's
+// decision, so every failure here is just an error.
+func requestForPVC(
+	ctx context.Context,
+	cl client.Client,
+	pvc *corev1.PersistentVolumeClaim,
+	sc *storagev1.StorageClass,
+) (PVCRequest, error) {
+	deviceType, err := deviceTypeForSC(ctx, cl, sc)
+	if err != nil {
+		return PVCRequest{}, err
+	}
+	if deviceType == "" {
+		return PVCRequest{}, fmt.Errorf("[extractRequestedSize] unable to determine device type for PVC %s/%s", pvc.Namespace, pvc.Name)
+	}
+
+	requested := pvc.Spec.Resources.Requests.Storage().Value()
+	if pvc.Spec.VolumeName == "" {
+		return PVCRequest{DeviceType: deviceType, RequestedSize: requested}, nil
+	}
+
+	pv := &corev1.PersistentVolume{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv); err != nil {
+		return PVCRequest{}, fmt.Errorf("[extractRequestedSize] error getting PV %s: %v", pvc.Spec.VolumeName, err)
+	}
+
+	// A bound PVC only needs the growth delta. Clamp at 0: LVM rounds an LV up to
+	// the extent boundary, so a PV backing a decimal-unit request ("10G") is
+	// larger than the request itself. A negative size would be summed into
+	// Cache.GetReservedSpace and, via getAvailableSpace's baseFree-reserved,
+	// inflate the pool's free space for every other Pod scheduled in the same
+	// window.
+	return PVCRequest{
+		DeviceType:    deviceType,
+		RequestedSize: max(requested-pv.Spec.Capacity.Storage().Value(), 0),
+	}, nil
+}
+
+// deviceTypeForSC maps a StorageClass to the LVM device type its volumes land
+// on. A local class carries it directly in the lvm-type parameter; a replicated
+// one hides it one hop away, behind RSC -> RSP.
+func deviceTypeForSC(ctx context.Context, cl client.Client, sc *storagev1.StorageClass) (string, error) {
+	if sc.Provisioner != consts.SdsReplicatedVolumeProvisioner {
+		return sc.Parameters[consts.LvmTypeParamKey], nil
+	}
+
+	rsc, err := getReplicatedStorageClassForExtract(ctx, cl, sc.Name)
+	if err != nil {
+		return "", fmt.Errorf("[extractRequestedSize] unable to get RSC for SC %s: %w", sc.Name, err)
+	}
+
+	rspName := rscStoragePoolName(rsc)
+	rsp, err := getReplicatedStoragePoolForExtract(ctx, cl, rspName)
+	if err != nil {
+		return "", fmt.Errorf("[extractRequestedSize] unable to get RSP %s: %w", rspName, err)
+	}
+
+	switch rsp.Spec.Type {
+	case srv.ReplicatedStoragePoolTypeLVM:
+		return consts.Thick, nil
+	case srv.ReplicatedStoragePoolTypeLVMThin:
+		return consts.Thin, nil
+	default:
+		return consts.Thick, nil
+	}
 }
 
 func getReplicatedStorageClassForExtract(ctx context.Context, cl client.Client, scName string) (*srv.ReplicatedStorageClass, error) {

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package scheduler
@@ -485,12 +485,31 @@ func podPVCNames(pod *corev1.Pod) (names []string, fromSpec map[string]bool) {
 	return names, fromSpec
 }
 
-// Get all PVCs from the Pod which are managed by our modules
-func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Logger, pod *corev1.Pod, targetProvisioners []string) (map[string]*corev1.PersistentVolumeClaim, error) {
+// Get all PVCs from the Pod which are managed by our modules.
+//
+// The second return value marks the PVCs that came only from the
+// PodExtraPVCsAnnotation annotation. Their origin has to survive this function:
+// past it, any resolution error (a missing lvm-type parameter, a deleted RSC/RSP,
+// a PV gone from under a bound PVC) would otherwise turn the hint into a hard
+// requirement and reject every node for a Pod that does not even mount the volume.
+// See extractRequestedSize.
+func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Logger, pod *corev1.Pod, targetProvisioners []string) (map[string]*corev1.PersistentVolumeClaim, map[string]bool, error) {
 	pvcNames, fromSpec := podPVCNames(pod)
 	managedPVCs := make(map[string]*corev1.PersistentVolumeClaim, len(pvcNames))
+	hintOnly := make(map[string]bool, len(pvcNames))
 	var newControlPlane *bool
 	var missingAnnotationPVCs []string
+
+	// Emitted from a defer so the diagnostics survive the loop's error exits: a
+	// stale annotation is most worth reporting exactly when some other PVC fails
+	// and the operator is debugging both at once. Repeating it on every
+	// filter/prioritize call for a Pod stuck Pending is deliberate — one line per
+	// call is the price of keeping typo diagnostics at the default log level.
+	defer func() {
+		if len(missingAnnotationPVCs) > 0 {
+			log.Warning(fmt.Sprintf("[getManagedPVCsFromPod] PVC name(s) listed in the %s annotation do not exist and were skipped (the annotation is a scheduling hint, not a guarantee): %v", consts.PodExtraPVCsAnnotation, missingAnnotationPVCs))
+		}
+	}()
 
 	for _, pvcName := range pvcNames {
 		pvcLog := log.WithValues("PVC", pvcName)
@@ -502,7 +521,7 @@ func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Log
 			// legitimately not exist yet. Skip it instead of failing the whole
 			// scheduling request. A PVC from pod.Spec.Volumes keeps the previous
 			// fail-the-request behavior. Names are collected and reported in a
-			// single aggregated Warning after the loop (see below) instead of one
+			// single aggregated Warning (see the defer above) instead of one
 			// Warning per PVC, so a stale/mistyped annotation on a Pod that gets
 			// retried by kube-scheduler doesn't flood the logs at the default
 			// (INFO) log level.
@@ -511,12 +530,12 @@ func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Log
 				missingAnnotationPVCs = append(missingAnnotationPVCs, pvcName)
 				continue
 			}
-			return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting PVC: %v", err)
+			return nil, nil, fmt.Errorf("[getManagedPVCsFromPod] error getting PVC: %v", err)
 		}
 
 		discoveredProvisioner, err := discoverProvisionerForPVC(ctx, cl, pvcLog, pvc)
 		if err != nil {
-			return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting provisioner: %v", err)
+			return nil, nil, fmt.Errorf("[getManagedPVCsFromPod] error getting provisioner: %v", err)
 		}
 		pvcLog.Trace(fmt.Sprintf("[getManagedPVCsFromPod] discovered provisioner: %s", discoveredProvisioner))
 
@@ -529,7 +548,7 @@ func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Log
 			if newControlPlane == nil {
 				newControlPlane, err = getNewControlPlane(ctx, cl, pvcLog)
 				if err != nil {
-					return nil, fmt.Errorf("[getManagedPVCsFromPod] error getting newControlPlane: %v", err)
+					return nil, nil, fmt.Errorf("[getManagedPVCsFromPod] error getting newControlPlane: %v", err)
 				}
 			}
 
@@ -541,13 +560,12 @@ func getManagedPVCsFromPod(ctx context.Context, cl client.Client, log logger.Log
 
 		pvcLog.Debug("[getManagedPVCsFromPod] add PVC to the managed PVCs")
 		managedPVCs[pvcName] = pvc
+		if !fromSpec[pvcName] {
+			hintOnly[pvcName] = true
+		}
 	}
 
-	if len(missingAnnotationPVCs) > 0 {
-		log.Warning(fmt.Sprintf("[getManagedPVCsFromPod] PVC name(s) listed in the %s annotation do not exist and were skipped (the annotation is a scheduling hint, not a guarantee): %v", consts.PodExtraPVCsAnnotation, missingAnnotationPVCs))
-	}
-
-	return managedPVCs, nil
+	return managedPVCs, hintOnly, nil
 }
 
 // getStorageClassesUsedByPVCs fetches only the StorageClasses referenced by PVCs.
@@ -667,17 +685,37 @@ func getNewControlPlane(ctx context.Context, cl client.Client, log logger.Logger
 // silently drops the PVC. Spec.VolumeName, on the other hand, is set in the same
 // transaction as the binding and matches what the upstream VolumeBinding plugin
 // uses to decide whether a PVC is bound.
+//
+// hintOnly (from getManagedPVCsFromPod) marks PVCs known only from the
+// PodExtraPVCsAnnotation annotation. Failing to resolve one of those drops that
+// single PVC instead of the whole request: the caller turns an error here into a
+// rejection of every node, which for a Pod that does not mount the volume means
+// it never schedules at all.
 func extractRequestedSize(
 	ctx context.Context,
 	cl client.Client,
 	log logger.Logger,
 	pvcs map[string]*corev1.PersistentVolumeClaim,
 	scs map[string]*storagev1.StorageClass,
+	hintOnly map[string]bool,
 ) (map[string]PVCRequest, error) {
 	pvcRequests := make(map[string]PVCRequest, len(pvcs))
 	for _, pvc := range pvcs {
 		sc := scs[*pvc.Spec.StorageClassName]
 		log.Debug(fmt.Sprintf("[extractRequestedSize] PVC %s/%s has status phase: %q, spec.volumeName: %q", pvc.Namespace, pvc.Name, pvc.Status.Phase, pvc.Spec.VolumeName))
+
+		// skipHint reports whether err may be downgraded to "drop this PVC". The
+		// PVC is removed from pvcs as well, so the downstream node filter does not
+		// keep checking it with a zero-value PVCRequest (deleting during range is
+		// safe, and dropPVCsWithMissingSC mutates the same map the same way).
+		skipHint := func(err error) bool {
+			if !hintOnly[pvc.Name] {
+				return false
+			}
+			log.Warning(fmt.Sprintf("[extractRequestedSize] skipping PVC %s/%s listed only in the %s annotation: %v", pvc.Namespace, pvc.Name, consts.PodExtraPVCsAnnotation, err))
+			delete(pvcs, pvc.Name)
+			return true
+		}
 
 		var deviceType string
 		isReplicated := sc.Provisioner == consts.SdsReplicatedVolumeProvisioner
@@ -685,12 +723,20 @@ func extractRequestedSize(
 		if isReplicated {
 			rsc, err := getReplicatedStorageClassForExtract(ctx, cl, sc.Name)
 			if err != nil {
-				return nil, fmt.Errorf("[extractRequestedSize] unable to get RSC for SC %s: %w", sc.Name, err)
+				err = fmt.Errorf("[extractRequestedSize] unable to get RSC for SC %s: %w", sc.Name, err)
+				if skipHint(err) {
+					continue
+				}
+				return nil, err
 			}
 			rspName := rscStoragePoolName(rsc)
 			rsp, err := getReplicatedStoragePoolForExtract(ctx, cl, rspName)
 			if err != nil {
-				return nil, fmt.Errorf("[extractRequestedSize] unable to get RSP %s: %w", rspName, err)
+				err = fmt.Errorf("[extractRequestedSize] unable to get RSP %s: %w", rspName, err)
+				if skipHint(err) {
+					continue
+				}
+				return nil, err
 			}
 			switch rsp.Spec.Type {
 			case srv.ReplicatedStoragePoolTypeLVM:
@@ -705,7 +751,11 @@ func extractRequestedSize(
 		}
 
 		if deviceType == "" {
-			return nil, fmt.Errorf("[extractRequestedSize] unable to determine device type for PVC %s/%s", pvc.Namespace, pvc.Name)
+			err := fmt.Errorf("[extractRequestedSize] unable to determine device type for PVC %s/%s", pvc.Namespace, pvc.Name)
+			if skipHint(err) {
+				continue
+			}
+			return nil, err
 		}
 
 		var requestedSize int64
@@ -714,9 +764,21 @@ func extractRequestedSize(
 		} else {
 			pv := &corev1.PersistentVolume{}
 			if err := cl.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv); err != nil {
-				return nil, fmt.Errorf("[extractRequestedSize] error getting PV %s: %v", pvc.Spec.VolumeName, err)
+				err = fmt.Errorf("[extractRequestedSize] error getting PV %s: %v", pvc.Spec.VolumeName, err)
+				if skipHint(err) {
+					continue
+				}
+				return nil, err
 			}
 			requestedSize = pvc.Spec.Resources.Requests.Storage().Value() - pv.Spec.Capacity.Storage().Value()
+			if requestedSize < 0 {
+				// LVM rounds an LV up to the extent boundary, so a PV backing a
+				// decimal-unit request ("10G") is larger than the request itself.
+				// A negative size would be summed into GetReservedSpace and, via
+				// getAvailableSpace's baseFree-reserved, inflate the pool's free
+				// space for every other Pod scheduled in the same window.
+				requestedSize = 0
+			}
 		}
 
 		pvcRequests[pvc.Name] = PVCRequest{

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2025 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package scheduler

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strings"
 
 	"github.com/stretchr/testify/assert/yaml"
 	corev1 "k8s.io/api/core/v1"
@@ -420,6 +421,30 @@ func getNodeNames(inputData ExtenderArgs) ([]string, error) {
 	}
 
 	return nil, fmt.Errorf("no nodes provided")
+}
+
+// parseExtraPVCNames parses the CSV value of the PodExtraPVCsAnnotation
+// annotation. Entries are trimmed and empty ones are dropped, so a malformed
+// value ("a,,b", " , ") degrades to the usable names instead of an error: the
+// annotation is a scheduling hint and must never fail a scheduling request.
+// Input order is preserved; deduplication is the caller's job.
+func parseExtraPVCNames(value string) []string {
+	if value == "" {
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	names := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			names = append(names, trimmed)
+		}
+	}
+
+	if len(names) == 0 {
+		return nil
+	}
+	return names
 }
 
 // Get all PVCs from the Pod which are managed by our modules

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
@@ -32,10 +32,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/consts"
 	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/logger"
+	srv "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 )
 
 func TestShouldProcessPod(t *testing.T) {
@@ -1014,7 +1016,7 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 		pvcs := map[string]*corev1.PersistentVolumeClaim{
 			pvFreshlyCreatedNoPhase.Name: pvFreshlyCreatedNoPhase,
 		}
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
+		got, _, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvFreshlyCreatedNoPhase.Name, "PVC with empty Status.Phase must NOT be dropped")
 		assert.Equal(t, requestQty.Value(), got[pvFreshlyCreatedNoPhase.Name].RequestedSize)
@@ -1025,7 +1027,7 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 		pvcs := map[string]*corev1.PersistentVolumeClaim{
 			pvcExplicitlyPending.Name: pvcExplicitlyPending,
 		}
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
+		got, _, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvcExplicitlyPending.Name)
 		assert.Equal(t, requestQty.Value(), got[pvcExplicitlyPending.Name].RequestedSize)
@@ -1033,7 +1035,7 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 
 	t.Run("bound PVC reports resize delta", func(t *testing.T) {
 		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcBound.Name: pvcBound}
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
+		got, _, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvcBound.Name)
 		assert.Equal(t, requestQty.Value()-pvCapacity.Value(), got[pvcBound.Name].RequestedSize,
@@ -1045,7 +1047,7 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 		pvcBoundNoPhase.Name = "pvc-bound-no-phase"
 		pvcBoundNoPhase.Status = corev1.PersistentVolumeClaimStatus{}
 		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcBoundNoPhase.Name: pvcBoundNoPhase}
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
+		got, _, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvcBoundNoPhase.Name,
 			"a PVC with Spec.VolumeName set but empty Status.Phase must be treated as bound, not dropped")
@@ -1078,7 +1080,7 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 
 		clWithBigPV := newFakeClient(bigPV)
 		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcOverProvisioned.Name: pvcOverProvisioned}
-		got, err := extractRequestedSize(context.Background(), clWithBigPV, log, pvcs, scs, nil)
+		got, _, err := extractRequestedSize(context.Background(), clWithBigPV, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvcOverProvisioned.Name)
 		assert.Equal(t, int64(0), got[pvcOverProvisioned.Name].RequestedSize,
@@ -1086,8 +1088,9 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 	})
 
 	// A PVC known only from the extra-pvcs annotation must never fail the whole
-	// request: an unresolvable one is dropped from both the requests and the
-	// managed-PVC map, so the downstream node filter stops considering it.
+	// request: an unresolvable one is left out of the requests and reported in
+	// dropped, so the caller can take it out of managedPVCs and the downstream
+	// node filter stops considering it.
 	t.Run("unresolvable annotation-only PVC is dropped instead of failing", func(t *testing.T) {
 		brokenSCName := "local-sc-no-lvm-type"
 		brokenSC := &storagev1.StorageClass{
@@ -1111,12 +1114,14 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 		}
 		allSCs := map[string]*storagev1.StorageClass{scName: sc, brokenSCName: brokenSC}
 
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, allSCs,
+		got, dropped, err := extractRequestedSize(context.Background(), cl, log, pvcs, allSCs,
 			map[string]bool{pvcHint.Name: true})
 		require.NoError(t, err, "an annotation-only PVC must not fail the request")
 		assert.NotContains(t, got, pvcHint.Name)
-		assert.NotContains(t, pvcs, pvcHint.Name,
-			"the dropped PVC must also leave managedPVCs, or the node filter keeps checking it")
+		assert.Equal(t, []string{pvcHint.Name}, dropped,
+			"the dropped PVC must be reported so the caller removes it from managedPVCs")
+		assert.Contains(t, pvcs, pvcHint.Name,
+			"extractRequestedSize must not mutate the caller's map behind its back")
 		assert.Contains(t, got, pvcExplicitlyPending.Name, "the other PVCs must still be processed")
 	})
 
@@ -1139,10 +1144,121 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 		}
 
 		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcSpec.Name: pvcSpec}
-		_, err := extractRequestedSize(context.Background(), cl, log, pvcs,
+		_, _, err := extractRequestedSize(context.Background(), cl, log, pvcs,
 			map[string]*storagev1.StorageClass{brokenSCName: brokenSC}, nil)
 		require.Error(t, err)
 	})
+}
+
+// TestExtractRequestedSize_HintOnlyDowngrade walks every failure point of
+// requestForPVC from both sides. A PVC known only from the extra-pvcs annotation
+// must be reported in dropped and never fail the request; the identical failure
+// on a spec-sourced PVC must still fail it, because the Pod cannot run without
+// that mount.
+//
+// The replicated cases matter most: the e2e stand installs only sds-local-volume
+// (see e2e/tests/cluster_config.yml), so the RSC/RSP path has no e2e coverage at
+// all and this table is its only regression net.
+func TestExtractRequestedSize_HintOnlyDowngrade(t *testing.T) {
+	log, _ := logger.NewLogger("0")
+	ctx := context.Background()
+
+	const (
+		replicatedSCName = "repl-sc"
+		localSCName      = "local-sc"
+		poolName         = "repl-pool"
+		missingPVName    = "pv-already-deleted"
+	)
+
+	replicatedSC := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: replicatedSCName},
+		Provisioner: consts.SdsReplicatedVolumeProvisioner,
+	}
+	localSCWithoutLVMType := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: localSCName},
+		Provisioner: consts.SdsLocalVolumeProvisioner,
+		Parameters:  map[string]string{consts.LVMVolumeGroupsParamKey: `[{"name":"lvg1"}]`},
+	}
+	localSC := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: localSCName},
+		Provisioner: consts.SdsLocalVolumeProvisioner,
+		Parameters: map[string]string{
+			consts.LvmTypeParamKey:         consts.Thick,
+			consts.LVMVolumeGroupsParamKey: `[{"name":"lvg1"}]`,
+		},
+	}
+
+	// pvcFor builds a PVC named after the case so the two subtests of one case
+	// cannot collide in the fake client.
+	pvcFor := func(name, scName, volumeName string) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &scName,
+				VolumeName:       volumeName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+				},
+			},
+		}
+	}
+
+	tt := []struct {
+		name    string
+		sc      *storagev1.StorageClass
+		pvc     *corev1.PersistentVolumeClaim
+		objects []client.Object
+	}{
+		{
+			name: "RSC for the replicated SC does not exist",
+			sc:   replicatedSC,
+			pvc:  pvcFor("pvc-no-rsc", replicatedSCName, ""),
+			// no RSC object on purpose
+		},
+		{
+			name:    "RSP referenced by the RSC does not exist",
+			sc:      replicatedSC,
+			pvc:     pvcFor("pvc-no-rsp", replicatedSCName, ""),
+			objects: []client.Object{testRSC(replicatedSCName, srv.VolumeAccessLocal, poolName)},
+		},
+		{
+			name: "local SC carries no lvm-type parameter",
+			sc:   localSCWithoutLVMType,
+			pvc:  pvcFor("pvc-no-lvm-type", localSCName, ""),
+		},
+		{
+			name: "PV vanished from under a bound PVC",
+			sc:   localSC,
+			pvc:  pvcFor("pvc-dangling-pv", localSCName, missingPVName),
+			// no PV object on purpose
+		},
+	}
+
+	for _, tc := range tt {
+		scs := map[string]*storagev1.StorageClass{tc.sc.Name: tc.sc}
+
+		t.Run(tc.name+"/annotation-only PVC is dropped", func(t *testing.T) {
+			cl := newFakeClient(tc.objects...)
+			pvcs := map[string]*corev1.PersistentVolumeClaim{tc.pvc.Name: tc.pvc}
+
+			got, dropped, err := extractRequestedSize(ctx, cl, log, pvcs, scs,
+				map[string]bool{tc.pvc.Name: true})
+
+			require.NoError(t, err, "a hint PVC must never fail the whole scheduling request")
+			assert.Equal(t, []string{tc.pvc.Name}, dropped)
+			assert.NotContains(t, got, tc.pvc.Name, "a dropped PVC must not reserve space")
+		})
+
+		t.Run(tc.name+"/spec-sourced PVC still fails", func(t *testing.T) {
+			cl := newFakeClient(tc.objects...)
+			pvcs := map[string]*corev1.PersistentVolumeClaim{tc.pvc.Name: tc.pvc}
+
+			_, dropped, err := extractRequestedSize(ctx, cl, log, pvcs, scs, nil)
+
+			require.Error(t, err, "a PVC the Pod actually mounts must keep failing the request")
+			assert.Empty(t, dropped)
+		})
+	}
 }
 
 // TestFilter_LocalPVC_EmptyPhase_NoMatchingLVG is the end-to-end regression for

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2025 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package scheduler

--- a/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/func_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package scheduler
@@ -236,7 +236,7 @@ func TestShouldProcessPod(t *testing.T) {
 
 			cl := fake.NewFakeClient(tc.objects...)
 			targetProvisioners := []string{tc.targetProvisioner}
-			managedPVCs, err := getManagedPVCsFromPod(ctx, cl, log, tc.pod, targetProvisioners)
+			managedPVCs, _, err := getManagedPVCsFromPod(ctx, cl, log, tc.pod, targetProvisioners)
 			if (err != nil) != tc.expectedError {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -1014,7 +1014,7 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 		pvcs := map[string]*corev1.PersistentVolumeClaim{
 			pvFreshlyCreatedNoPhase.Name: pvFreshlyCreatedNoPhase,
 		}
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs)
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvFreshlyCreatedNoPhase.Name, "PVC with empty Status.Phase must NOT be dropped")
 		assert.Equal(t, requestQty.Value(), got[pvFreshlyCreatedNoPhase.Name].RequestedSize)
@@ -1025,7 +1025,7 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 		pvcs := map[string]*corev1.PersistentVolumeClaim{
 			pvcExplicitlyPending.Name: pvcExplicitlyPending,
 		}
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs)
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvcExplicitlyPending.Name)
 		assert.Equal(t, requestQty.Value(), got[pvcExplicitlyPending.Name].RequestedSize)
@@ -1033,7 +1033,7 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 
 	t.Run("bound PVC reports resize delta", func(t *testing.T) {
 		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcBound.Name: pvcBound}
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs)
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvcBound.Name)
 		assert.Equal(t, requestQty.Value()-pvCapacity.Value(), got[pvcBound.Name].RequestedSize,
@@ -1045,11 +1045,103 @@ func TestExtractRequestedSize_PhaseLag(t *testing.T) {
 		pvcBoundNoPhase.Name = "pvc-bound-no-phase"
 		pvcBoundNoPhase.Status = corev1.PersistentVolumeClaimStatus{}
 		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcBoundNoPhase.Name: pvcBoundNoPhase}
-		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs)
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, scs, nil)
 		require.NoError(t, err)
 		require.Contains(t, got, pvcBoundNoPhase.Name,
 			"a PVC with Spec.VolumeName set but empty Status.Phase must be treated as bound, not dropped")
 		assert.Equal(t, requestQty.Value()-pvCapacity.Value(), got[pvcBoundNoPhase.Name].RequestedSize)
+	})
+
+	// LVM rounds an LV up to the extent boundary, so a PV backing a decimal-unit
+	// request is larger than the request. The delta must clamp at 0: a negative
+	// size is summed into Cache.GetReservedSpace and getAvailableSpace subtracts
+	// it, which would inflate the pool's free space for every other Pod.
+	t.Run("bound PVC whose PV is larger than the request reserves nothing", func(t *testing.T) {
+		bigPVName := "pv-rounded-up"
+		bigPV := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: bigPVName},
+			Spec: corev1.PersistentVolumeSpec{
+				Capacity:         corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("11Gi")},
+				StorageClassName: scName,
+			},
+		}
+		pvcOverProvisioned := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-rounded-up", Namespace: "default"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &scName,
+				VolumeName:       bigPVName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+				},
+			},
+		}
+
+		clWithBigPV := newFakeClient(bigPV)
+		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcOverProvisioned.Name: pvcOverProvisioned}
+		got, err := extractRequestedSize(context.Background(), clWithBigPV, log, pvcs, scs, nil)
+		require.NoError(t, err)
+		require.Contains(t, got, pvcOverProvisioned.Name)
+		assert.Equal(t, int64(0), got[pvcOverProvisioned.Name].RequestedSize,
+			"pv.capacity > requests.storage must clamp to 0, never go negative")
+	})
+
+	// A PVC known only from the extra-pvcs annotation must never fail the whole
+	// request: an unresolvable one is dropped from both the requests and the
+	// managed-PVC map, so the downstream node filter stops considering it.
+	t.Run("unresolvable annotation-only PVC is dropped instead of failing", func(t *testing.T) {
+		brokenSCName := "local-sc-no-lvm-type"
+		brokenSC := &storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: brokenSCName},
+			Provisioner: provisioner,
+			Parameters:  map[string]string{consts.LVMVolumeGroupsParamKey: `[{"name":"lvg1"}]`},
+		}
+		pvcHint := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-hint-broken-sc", Namespace: "default"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &brokenSCName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: requestQty},
+				},
+			},
+		}
+
+		pvcs := map[string]*corev1.PersistentVolumeClaim{
+			pvcHint.Name:              pvcHint,
+			pvcExplicitlyPending.Name: pvcExplicitlyPending,
+		}
+		allSCs := map[string]*storagev1.StorageClass{scName: sc, brokenSCName: brokenSC}
+
+		got, err := extractRequestedSize(context.Background(), cl, log, pvcs, allSCs,
+			map[string]bool{pvcHint.Name: true})
+		require.NoError(t, err, "an annotation-only PVC must not fail the request")
+		assert.NotContains(t, got, pvcHint.Name)
+		assert.NotContains(t, pvcs, pvcHint.Name,
+			"the dropped PVC must also leave managedPVCs, or the node filter keeps checking it")
+		assert.Contains(t, got, pvcExplicitlyPending.Name, "the other PVCs must still be processed")
+	})
+
+	// The same failure on a spec-sourced PVC keeps failing the whole request.
+	t.Run("unresolvable spec PVC still fails the request", func(t *testing.T) {
+		brokenSCName := "local-sc-no-lvm-type-2"
+		brokenSC := &storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: brokenSCName},
+			Provisioner: provisioner,
+			Parameters:  map[string]string{consts.LVMVolumeGroupsParamKey: `[{"name":"lvg1"}]`},
+		}
+		pvcSpec := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-spec-broken-sc", Namespace: "default"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &brokenSCName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: requestQty},
+				},
+			},
+		}
+
+		pvcs := map[string]*corev1.PersistentVolumeClaim{pvcSpec.Name: pvcSpec}
+		_, err := extractRequestedSize(context.Background(), cl, log, pvcs,
+			map[string]*storagev1.StorageClass{brokenSCName: brokenSC}, nil)
+		require.Error(t, err)
 	})
 }
 

--- a/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	d8commonapi "github.com/deckhouse/sds-common-lib/api/v1alpha1"
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/cache"
 	"github.com/deckhouse/sds-node-configurator/images/sds-common-scheduler-extender/pkg/consts"
@@ -40,6 +41,7 @@ func init() {
 	_ = srv.AddToScheme(scheme.Scheme)
 	_ = corev1.AddToScheme(scheme.Scheme)
 	_ = storagev1.AddToScheme(scheme.Scheme)
+	_ = d8commonapi.AddToScheme(scheme.Scheme)
 }
 
 func newTestScheduler(cl client.Client, c *cache.Cache) *scheduler {

--- a/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2025 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package scheduler

--- a/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package scheduler
@@ -388,13 +388,18 @@ func testLocalThinSC(name, lvgName, thinPoolName string) *storagev1.StorageClass
 }
 
 func testPendingPVC(name, namespace, scName string) *corev1.PersistentVolumeClaim { //nolint:unparam
+	return pendingPVCWithSize(name, namespace, scName, oneGiB)
+}
+
+// pendingPVCWithSize is testPendingPVC with a caller-chosen request size.
+func pendingPVCWithSize(name, namespace, scName string, size int64) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			StorageClassName: &scName,
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse("1Gi"),
+					corev1.ResourceStorage: *resource.NewQuantity(size, resource.BinarySI),
 				},
 			},
 		},

--- a/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/handler_test_helpers_test.go
@@ -385,7 +385,7 @@ func testLocalThinSC(name, lvgName, thinPoolName string) *storagev1.StorageClass
 	}
 }
 
-func testPendingPVC(name, namespace, scName string) *corev1.PersistentVolumeClaim {
+func testPendingPVC(name, namespace, scName string) *corev1.PersistentVolumeClaim { //nolint:unparam
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec: corev1.PersistentVolumeClaimSpec{

--- a/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package scheduler
@@ -70,7 +70,7 @@ func (s *scheduler) prioritize(w http.ResponseWriter, r *http.Request) {
 	}
 	servingLog.Trace(fmt.Sprintf("NodeNames from the request: %+v", nodeNames))
 
-	managedPVCs, err := getManagedPVCsFromPod(ctx, s.client, servingLog, inputData.Pod, s.targetProvisioners)
+	managedPVCs, hintOnlyPVCs, err := getManagedPVCsFromPod(ctx, s.client, servingLog, inputData.Pod, s.targetProvisioners)
 	if err != nil {
 		servingLog.Error(err, "unable to get managed PVCs from the Pod")
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -113,7 +113,7 @@ func (s *scheduler) prioritize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	servingLog.Debug("starts to extract PVC requested sizes")
-	pvcRequests, err := extractRequestedSize(ctx, s.client, servingLog, managedPVCs, scUsedByPVCs)
+	pvcRequests, err := extractRequestedSize(ctx, s.client, servingLog, managedPVCs, scUsedByPVCs, hintOnlyPVCs)
 	if err != nil {
 		servingLog.Error(err, "unable to extract request size")
 		http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
@@ -113,12 +113,30 @@ func (s *scheduler) prioritize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	servingLog.Debug("starts to extract PVC requested sizes")
-	pvcRequests, err := extractRequestedSize(ctx, s.client, servingLog, managedPVCs, scUsedByPVCs, hintOnlyPVCs)
+	pvcRequests, droppedHints, err := extractRequestedSize(ctx, s.client, servingLog, managedPVCs, scUsedByPVCs, hintOnlyPVCs)
 	if err != nil {
 		servingLog.Error(err, "unable to extract request size")
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
+
+	// Mirror of filter: an unresolvable annotation-only PVC is dropped rather
+	// than allowed to fail the request, so scoring stops accounting for it.
+	if len(droppedHints) > 0 {
+		for _, name := range droppedHints {
+			delete(managedPVCs, name)
+		}
+		servingLog.Warning(fmt.Sprintf("dropping unresolvable PVCs listed only in the %s annotation: %v", consts.PodExtraPVCsAnnotation, droppedHints))
+	}
+	if len(managedPVCs) == 0 {
+		servingLog.Debug("After dropping unresolvable annotation PVCs, no managed PVCs left. Return the same nodes with 0 score")
+		if err := writeNodeScoresResponse(w, servingLog, nodeNames, 0); err != nil {
+			servingLog.Error(err, "unable to write node scores response")
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}
+		return
+	}
+
 	// Mirror of filter: do not short-circuit when len(pvcRequests) == 0. Scoring
 	// always runs so the response is consistent with the filter contract (the
 	// filter never returns "all nodes" for a local PVC; therefore prioritize

--- a/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/prioritize.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2025 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package scheduler

--- a/images/sds-common-scheduler-extender/pkg/scheduler/space_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/space_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2025 Flant JSC
+	Copyright 2026 Flant JSC
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package scheduler
@@ -29,6 +29,7 @@ import (
 
 const (
 	oneGiB     = int64(1 << 30) // 1 GiB in bytes
+	tenGiB     = int64(10) * oneGiB
 	hundredGiB = int64(100) * oneGiB
 )
 

--- a/images/sds-common-scheduler-extender/pkg/scheduler/space_test.go
+++ b/images/sds-common-scheduler-extender/pkg/scheduler/space_test.go
@@ -1,17 +1,17 @@
 /*
-	Copyright 2026 Flant JSC
+Copyright 2025 Flant JSC
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package scheduler


### PR DESCRIPTION
## What

Teach `sds-common-scheduler-extender` to read the PVCs a Pod needs from the
`scheduler.deckhouse.io/extra-pvcs` annotation, as a **second source in addition to**
`pod.Spec.Volumes`.

- **Key:** `scheduler.deckhouse.io/extra-pvcs`, one constant (`pkg/consts/consts.go`).
- **Value:** CSV of PVC names — `"pvc-a,pvc-b"`. Entries are trimmed, empties ignored.
- **Namespace:** always the Pod's own.

The collection point is `getManagedPVCsFromPod` (`pkg/scheduler/func.go`): it now walks a
deduplicated union of the spec-volume claim names and the CSV names from the annotation.
Once a PVC is in `managedPVCs`, the existing pipeline (`getStorageClassesUsedByPVCs` →
`extractRequestedSize` → local/replicated split → LVG/space filter → `createReservations`)
treats it exactly like a spec-sourced one. Both handlers (`filter`, `prioritize`) inherit
it, and the 60s reservation is created automatically.

### The hint contract

An annotation is a **best-effort hint, not a mount** — the Pod runs fine without that
volume — so an unresolvable name must never cost the Pod its nodes. A spec-sourced PVC
keeps the opposite rule: the Pod genuinely cannot run without it, so failing to resolve one
still fails the whole scheduling request.

Carrying that distinction past the collection point needs the PVC's origin, so
`getManagedPVCsFromPod` returns a second map marking the annotation-only names, and it is
honoured at two places:

1. **The PVC itself is missing.** `IsNotFound` on the `Get` skips the name (it may
   legitimately not exist yet); the skipped names are reported in one aggregated `Warning`.
2. **The PVC exists but cannot be resolved** — no `lvm-type` parameter, a deleted RSC/RSP,
   a PV gone from under a bound PVC. `extractRequestedSize` reports those names in a new
   `dropped` return value instead of failing; `filter`/`prioritize` then remove them from
   `managedPVCs`, exactly as they already do for `dropPVCsWithMissingSC`, and short-circuit
   if nothing is left. The Pod degrades to its pre-annotation behavior.

Not yet covered by (2): errors from `discoverProvisionerForPVC` and `getNewControlPlane`
inside `getManagedPVCsFromPod`, and from `getStorageClassesUsedByPVCs` / node lookups in
the handlers, still fail the request for an annotation-only PVC. See Known gaps.

### Behavior for Pods without the annotation

Unchanged, with **one deliberate exception**: `requestForPVC` now clamps the bound-PVC
delta at zero.

```go
RequestedSize: max(requested-pv.Spec.Capacity.Storage().Value(), 0)
```

LVM rounds an LV up to the extent boundary, so a PV backing a decimal-unit request ("10G")
is larger than the request itself and the delta went negative. `Cache.GetReservedSpace`
sums reservation sizes without checking the sign and `getAvailableSpace` computes
`baseFree - reserved`, so a negative reservation **inflated** the pool's free space for
every other Pod scheduled in the same 60s window. This is a fix on the main (spec-sourced)
path, not on the annotation path, and it applies whether or not the annotation is present.

Everything else for an annotation-free Pod is byte-identical, pinned by tests including the
pre-existing `TestShouldProcessPod` regression suite.

## Why do we need it, and what problem does it solve?

Kaiten US 67033244. A DVP VM with a hotplug disk is two Pods:

- `virt-launcher` (`d8v-vm-*`) runs the VM, and KubeVirt **deliberately** keeps hotplug
  volumes out of its `spec.volumes`;
- the hotplug attachment Pod (`d8v-hp-*`) carries the PVC and is pinned to the launcher's
  node by `nodeAffinity`.

So the launcher schedules **first and blind** — free space and replica proximity are never
consulted — and the attachment Pod is then forced onto whatever node the launcher picked.
If the volume can't live there, the attachment Pod hangs `Pending` while the launcher is
already on the wrong node.

Confirmed live on the `base` DVP stand (2026-08-03): launcher `d8v-vm-worker-1-2nzxw` has
only an `emptyDir` in `spec.volumes` and no PVC at all; its attachment Pod
`d8v-hp-worker-1-kph6b` holds the PVC on the same node. The extender is registered without
`managedResources`, so kube-scheduler *does* call `filter` for the launcher — the hook
exists, there was just nothing for it to act on.

**This is a best-effort hint, not a guarantee.** The extender is registered with
`ignorable: true` (if it times out, kube-scheduler schedules without it), the reservation
lives 60s and is not renewed, and only *hotplug-at-VM-start* is covered — hotplugging into
an already-running VM is explicitly out of scope, since `filter` for that launcher will
never run again.

## What is the expected result?

- A Pod **without** the annotation: no observable change, except the negative-reservation
  clamp described above.
- A `virt-launcher`-shaped Pod (no PVC in `spec.volumes`) **with** the annotation: the
  extender stops being a no-op for it — it filters out nodes whose LVMVolumeGroup lacks
  space and places a 60s reservation on the survivors, so the launcher lands where the
  hotplug volume can actually be provisioned.
- An annotation naming a PVC of a foreign provisioner, or one that doesn't exist, or one
  the extender cannot resolve, or a malformed value: ignored with a `Warning`, and the Pod
  is scheduled as it would have been before this annotation existed.

Known mis-annotation risk: within a namespace, any Pod can name any PVC, and for
`Local`-access replicated PVCs that means a **hard reject** of nodes, not merely a bad
placement. Blast radius is namespace-bounded; validating who may set the annotation is
deliberately deferred until a real abuse case appears.

## Checklist

- [x] The code is covered by unit tests.
- [ ] **e2e tests passed** — no e2e in this PR. The annotation e2e specs are deliberately
      split out: they need their own design pass and land separately. This PR is the
      scheduler-extender change plus its unit and handler-level coverage.
- [ ] Documentation updated according to the changes — **no user-facing docs on purpose:**
      the final annotation key is still pending agreement with the other consumers, so
      publishing it now would document an unagreed contract.
- [ ] Changes were tested in the Kubernetes cluster manually — not yet.

## Test coverage

**Parsing and collection** (`pkg/scheduler/extra_pvcs_test.go`):

- CSV parser edge cases; the annotation key is pinned by a test, since it's a cross-module
  contract.
- `getManagedPVCsFromPod` table: no annotation (backward-compat), annotation-only, several
  names, spec+annotation dedup (a duplicate counts as spec-sourced), missing annotation PVC
  skipped, foreign provisioner filtered, malformed value, and **missing spec PVC still
  errors**. Each case also asserts which names come back marked annotation-only.

**Hint downgrade** (`pkg/scheduler/func_test.go`):

- `TestExtractRequestedSize_HintOnlyDowngrade` — every failure point of `requestForPVC`
  from both sides: RSC missing, RSP missing, no `lvm-type` parameter, PV gone from under a
  bound PVC; each asserted as *dropped* for an annotation-only PVC and as *still failing*
  for a spec-sourced one.
- `extractRequestedSize` must not mutate the caller's PVC map — the dropped names come back
  as a return value.
- The negative-delta clamp: a bound PVC whose PV is larger than the request reserves 0.

**Handler level** (`pkg/scheduler/extra_pvcs_test.go`), driving the real HTTP handlers:

- `/filter` local space-reject with the reservation actually created;
- `/filter` no-annotation no-op;
- `/filter` with an unbound **replicated** PVC at `volumeAccess: Local`;
- `/filter` with an unresolvable annotation PVC — all nodes survive and nothing is reserved;
- `/prioritize` scores nodes for an annotation PVC and narrows the reservation to the final
  node list.

**e2e** — none in this PR, on purpose (see the checklist above).

## Known gaps

- **No e2e coverage in this PR at all.** Behavior is pinned by unit and handler-level tests
  only. Note also that the e2e stand (`e2e/tests/cluster_config.yml`) installs only
  `sds-local-volume`, so whenever the e2e specs do land, the replicated path still cannot be
  covered there without adding `sds-replicated-volume` to the stand — today that path is
  covered at handler level by `TestFilter_AnnotationPVC_ReplicatedLocalAccess` and at unit
  level by the RSC/RSP cases of `TestExtractRequestedSize_HintOnlyDowngrade`.
- **The hint downgrade is not applied everywhere.** An annotation-only PVC still fails the
  whole scheduling request if `discoverProvisionerForPVC` or `getNewControlPlane` errors
  inside `getManagedPVCsFromPod`, or if `getStorageClassesUsedByPVCs` / the node lookups in
  the handlers error. Most of those are transient and kube-scheduler retries; the one that
  does not self-heal is a bound annotation PVC whose PV was deleted and whose StorageClass
  is also gone, which sends `discoverProvisionerForPVC` into a PV lookup that fails
  permanently.
- **The reservation for an annotation PVC never narrows to a single node.** `filter` spreads
  it over every surviving node and `prioritize` narrows it to the final node list, but the
  last step — narrowing to one node once VolumeBinding stamps `selected-node` on the PVC —
  never happens, because the Pod does not mount the PVC and no binding cycle touches it. So
  the reservation stays spread across all candidate nodes until the 60s TTL expires,
  temporarily understating free space on each of them for other Pods.
- **`local` + already-bound annotation PVC is not filtered meaningfully** — for a bound PVC
  the requested delta is ≈0, so the space check passes trivially and nothing verifies the
  node actually holds the LV. This is status quo, not a regression (before this change the
  extender returned all nodes for such a Pod), but it is worth knowing before anyone relies
  on annotation PVCs for bound local volumes.
- The `managedResources`-is-empty precondition lives in control-plane-manager, outside this
  repo, and can drift independently of this code.
