### PR TITLE
fix(crds): make the LVMVolumeGroup condition type a required field

### DIFF
--- a/crds/lvmvolumegroup.yaml
+++ b/crds/lvmvolumegroup.yaml
@@ -321,6 +321,9 @@ spec:
                     - type
                   items:
                     type: object
+                    required:
+                      - type
+                      - status
                     properties:
                       type:
                         type: string


### PR DESCRIPTION
## Problem

`ModuleEnsureCRDs` fails on `main`:

```
update crd: CustomResourceDefinition.apiextensions.k8s.io "lvmvolumegroups.storage.deckhouse.io" is invalid:
spec.validation.openAPIV3Schema.properties[status].properties[conditions].items.properties[type].default:
Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
```

#341 declared `status.conditions` as `x-kubernetes-list-type: map` with `type` as the map key, but left `type` optional in the item schema. The API server requires every map key to be either `required` or defaulted, so that the merge key of an item is always computable. The CRD update is rejected and the module stays on the previously registered schema.

## Fix

Mark `type` as required, along with `status`, which is equally mandatory for a condition to carry any meaning.

## Compatibility

Both writers of the list — `UpdateLVGConditionIfNeeded` in the agent and `updateLVGConditionIfNeeded` in the controller — always populate `type` and `status`, so existing objects keep validating on update.

## Related

Fixes the regression from #341.