### PR TITLE
fix(templates): gate optional resources on CRD presence, not the module list

### DIFF
--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -8,7 +8,7 @@ cpu: 50m
 memory: 50Mi
 {{- end }}
 
-{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if (include "helm_lib_api_version_exists" (list . "autoscaling.k8s.io/v1/VerticalPodAutoscaler")) }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -107,7 +107,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if not (include "helm_lib_api_version_exists" (list . "autoscaling.k8s.io/v1/VerticalPodAutoscaler")) }}
             {{- include "sds_utils_installer_resources" . | nindent 14 }}
 {{- end }}
 {{- if .Values.sdsNodeConfigurator.enableThinProvisioning }}
@@ -150,7 +150,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if not (include "helm_lib_api_version_exists" (list . "autoscaling.k8s.io/v1/VerticalPodAutoscaler")) }}
             {{- include "sds_utils_installer_resources" . | nindent 14 }}
 {{- end }}
 {{- end }}
@@ -233,7 +233,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if not (include "helm_lib_api_version_exists" (list . "autoscaling.k8s.io/v1/VerticalPodAutoscaler")) }}
             {{- include "sds_node_configurator_agent_resources" . | nindent 14 }}
 {{- end }}
       - name: kube-rbac-proxy
@@ -282,7 +282,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if not (include "helm_lib_api_version_exists" (list . "autoscaling.k8s.io/v1/VerticalPodAutoscaler")) }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 14 }}
 {{- end }}
       volumes:

--- a/templates/agent/daemonset.yaml
+++ b/templates/agent/daemonset.yaml
@@ -8,7 +8,7 @@ cpu: 50m
 memory: 50Mi
 {{- end }}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -107,7 +107,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "sds_utils_installer_resources" . | nindent 14 }}
 {{- end }}
 {{- if .Values.sdsNodeConfigurator.enableThinProvisioning }}
@@ -150,7 +150,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "sds_utils_installer_resources" . | nindent 14 }}
 {{- end }}
 {{- end }}
@@ -233,7 +233,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "sds_node_configurator_agent_resources" . | nindent 14 }}
 {{- end }}
       - name: kube-rbac-proxy
@@ -282,7 +282,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 14 }}
 {{- end }}
       volumes:

--- a/templates/agent/podmonitor.yaml
+++ b/templates/agent/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
+{{- if (include "helm_lib_api_version_exists" (list . "monitoring.coreos.com/v1/PodMonitor")) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/templates/agent/podmonitor.yaml
+++ b/templates/agent/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/templates/controller/servicemonitor.yaml
+++ b/templates/controller/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
+{{- if (include "helm_lib_api_version_exists" (list . "monitoring.coreos.com/v1/ServiceMonitor")) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/templates/controller/servicemonitor.yaml
+++ b/templates/controller/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/templates/sds-common-scheduler-extender/deployment.yaml
+++ b/templates/sds-common-scheduler-extender/deployment.yaml
@@ -3,7 +3,7 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -112,7 +112,7 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-              {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+              {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "sds_common_scheduler_extender_resources" . | nindent 14 }}
               {{- end }}
           ports:

--- a/templates/sds-common-scheduler-extender/deployment.yaml
+++ b/templates/sds-common-scheduler-extender/deployment.yaml
@@ -3,7 +3,7 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
-{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if (include "helm_lib_api_version_exists" (list . "autoscaling.k8s.io/v1/VerticalPodAutoscaler")) }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -112,7 +112,7 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-              {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+              {{- if not (include "helm_lib_api_version_exists" (list . "autoscaling.k8s.io/v1/VerticalPodAutoscaler")) }}
               {{- include "sds_common_scheduler_extender_resources" . | nindent 14 }}
               {{- end }}
           ports:


### PR DESCRIPTION
## Description

VerticalPodAutoscaler and PodMonitor/ServiceMonitor objects in `templates/` were rendered only when the module that ships their CRD appeared in `.Values.global.enabledModules` (`... | has "<name>-crd"`). Every one of those gates now asks whether the CRD is actually available, through the lib-helm helper:

```
{{- if (include "helm_lib_api_version_exists" (list . "<group>/<version>/<Kind>")) }}
```

Kinds used:

- `vertical-pod-autoscaler-crd` → `autoscaling.k8s.io/v1/VerticalPodAutoscaler`
- `operator-prometheus-crd` → `monitoring.coreos.com/v1/PodMonitor` or `.../ServiceMonitor`, matching the kind the file renders

Files touched (4):

- `templates/agent/daemonset.yaml`
- `templates/agent/podmonitor.yaml`
- `templates/controller/servicemonitor.yaml`
- `templates/sds-common-scheduler-extender/deployment.yaml`

Gates inside the vendored lib-helm helpers still key on `enabledModules`; changing those needs a lib-helm MR and is out of scope here.

## Why do we need it, and what problem does it solve?

The name of the module that installs a CRD is a proxy for what the template really depends on, which is the CRD being available. The two diverge — the CRD is in the cluster but was installed by something else, or the module gets renamed — and then the template silently skips a resource it could perfectly well create.

`helm_lib_api_version_exists` (lib-helm 1.72.13) is the right question to ask: it ORs `global.discovery.apiVersions`, the GVKs deckhouse collects from the `crds/` directories of enabled modules, with real cluster discovery. A check written against `.Capabilities` alone sees only the second source and stays false until discovery catches up with a freshly installed CRD.

## What is the expected result?

Nothing changes on a cluster where the `-crd` module and the CRDs it installs agree, which is every normal installation. Verified by rendering this chart with `helm template` in four configurations — CRDs absent, present in cluster discovery, present in discovery but with the `-crd` modules missing from `enabledModules`, and known only through `global.discovery.apiVersions` — each in two variants of the module's internal feature flags. Output is byte-identical to the old gates wherever cluster discovery decides the outcome. It differs in exactly the two intended cases: the CRD present without its `-crd` module listed, and the CRD known from a module's `crds/` directory but not yet in discovery — there the new gates emit the objects the old ones skipped.

## Checklist
- [ ] The code is covered by unit tests. — no Go code is touched.
- [ ] e2e tests passed. — left to CI.
- [ ] Documentation updated according to the changes. — no user-visible change.
- [ ] Changes were tested in the Kubernetes cluster manually. — verified by rendering the chart, not on a live cluster.
