### PR TITLE
fix(crds): declare LVMVolumeGroup status.conditions as a keyed list

### DIFF
--- a/crds/lvmvolumegroup.yaml
+++ b/crds/lvmvolumegroup.yaml
@@ -316,6 +316,9 @@ spec:
                   description: |
                     LVMVolumeGroup conditions.
                   type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - type
                   items:
                     type: object
                     properties:


### PR DESCRIPTION
## Description

Adds `x-kubernetes-list-type: map` and `x-kubernetes-list-map-keys: [type]` to `status.conditions` in the LVMVolumeGroup CRD.

No controller or agent code changes. Nothing outside this module's own CRD is affected, and no component restarts.

## Why do we need it, and what problem does it solve?

With the array left untyped, the API server treats `status.conditions` as atomic:

- it enforces no uniqueness on the condition type, so nothing at the schema level prevents two entries with the same `type`;
- server-side apply replaces the entire list rather than merging per type.

LVMVolumeGroup is the object in this module where that matters most, because two separate components write conditions to the same object:

- the node agent publishes `VGConfigurationApplied` and `VGReady`;
- the controller publishes `NodeReady`, `AgentReady` and the aggregate `Ready`.

Both currently reconcile the list by hand under `RetryOnConflict` — the agent in `LVGClient.UpdateLVGConditionIfNeeded`, the controller in `sds_infra_watcher_funcs.go` — so nothing is broken today. The point of this change is that the schema now encodes the invariant those two hand-rolled implementations rely on, instead of leaving it to convention.

This came out of a review of `status.conditions` across the storage modules. The same gap exists in sds-elastic, sds-object and csi-scsi-generic, each fixed in its own PR.

LvmVolumeGroupBackup has the same gap and is deliberately left alone: nothing in the module reconciles that kind today.

## What is the expected result?

After applying, the CRD schema carries the list-type markers:

```
kubectl get crd lvmvolumegroups.storage.deckhouse.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.x-kubernetes-list-type}'
# map
```

Existing LVMVolumeGroups and their conditions are unaffected — this only constrains how the API server merges and validates future writes. Agent and controller behaviour is unchanged; conditions must keep converging exactly as before.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Schema-only change with no Go code, so there is nothing to unit test. Not verified on a live cluster. Given that two writers touch this list, an e2e run that exercises LVG creation and node/agent readiness transitions would be the meaningful check before merge.
