### PR TITLE
fix(status): truncate the condition message to what the schema allows

### DIFF
--- a/images/agent/internal/conditions.go
+++ b/images/agent/internal/conditions.go
@@ -74,5 +74,14 @@ func ReadyConditionForPhase(generation int64, phase, reason, kind string) metav1
 		cond.Message = fmt.Sprintf("the %s is in the %s phase", kind, phase)
 	}
 
+	// status.reason is free-form and carries raw LVM output, while the schema
+	// caps the condition message at 32768. Over the cap the API server rejects
+	// the whole status write, so the resource would keep reporting its previous
+	// verdict and the agent would fail on the write rather than on the command
+	// that actually went wrong. conditions.Set does not truncate: it is a thin
+	// wrapper over meta.SetStatusCondition, and only the library's Ready and
+	// ReadyWithMessage builders truncate for you.
+	cond.Message = conditions.TruncateMessage(cond.Message)
+
 	return cond
 }

--- a/images/agent/internal/conditions_test.go
+++ b/images/agent/internal/conditions_test.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,6 +52,18 @@ func TestReadyConditionForPhase(t *testing.T) {
 			assert.Equal(t, int64(7), cond.ObservedGeneration)
 		})
 	}
+}
+
+// status.reason carries raw LVM output, and the schema caps the condition
+// message at 32768. Over the cap the API server rejects the whole status write,
+// so the resource keeps reporting its previous verdict and the agent fails on
+// the write instead of on the command that actually went wrong.
+func TestReadyConditionForPhaseTruncatesAnOversizedMessage(t *testing.T) {
+	huge := strings.Repeat("x", conditions.MaxMessageLen+100)
+
+	cond := ReadyConditionForPhase(1, v1alpha1.PhaseFailed, huge, "LVMLogicalVolume")
+
+	assert.LessOrEqual(t, len(cond.Message), conditions.MaxMessageLen)
 }
 
 // status.reason carries free-form text, including raw output from a failed LVM

--- a/images/agent/internal/conditions_test.go
+++ b/images/agent/internal/conditions_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,11 +60,15 @@ func TestReadyConditionForPhase(t *testing.T) {
 // so the resource keeps reporting its previous verdict and the agent fails on
 // the write instead of on the command that actually went wrong.
 func TestReadyConditionForPhaseTruncatesAnOversizedMessage(t *testing.T) {
-	huge := strings.Repeat("x", conditions.MaxMessageLen+100)
+	// Multi-byte on purpose. The schema's maxLength is an OpenAPI string
+	// length, counted in runes, and TruncateMessage counts the same way — a
+	// byte-counting assertion here would fail on a message that is in fact
+	// within the limit.
+	huge := strings.Repeat("я", conditions.MaxMessageLen+100)
 
 	cond := ReadyConditionForPhase(1, v1alpha1.PhaseFailed, huge, "LVMLogicalVolume")
 
-	assert.LessOrEqual(t, len(cond.Message), conditions.MaxMessageLen)
+	assert.LessOrEqual(t, utf8.RuneCountInString(cond.Message), conditions.MaxMessageLen)
 }
 
 // status.reason carries free-form text, including raw output from a failed LVM

--- a/images/agent/internal/conditions_test.go
+++ b/images/agent/internal/conditions_test.go
@@ -64,7 +64,10 @@ func TestReadyConditionForPhaseTruncatesAnOversizedMessage(t *testing.T) {
 	// length, counted in runes, and TruncateMessage counts the same way — a
 	// byte-counting assertion here would fail on a message that is in fact
 	// within the limit.
-	huge := strings.Repeat("я", conditions.MaxMessageLen+100)
+	//
+	// Written as an escape rather than the character itself: the module linter
+	// rejects non-ASCII bytes in Go sources.
+	huge := strings.Repeat("\u044f", conditions.MaxMessageLen+100)
 
 	cond := ReadyConditionForPhase(1, v1alpha1.PhaseFailed, huge, "LVMLogicalVolume")
 

--- a/images/agent/internal/repository/client_lvg.go
+++ b/images/agent/internal/repository/client_lvg.go
@@ -80,6 +80,14 @@ func (lvgCl *LVGClient) UpdateLVGConditionIfNeeded(
 ) error {
 	lvgCl.log.Debug(fmt.Sprintf("[UpdateLVGConditionIfNeeded] set the condition type %s status %s reason %s message %s on the LVMVolumeGroup %s", conType, status, reason, message, lvg.Name))
 
+	// Callers pass raw error text, including the output of failed LVM commands,
+	// while the schema caps the message at 32768. Over the cap the API server
+	// rejects the whole status write, so the group would keep reporting its
+	// previous verdict and the agent would fail on the write rather than on the
+	// command that actually went wrong. conditions.Set does not truncate: it is
+	// a thin wrapper over meta.SetStatusCondition.
+	message = conditions.TruncateMessage(message)
+
 	// The state UpdateStatus read and wrote, kept so the server-side values can be
 	// mirrored onto the caller's object below.
 	var written *v1alpha1.LVMVolumeGroup

--- a/images/controller/pkg/controller/lvg_conditions_watcher_funcs.go
+++ b/images/controller/pkg/controller/lvg_conditions_watcher_funcs.go
@@ -73,7 +73,13 @@ func decideLVGReadyAndPhase(lvg *v1alpha1.LVMVolumeGroup) lvgVerdict {
 				Status:             status,
 				ObservedGeneration: lvg.Generation,
 				Reason:             reason,
-				Message:            message,
+				// The messages below list condition types, so they stay well
+				// inside the schema's 32768 in practice. Truncating anyway is
+				// what makes "every condition this module writes fits the
+				// schema" true by construction rather than by argument: the
+				// list is as long as the conditions the agents happen to have
+				// written, and nothing here bounds that.
+				Message: conditions.TruncateMessage(message),
 			},
 		}
 	}

--- a/images/controller/pkg/controller/lvm_volume_group_set_conditions_test.go
+++ b/images/controller/pkg/controller/lvm_volume_group_set_conditions_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,11 +71,15 @@ func TestReadyConditionForSetPhaseKeepsFreeFormTextOutOfTheReason(t *testing.T) 
 // set keeps reporting its previous verdict and the reconcile fails on the write
 // instead of on what actually went wrong.
 func TestReadyConditionForSetPhaseTruncatesAnOversizedMessage(t *testing.T) {
-	huge := strings.Repeat("x", conditions.MaxMessageLen+100)
+	// Multi-byte on purpose. The schema's maxLength is an OpenAPI string
+	// length, counted in runes, and TruncateMessage counts the same way — a
+	// byte-counting assertion here would fail on a message that is in fact
+	// within the limit.
+	huge := strings.Repeat("я", conditions.MaxMessageLen+100)
 
 	cond := readyConditionForSetPhase(1, phaseNotCreated, huge)
 
-	assert.LessOrEqual(t, len(cond.Message), conditions.MaxMessageLen)
+	assert.LessOrEqual(t, utf8.RuneCountInString(cond.Message), conditions.MaxMessageLen)
 }
 
 // Every phase the CRD admits, apart from the empty string it explicitly allows,

--- a/images/controller/pkg/controller/lvm_volume_group_set_conditions_test.go
+++ b/images/controller/pkg/controller/lvm_volume_group_set_conditions_test.go
@@ -75,7 +75,10 @@ func TestReadyConditionForSetPhaseTruncatesAnOversizedMessage(t *testing.T) {
 	// length, counted in runes, and TruncateMessage counts the same way — a
 	// byte-counting assertion here would fail on a message that is in fact
 	// within the limit.
-	huge := strings.Repeat("я", conditions.MaxMessageLen+100)
+	//
+	// Written as an escape rather than the character itself: the module linter
+	// rejects non-ASCII bytes in Go sources.
+	huge := strings.Repeat("\u044f", conditions.MaxMessageLen+100)
 
 	cond := readyConditionForSetPhase(1, phaseNotCreated, huge)
 

--- a/images/controller/pkg/controller/lvm_volume_group_set_conditions_test.go
+++ b/images/controller/pkg/controller/lvm_volume_group_set_conditions_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,18 @@ func TestReadyConditionForSetPhaseKeepsFreeFormTextOutOfTheReason(t *testing.T) 
 
 	assert.Equal(t, text, cond.Message)
 	assert.Equal(t, conditions.ReasonReconcileFailed, cond.Reason)
+}
+
+// That free-form text is unbounded, and the schema caps the condition message
+// at 32768. Over the cap the API server rejects the whole status write, so the
+// set keeps reporting its previous verdict and the reconcile fails on the write
+// instead of on what actually went wrong.
+func TestReadyConditionForSetPhaseTruncatesAnOversizedMessage(t *testing.T) {
+	huge := strings.Repeat("x", conditions.MaxMessageLen+100)
+
+	cond := readyConditionForSetPhase(1, phaseNotCreated, huge)
+
+	assert.LessOrEqual(t, len(cond.Message), conditions.MaxMessageLen)
 }
 
 // Every phase the CRD admits, apart from the empty string it explicitly allows,

--- a/images/controller/pkg/controller/lvm_volume_group_set_watcher.go
+++ b/images/controller/pkg/controller/lvm_volume_group_set_watcher.go
@@ -372,6 +372,14 @@ func readyConditionForSetPhase(generation int64, phase, reason string) metav1.Co
 		cond.Message = fmt.Sprintf("the LVMVolumeGroupSet is in the %s phase", phase)
 	}
 
+	// reason is free-form and carries raw error strings, while the schema caps
+	// the condition message at 32768. Over the cap the API server rejects the
+	// whole status write, so the set would keep reporting its previous verdict
+	// and the reconcile would fail on the write rather than on what actually
+	// went wrong. conditions.Set does not truncate: it is a thin wrapper over
+	// meta.SetStatusCondition.
+	cond.Message = conditions.TruncateMessage(cond.Message)
+
 	return cond
 }
 

--- a/images/controller/pkg/controller/sds_infra_watcher_funcs.go
+++ b/images/controller/pkg/controller/sds_infra_watcher_funcs.go
@@ -186,6 +186,13 @@ func GetLVMVolumeGroups(ctx context.Context, cl client.Client, metrics monitorin
 func updateLVGConditionIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, lvg *v1alpha1.LVMVolumeGroup, status metav1.ConditionStatus, conType, reason, message string) error {
 	log.Debug(fmt.Sprintf("[updateLVGConditionIfNeeded] set the condition type %s status %s reason %s message %s on the LVMVolumeGroup %s", conType, status, reason, message, lvg.Name))
 
+	// Callers pass raw error text, while the schema caps the message at 32768.
+	// Over the cap the API server rejects the whole status write, so the group
+	// would keep reporting its previous verdict and the reconcile would fail on
+	// the write rather than on what actually went wrong. conditions.Set does not
+	// truncate: it is a thin wrapper over meta.SetStatusCondition.
+	message = conditions.TruncateMessage(message)
+
 	// The state UpdateStatus read and wrote, kept so the server-side values can be
 	// mirrored onto the caller's object below.
 	var written *v1alpha1.LVMVolumeGroup


### PR DESCRIPTION
## Description

Every writer in this module builds its `Ready` condition by hand and puts `status.reason` in the message — free-form text that holds the raw output of failed LVM commands. The CRDs cap `message` at 32768, the limit `metav1.Condition` itself declares. Nothing between the two truncates.

`conditions.Set` looks like it would, but it does not: it is a thin wrapper over `meta.SetStatusCondition`. Only the library's `Ready` and `ReadyWithMessage` builders call `TruncateMessage`, and this module uses neither.

Five writers, across both binaries:

- the agent's `ReadyConditionForPhase`, shared by `LVMLogicalVolume` and `LVMLogicalVolumeSnapshot`
- the agent's `UpdateLVGConditionIfNeeded`
- the controller's `updateLVGConditionIfNeeded`
- `readyConditionForSetPhase` for `LVMVolumeGroupSet`
- the aggregate verdict in `decideLVGReadyAndPhase`

The last one lists condition types rather than error text, so it stays well inside the cap in practice. It is truncated anyway: the list is as long as the conditions the agents happen to have written, and nothing there bounds it.

## Why do we need it, and what problem does it solve?

An oversized message does not get trimmed by the API server — the whole status write is rejected. Three things follow, in order of how confusing they are:

1. The resource keeps advertising its **previous** verdict. A `Ready=True` from the last successful pass survives the failure that should have replaced it, so an alert on `Ready=False` never fires for exactly the failure that produced the most output.
2. The reconcile fails on the status write rather than on the underlying problem, so the log names an admission error instead of the thing that actually broke.
3. It is self-reinforcing: the longer the error, the more certain it is to be lost.

The errors that reach this length are the ones worth reading — an aggregate over many nodes, or a command's captured output.

## What is the expected result?

A failure whose message exceeds 32768 is published with the message truncated to the cap (the library appends an ellipsis), `Ready=False` and `reason: ReconcileFailed`, instead of the status write being rejected.

Unchanged: `status.reason`, which the schema does not limit, still carries the full text; the debug logs still print it untruncated; messages under the cap are byte-for-byte what they were.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
