### PR TITLE
refactor(conditions): drop the module's copy of the shared Pending reason

### DIFF
--- a/images/controller/internal/const.go
+++ b/images/controller/internal/const.go
@@ -19,7 +19,6 @@ package internal
 const (
 	SdsNodeConfiguratorNamespace = "d8-sds-node-configurator"
 
-	ReasonPending          = "Pending"
 	ReasonUpdating         = "Updating"
 	ReasonCreating         = "Creating"
 	ReasonTerminating      = "Terminating"

--- a/images/controller/pkg/controller/lvg_conditions_watcher_funcs.go
+++ b/images/controller/pkg/controller/lvg_conditions_watcher_funcs.go
@@ -85,7 +85,7 @@ func decideLVGReadyAndPhase(lvg *v1alpha1.LVMVolumeGroup) lvgVerdict {
 	}
 
 	if missing := missingConditionTypes(lvg); len(missing) > 0 {
-		return verdict(v1alpha1.PhasePending, metav1.ConditionFalse, internal.ReasonPending,
+		return verdict(v1alpha1.PhasePending, metav1.ConditionFalse, conditions.ReasonPending,
 			fmt.Sprintf("waiting for the conditions %s to be configured", strings.Join(missing, ",")))
 	}
 
@@ -100,7 +100,7 @@ func decideLVGReadyAndPhase(lvg *v1alpha1.LVMVolumeGroup) lvgVerdict {
 		// loop that used to break here.
 		switch c.Reason {
 		case internal.ReasonCreating:
-			return verdict(v1alpha1.PhasePending, metav1.ConditionFalse, internal.ReasonPending,
+			return verdict(v1alpha1.PhasePending, metav1.ConditionFalse, conditions.ReasonPending,
 				fmt.Sprintf("condition %s has Creating reason", c.Type))
 		case internal.ReasonTerminating:
 			return verdict(v1alpha1.PhaseTerminating, metav1.ConditionFalse, internal.ReasonTerminating,

--- a/images/controller/pkg/controller/lvg_ready_verdict_test.go
+++ b/images/controller/pkg/controller/lvg_ready_verdict_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"github.com/deckhouse/sds-common-lib/conditions"
 	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 	"github.com/deckhouse/sds-node-configurator/images/controller/internal"
 )
@@ -89,14 +90,14 @@ func TestDecideLVGReadyAndPhase(t *testing.T) {
 			}(),
 			wantPhase:  v1alpha1.PhasePending,
 			wantStatus: metav1.ConditionFalse,
-			wantReason: internal.ReasonPending,
+			wantReason: conditions.ReasonPending,
 		},
 		{
 			name:       "a stage is still being created",
 			lvg:        lvgWith(falseCond(internal.TypeVGConfigurationApplied, internal.ReasonCreating)),
 			wantPhase:  v1alpha1.PhasePending,
 			wantStatus: metav1.ConditionFalse,
-			wantReason: internal.ReasonPending,
+			wantReason: conditions.ReasonPending,
 		},
 		{
 			name:       "a stage is terminating",


### PR DESCRIPTION
## Description

`images/controller/internal` declared `ReasonPending = "Pending"` alongside `conditions.ReasonPending` from sds-common-lib, which holds the same string. This drops the local copy and points its two call sites at the library constant.

The set watcher already used the library one; only the conditions watcher used the local one. Now both do.

Stacked on #345; the diff against `main` will contain that PR's commit until it merges.

## Why do we need it, and what problem does it solve?

Two names for one value is how the two drift apart. A change to the shared vocabulary — of the kind sds-elastic and sds-object just went through — would have moved `conditions.ReasonPending` and left `internal.ReasonPending` behind, and nothing would have failed: no compile error, no test, no schema violation. The symptom would have surfaced only as an `LVMVolumeGroup` and an `LVMVolumeGroupSet` describing the same situation in two different words, which is exactly what the standardization was for.

## What is the expected result?

No behavioural change: both constants held `"Pending"`, so every condition this module writes carries the same reason it did before. What changes is that a future edit to the shared vocabulary now reaches this module.

The reasons that stay in `internal` — `Creating`, `Updating`, `Terminating`, `ValidationFailed`, `FileDeviceDrift` — are this module's own. They name states no shared vocabulary describes, and the aggregate verdict reads `Creating` and `Terminating` to decide the phase.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
