### PR TITLE
fix(agent): one orphaned device-mapper node must not stop all BlockDevice discovery

### DIFF
--- a/e2e/framework/exec.go
+++ b/e2e/framework/exec.go
@@ -24,9 +24,22 @@ import (
 	"github.com/deckhouse/storage-e2e/pkg/e2e"
 )
 
+// ExitCodeError is a command that ran and failed, as opposed to one that could not
+// be run at all. It carries the code so a caller whose script uses exit codes to
+// say WHY it failed can tell those reasons apart without matching on the message.
+type ExitCodeError struct {
+	Node     string
+	ExitCode int
+	Stderr   string
+}
+
+func (e *ExitCodeError) Error() string {
+	return fmt.Sprintf("command on node %s exited with code %d: %s", e.Node, e.ExitCode, e.Stderr)
+}
+
 // NodeExecChecked runs cmd on node via the SDK NodeExecutor and returns the
-// command's stdout. A non-zero exit code is surfaced as an error (with stderr
-// included); an err from Exec itself signals a transport failure.
+// command's stdout. A non-zero exit code is surfaced as an *ExitCodeError (with
+// stderr included); an err from Exec itself signals a transport failure.
 func NodeExecChecked(ctx context.Context, cl *e2e.Cluster, node, cmd string) (string, error) {
 	res, err := cl.Nodes().Exec(ctx, node, cmd)
 	if err != nil {
@@ -34,8 +47,11 @@ func NodeExecChecked(ctx context.Context, cl *e2e.Cluster, node, cmd string) (st
 	}
 	stdout := string(res.Stdout)
 	if res.ExitCode != 0 {
-		return stdout, fmt.Errorf("command on node %s exited with code %d: %s",
-			node, res.ExitCode, strings.TrimSpace(string(res.Stderr)))
+		return stdout, &ExitCodeError{
+			Node:     node,
+			ExitCode: res.ExitCode,
+			Stderr:   strings.TrimSpace(string(res.Stderr)),
+		}
 	}
 	return stdout, nil
 }

--- a/e2e/framework/lvmwipe.go
+++ b/e2e/framework/lvmwipe.go
@@ -1,0 +1,286 @@
+/*
+	Copyright 2026 Flant JSC
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
+	"github.com/deckhouse/storage-e2e/pkg/e2e"
+)
+
+// E2EVGNamePrefix is the prefix every Volume Group the suite creates on a node
+// carries. Device-mapper doubles the hyphens in a VG name, so the same groups
+// appear in `dmsetup ls` under E2EDMNamePrefix.
+const (
+	E2EVGNamePrefix = "e2e-vg-"
+	E2EDMNamePrefix = "e2e--vg--"
+)
+
+// dmNameForVG is how device-mapper spells a Volume Group's name: every hyphen
+// doubled, which is what makes E2EDMNamePrefix the E2EVGNamePrefix of the dm
+// world.
+func dmNameForVG(vgName string) string {
+	return strings.ReplaceAll(vgName, "-", "--")
+}
+
+// vgNamePattern is what LVM accepts in a Volume Group name.
+//
+// It is applied to every name that reaches the script, which is the one place a
+// value from the cluster is interpolated into a shell command that runs as root.
+// A name is data an LVMVolumeGroup's author chooses, so it is not this file's to
+// trust — and a name that could not be a Volume Group's cannot be protecting one
+// either, so dropping it loses nothing.
+var vgNamePattern = regexp.MustCompile(`^[A-Za-z0-9+_.][A-Za-z0-9+_.-]*$`)
+
+// wipeE2ELVMScript removes the suite's Volume Groups from a node and then the
+// device-mapper nodes that survived them.
+//
+// It is prefixed with the KEEP_VGS and KEEP_DMS definitions keepPrelude builds,
+// and every listing goes through e2e_vgs/e2e_dms, so the prefix filter and the
+// keep list cannot be applied in three places and forgotten in the fourth.
+//
+// The second half is the one that matters. A device-mapper node outlives the
+// disk underneath it: detach a disk carrying a Volume Group and the pool's dm
+// entries stay, now pointing at a device that no longer exists. vgremove cannot
+// clear those — LVM sees no PV to work with — so they have to be removed
+// directly.
+//
+// The dm half loops until a pass removes nothing, rather than a fixed number of
+// times. `dmsetup ls` is not in dependency order and the chain is deeper than it
+// looks: a thin volume holds its pool, and the pool holds its _tdata and _tmeta,
+// so the worst ordering needs one pass per level. Two passes covered the pool over
+// its _tdata and left the rest — including any thin volume the suite created,
+// whose dm name carries the same e2e--vg-- prefix — for nobody.
+//
+// --retry as well as -f. Without it, `dmsetup remove -f` on a device something
+// still holds open replaces its table with one that fails all I/O and then fails
+// to remove it, so the entry stays in `dmsetup ls` with its mapping destroyed:
+// the loop sees no progress and the node keeps the orphan. The iteration cap is
+// what keeps a device nothing can remove from spinning here forever; it is
+// reported as a leftover instead.
+//
+// Every removal is best-effort. This runs in cleanup paths where the interesting
+// failure has usually already happened, and failing the wipe would replace a
+// useful error with a confusing one. What the script does report is whatever
+// survived, so the caller can say the node is still dirty — both kinds, because
+// it removes both. A vgremove that could not run leaves an e2e Volume Group on
+// the node, and listing only the device-mapper nodes made that look clean the
+// moment the dm entries went.
+//
+// Best-effort ends at the preflight checks keepPrelude puts in front of this.
+// Every command here needs root and a binary to run, and every one of them is
+// closed with `|| true` and a discarded stderr — so without those probes a node
+// where `sudo -n` does not work, or where `lvm` is not on PATH, produces an empty
+// leftovers list and an exit code of zero, which the caller reads as "the node is
+// clean". A wipe that cannot run has to look different from a wipe that found
+// nothing: this one exists precisely because leftovers accumulated unnoticed.
+const wipeE2ELVMScript = `
+e2e_vgs() {
+  sudo -n lvm vgs --noheadings -o vg_name 2>/dev/null | tr -d ' ' | grep '^` + E2EVGNamePrefix + `' | grep -vxF "$KEEP_VGS" || true
+}
+
+e2e_dms() {
+  sudo -n dmsetup ls 2>/dev/null | awk '{print $1}' | grep '^` + E2EDMNamePrefix + `' | awk -v keep="$KEEP_DMS" '
+    BEGIN { n = split(keep, kept, "\n") }
+    {
+      for (i = 1; i <= n; i++) {
+        if (kept[i] == "") continue
+        if ($0 == kept[i]) next
+        # A logical volume of the kept group, and only that. Device-mapper spells
+        # <vg>-<lv> with a single hyphen and doubles every hyphen inside either
+        # half, so one more hyphen after the separator is a longer VG NAME rather
+        # than an LV of this one. Matching on the separator alone kept
+        # e2e--vg--restart--<runID> under the kept e2e--vg--restart, which meant
+        # a leftover was neither removed nor reported as one.
+        if (index($0, kept[i] "-") == 1 && substr($0, length(kept[i]) + 2, 1) != "-") next
+      }
+      print
+    }' || true
+}
+
+for vg in $(e2e_vgs); do
+  sudo -n lvm vgremove -ff -y "$vg" >/dev/null 2>&1 || true
+done
+
+for _ in 1 2 3 4 5 6 7 8; do
+  before=$(e2e_dms | wc -l)
+  [ "$before" -eq 0 ] && break
+  for dm in $(e2e_dms); do
+    sudo -n dmsetup remove --retry -f "$dm" >/dev/null 2>&1 || true
+  done
+  after=$(e2e_dms | wc -l)
+  [ "$after" -eq "$before" ] && break
+done
+
+e2e_vgs | sed 's/^/vg:/'
+e2e_dms | sed 's/^/dm:/'
+`
+
+// wipeE2ELVMTools are the commands the script cannot do its job without. Both are
+// probed before anything else runs — see keepPrelude.
+var wipeE2ELVMTools = []string{"lvm", "dmsetup"}
+
+// wipeCannotRunExitCode is what keepPrelude's probes exit with, and it is a
+// distinct code rather than a bare failure so the caller can tell "this node
+// cannot be swept" from "the sweep ran and something went wrong on this node".
+const wipeCannotRunExitCode = 2
+
+// ErrWipeCannotRun reports that the preflight probes refused: no passwordless
+// sudo, or one of wipeE2ELVMTools missing. It is a property of how the run is
+// configured rather than of the node, so every node of the cluster gives the same
+// answer — which is why the caller is expected to say it once for the sweep
+// instead of once per node.
+var ErrWipeCannotRun = errors.New("the wipe cannot run on this cluster")
+
+// keepPrelude defines the two lists the script filters by — the Volume Group names
+// to leave alone and the same names as device-mapper spells them — and refuses to
+// go on unless the wipe can actually be carried out.
+//
+// The lists are newline-separated and single-quoted, which is safe because
+// vgNamePattern admits neither a newline nor a quote — a name that fails it is
+// dropped rather than escaped, since it could not be naming a Volume Group in the
+// first place.
+//
+// The probes exist because every command in the script is closed with `|| true`
+// and a discarded stderr, so a wipe that cannot run produces an empty leftovers
+// list and an exit code of zero — which the caller reads as "the node is clean".
+// A wipe that cannot run has to look different from a wipe that found nothing,
+// and there are two ways it cannot run:
+//
+//   - sudo does not work without a password;
+//   - a command is not there. `lvm` in particular is not a given: this module
+//     ships its own lvm.static under /opt/deckhouse/sds/bin and the host bundle
+//     need not carry one on PATH.
+//
+// Both are checked through sudo, since that is how the script invokes them: a
+// binary root can run and the calling user cannot would otherwise pass the probe
+// and fail every real command afterwards.
+func keepPrelude(keep []string) string {
+	var vgs, dms []string
+	for _, name := range keep {
+		if !vgNamePattern.MatchString(name) {
+			continue
+		}
+
+		vgs = append(vgs, name)
+		dms = append(dms, dmNameForVG(name))
+	}
+
+	prelude := "set -u\n" +
+		"if ! sudo -n true 2>/dev/null; then\n" +
+		`  echo "cannot wipe: passwordless sudo is unavailable on this node" >&2` + "\n" +
+		fmt.Sprintf("  exit %d\n", wipeCannotRunExitCode) +
+		"fi\n"
+
+	for _, tool := range wipeE2ELVMTools {
+		prelude += "if ! sudo -n " + tool + " --version >/dev/null 2>&1; then\n" +
+			`  echo "cannot wipe: ` + tool + ` is unavailable to sudo on this node" >&2` + "\n" +
+			fmt.Sprintf("  exit %d\n", wipeCannotRunExitCode) +
+			"fi\n"
+	}
+
+	return prelude +
+		"KEEP_VGS='" + strings.Join(vgs, "\n") + "'\n" +
+		"KEEP_DMS='" + strings.Join(dms, "\n") + "'\n"
+}
+
+// LiveVolumeGroupNames returns the Volume Group name on the node of every
+// LVMVolumeGroup the cluster currently has.
+//
+// This is what tells a leftover from a Volume Group somebody is still using, and
+// it is the reason WipeE2ELVM does not have to be told which run it belongs to. A
+// Volume Group the suite created while a spec is running has an LVMVolumeGroup
+// describing it; a leftover, by definition, does not — cleanupLVMVolumeGroups
+// strips the finalizers off the ones the agent could not delete, which removes the
+// resource and leaves the group on the node.
+func LiveVolumeGroupNames(ctx context.Context, cl client.Client) ([]string, error) {
+	var list v1alpha1.LVMVolumeGroupList
+	if err := cl.List(ctx, &list); err != nil {
+		return nil, fmt.Errorf("listing LVMVolumeGroups: %w", err)
+	}
+
+	names := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		if name := list.Items[i].Spec.ActualVGNameOnTheNode; name != "" {
+			names = append(names, name)
+		}
+	}
+
+	return names, nil
+}
+
+// WipeE2ELVM removes the suite's Volume Groups and any leftover device-mapper
+// nodes from one node, and returns what survived — Volume Groups as "vg:<name>",
+// device-mapper nodes as "dm:<name>".
+//
+// Both, because the script removes both and the caller reads an empty result as
+// "the node is clean". Reporting only the device-mapper half made a failed
+// vgremove — an open logical volume, a thin pool still in use — look like
+// success as soon as the dm entries went, which leaves on the node exactly the
+// artefact this whole sweep is about: an e2e Volume Group that outlives its run
+// and strands the next one.
+//
+// keep names the Volume Groups it must not touch, with their device-mapper nodes.
+// Pass LiveVolumeGroupNames: the suite's own prefix separates it from everything
+// else on the node but not one run of it from another, so a sweep matching on the
+// prefix alone would take a concurrently running suite's Volume Groups out from
+// under it — mid-spec, and reported by that run as a bug in the agent, since all
+// it sees is storage that vanished. The cluster lock the SDK takes does not close
+// that: this suite releases it between specs on purpose, so another run's
+// BeforeSuite can hold it while this one is between two specs of its own. An
+// LVMVolumeGroup describing the group is what says somebody still wants it, and
+// unlike a naming convention it is checked rather than agreed to.
+//
+// A kept Volume Group is not reported as a leftover. It is not one: something in
+// the cluster still describes it, and the caller supplied that list, so it already
+// knows.
+//
+// Call it before detaching a disk that carried a Volume Group. Skipping that is
+// what leaves an orphan behind: the agent used to abort its whole block-device
+// scan over one dm node whose parent disk was missing, which cost the node every
+// BlockDevice it had. That is fixed, but an orphan is still a device the agent
+// cannot describe, and the tidy state is the one worth leaving.
+//
+// It never removes anything outside the suite's own prefix, so it is safe on a
+// cluster that carries storage the suite did not create.
+func WipeE2ELVM(ctx context.Context, cl *e2e.Cluster, node string, keep []string) ([]string, error) {
+	out, err := NodeExecChecked(ctx, cl, node, keepPrelude(keep)+wipeE2ELVMScript)
+	if err != nil {
+		var exit *ExitCodeError
+		if errors.As(err, &exit) && exit.ExitCode == wipeCannotRunExitCode {
+			return nil, fmt.Errorf("%w on node %s: %s", ErrWipeCannotRun, node, exit.Stderr)
+		}
+
+		return nil, fmt.Errorf("wiping e2e LVM on node %s: %w", node, err)
+	}
+
+	var leftovers []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			leftovers = append(leftovers, name)
+		}
+	}
+
+	return leftovers, nil
+}

--- a/e2e/framework/lvmwipe_test.go
+++ b/e2e/framework/lvmwipe_test.go
@@ -1,0 +1,454 @@
+/*
+	Copyright 2026 Flant JSC
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package framework
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The script is run rather than read. Asserting on its text can only catch a
+// clumsy edit — it cannot tell whether the prefix filter actually holds, how many
+// removal passes a three-level device-mapper chain really gets, or whether the
+// sudo probe stops anything. Running it against stand-in lvm/dmsetup/sudo
+// binaries answers all three, and it is the arguments they were called with that
+// the assertions look at.
+//
+// The shims are ordinary shell scripts on a PATH of their own, so nothing here
+// touches the machine running the tests.
+
+// wipeHarness is a PATH with stand-in lvm, dmsetup and sudo on it, plus the file
+// every invocation appends its argv to.
+type wipeHarness struct {
+	binDir   string
+	callsLog string
+	stateDir string
+}
+
+func newWipeHarness(t *testing.T) *wipeHarness {
+	t.Helper()
+
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash is not available: %v", err)
+	}
+
+	dir := t.TempDir()
+	h := &wipeHarness{
+		binDir:   filepath.Join(dir, "bin"),
+		callsLog: filepath.Join(dir, "calls"),
+		stateDir: filepath.Join(dir, "state"),
+	}
+	require.NoError(t, os.MkdirAll(h.binDir, 0o755))
+	require.NoError(t, os.MkdirAll(h.stateDir, 0o755))
+
+	// sudo -n <cmd...> runs the command, so the shims below see the real argv.
+	// "sudo -n true" therefore succeeds, which is the has-privileges case; the
+	// no-privileges case replaces this one shim.
+	h.writeShim(t, "sudo", `[ "$1" = "-n" ] && shift
+exec "$@"`)
+
+	return h
+}
+
+func (h *wipeHarness) writeShim(t *testing.T, name, body string) {
+	t.Helper()
+
+	script := "#!/usr/bin/env bash\n" +
+		"printf '%s' \"" + name + "\" >> \"$CALLS\"\n" +
+		"for a in \"$@\"; do printf ' %s' \"$a\" >> \"$CALLS\"; done\n" +
+		"printf '\\n' >> \"$CALLS\"\n" +
+		body + "\n"
+
+	path := filepath.Join(h.binDir, name)
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+}
+
+// vgs makes the lvm shim report these Volume Group names, indented the way
+// `lvm vgs --noheadings` indents them.
+func (h *wipeHarness) vgs(t *testing.T, names ...string) {
+	t.Helper()
+
+	listing := ""
+	for _, name := range names {
+		listing += "  " + name + "\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(h.stateDir, "vgs"), []byte(listing), 0o644))
+
+	// vgremove drops the name from the listing, so the report at the end of the
+	// script shows what actually survived rather than what it started with.
+	h.writeShim(t, "lvm", `case "$1" in
+  vgs) cat "$STATE/vgs" ;;
+  vgremove)
+    for arg in "$@"; do :; done
+    grep -v -x "  $arg" "$STATE/vgs" > "$STATE/vgs.new" || true
+    mv "$STATE/vgs.new" "$STATE/vgs"
+    ;;
+esac`)
+}
+
+// dmNode is one device-mapper entry and the devices holding it open.
+type dmNode struct {
+	name string
+	// heldBy names the devices that have this one open. It is removable only once
+	// none of them is listed any more, which is what makes clearing a chain take one
+	// pass per level.
+	heldBy []string
+}
+
+// dm makes the dmsetup shim report these entries, in the order given.
+//
+// Ordered rather than a map, and the order is the point: `dmsetup ls` is not in
+// dependency order, and how many passes a chain needs depends entirely on which
+// end of it the listing starts from. A map would randomise that per run, so the
+// test would pass against a script that only sometimes finishes the job.
+func (h *wipeHarness) dm(t *testing.T, nodes ...dmNode) {
+	t.Helper()
+
+	listing, deps := "", ""
+	for _, node := range nodes {
+		listing += node.name + "\t(253:0)\n"
+		deps += node.name + ":" + strings.Join(node.heldBy, ",") + "\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(h.stateDir, "dm"), []byte(listing), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(h.stateDir, "deps"), []byte(deps), 0o644))
+
+	h.writeShim(t, "dmsetup", `case "$1" in
+  ls) cat "$STATE/dm" ;;
+  remove)
+    for arg in "$@"; do :; done
+    holders=$(grep "^$arg:" "$STATE/deps" | cut -d: -f2)
+    for holder in ${holders//,/ }; do
+      # Still listed means still holding this one open: refuse, the way dmsetup
+      # refuses a device something has open.
+      if cut -f1 "$STATE/dm" | grep -q -x "$holder"; then exit 1; fi
+    done
+    grep -v -P "^\Q$arg\E\t" "$STATE/dm" > "$STATE/dm.new" || true
+    mv "$STATE/dm.new" "$STATE/dm"
+    ;;
+esac`)
+}
+
+func (h *wipeHarness) run(t *testing.T, keep ...string) (stdout string, exitCode int) {
+	t.Helper()
+
+	cmd := exec.Command("bash", "-c", keepPrelude(keep)+wipeE2ELVMScript)
+	cmd.Env = append(os.Environ(),
+		"PATH="+h.binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"CALLS="+h.callsLog,
+		"STATE="+h.stateDir,
+	)
+
+	out, err := cmd.Output()
+	if exitErr := new(exec.ExitError); err != nil {
+		require.ErrorAs(t, err, &exitErr, "the script must fail by exiting, not by failing to start")
+		exitCode = exitErr.ExitCode()
+	}
+
+	return string(out), exitCode
+}
+
+func (h *wipeHarness) calls(t *testing.T) []string {
+	t.Helper()
+
+	raw, err := os.ReadFile(h.callsLog)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+
+	var lines []string
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	return lines
+}
+
+// The property that matters is not what the wipe removes but what it refuses to
+// touch: it runs as root on a cluster that carries storage the suite did not
+// create. Asserting it on the text of the script proves the filter is spelled
+// there; running it proves the filter holds.
+func TestWipeE2ELVM_LeavesForeignStorageAlone(t *testing.T) {
+	h := newWipeHarness(t)
+	h.vgs(t, E2EVGNamePrefix+"restart-1", "prod-data", "vg-system")
+	h.dm(t,
+		dmNode{name: E2EDMNamePrefix + "restart--1-pool"},
+		dmNode{name: "prod--data-lv"},
+	)
+
+	_, code := h.run(t)
+	require.Zero(t, code)
+
+	for _, call := range h.calls(t) {
+		if !strings.Contains(call, "vgremove") && !strings.Contains(call, "remove") {
+			continue
+		}
+		assert.NotContains(t, call, "prod", "a destructive command reached storage outside the suite's prefix: %s", call)
+		assert.NotContains(t, call, "vg-system", "a destructive command reached storage outside the suite's prefix: %s", call)
+	}
+
+	assert.Contains(t, h.calls(t), "lvm vgremove -ff -y "+E2EVGNamePrefix+"restart-1",
+		"and the suite's own group is still removed")
+}
+
+// A thin volume holds its pool and the pool holds its _tdata, so the worst
+// ordering of `dmsetup ls` needs one removal pass per level. Two fixed passes
+// cleared the pool over its _tdata and left the level below it on the node —
+// which is the orphan this whole sweep exists to prevent.
+func TestWipeE2ELVM_ClearsAThreeLevelDeviceMapperChain(t *testing.T) {
+	h := newWipeHarness(t)
+	h.vgs(t)
+
+	var (
+		pool  = E2EDMNamePrefix + "restart--1-pool"
+		tdata = pool + "_tdata"
+		thin  = E2EDMNamePrefix + "restart--1-volume"
+	)
+	// Listed worst-first: each device is visited before the one holding it open, so
+	// every pass can free exactly one level and no more.
+	h.dm(t,
+		dmNode{name: tdata, heldBy: []string{pool}},
+		dmNode{name: pool, heldBy: []string{thin}},
+		dmNode{name: thin},
+	)
+
+	stdout, code := h.run(t)
+	require.Zero(t, code)
+
+	assert.Empty(t, strings.TrimSpace(stdout),
+		"every level of the chain has to be gone, so nothing is reported as a leftover")
+}
+
+// A device nothing can remove must not spin the loop forever, and must be
+// reported rather than silently tolerated.
+func TestWipeE2ELVM_ReportsADeviceItCannotRemove(t *testing.T) {
+	h := newWipeHarness(t)
+	h.vgs(t, E2EVGNamePrefix+"stuck")
+
+	stuck := E2EDMNamePrefix + "stuck-pool"
+	// Held open by a device outside the suite's prefix. The wipe will not touch that
+	// one, so the pool never becomes removable however many passes it gets.
+	h.dm(t,
+		dmNode{name: stuck, heldBy: []string{"someone--elses-lv"}},
+		dmNode{name: "someone--elses-lv"},
+	)
+	// vgremove cannot take the group either.
+	h.writeShim(t, "lvm", `case "$1" in
+  vgs) cat "$STATE/vgs" ;;
+  vgremove) exit 5 ;;
+esac`)
+
+	stdout, code := h.run(t)
+	require.Zero(t, code, "the wipe is best-effort: it reports leftovers, it does not fail")
+
+	assert.Contains(t, stdout, "vg:"+E2EVGNamePrefix+"stuck",
+		"a Volume Group vgremove could not take has to be reported, or a failed wipe looks like a clean node")
+	assert.Contains(t, stdout, "dm:"+stuck,
+		"and so does a device-mapper node that survived")
+}
+
+// Every command in the script needs root and every one of them swallows its own
+// failure, so a node where sudo does not work would otherwise report an empty
+// leftovers list — indistinguishable from a node that is genuinely clean. The
+// probe has to come first and it has to be fatal, or the wipe can silently not
+// happen for a whole run.
+func TestWipeE2ELVM_RefusesToRunWithoutSudo(t *testing.T) {
+	h := newWipeHarness(t)
+	h.vgs(t, E2EVGNamePrefix+"restart-1")
+	h.dm(t, dmNode{name: E2EDMNamePrefix + "restart--1-pool"})
+
+	// Passwordless sudo unavailable: every invocation fails, including the probe.
+	h.writeShim(t, "sudo", `exit 1`)
+
+	_, code := h.run(t)
+	assert.Equal(t, wipeCannotRunExitCode, code,
+		"the caller tells 'cannot be swept' from 'swept and something went wrong' by this code, not by the message")
+
+	for _, call := range h.calls(t) {
+		assert.NotContains(t, call, "vgremove", "nothing destructive may run after a failed privilege check: %s", call)
+		assert.NotContains(t, call, "dmsetup remove", "nothing destructive may run after a failed privilege check: %s", call)
+	}
+}
+
+// The other way a wipe cannot run, and the one that does not announce itself: the
+// command is simply not there. `lvm` is not a given on a Deckhouse node — this
+// module ships its own lvm.static under /opt/deckhouse/sds/bin and the host bundle
+// need not carry one on PATH — and every listing in the script discards stderr and
+// ends in `|| true`, so a missing binary produced an empty leftovers list and an
+// exit code of zero. The caller reads that as "the node is clean", which is the
+// state this whole sweep exists to stop accumulating unnoticed.
+func TestWipeE2ELVM_RefusesToRunWithoutItsTools(t *testing.T) {
+	for _, missing := range wipeE2ELVMTools {
+		t.Run("no "+missing, func(t *testing.T) {
+			h := newWipeHarness(t)
+			h.vgs(t, E2EVGNamePrefix+"restart-1")
+			h.dm(t, dmNode{name: E2EDMNamePrefix + "restart--1-pool"})
+
+			// A shim that fails the way a missing command does, rather than deleting
+			// the shim: the harness keeps the real PATH behind its own so that grep,
+			// awk and the rest still work, and on a machine that happens to have lvm2
+			// installed a deleted shim would simply fall through to the host's binary.
+			// What the script sees either way is a probe that exits non-zero.
+			h.writeShim(t, missing, `exit 127`)
+
+			stdout, code := h.run(t)
+			assert.Equal(t, wipeCannotRunExitCode, code,
+				"a wipe that cannot run has to look different from a wipe that found nothing, and say so in the code WipeE2ELVM matches on")
+			assert.Empty(t, strings.TrimSpace(stdout),
+				"and it must not report a leftovers list it never gathered")
+
+			for _, call := range h.calls(t) {
+				assert.NotContains(t, call, "vgremove", "nothing destructive may run after a failed probe: %s", call)
+				assert.NotContains(t, call, "dmsetup remove", "nothing destructive may run after a failed probe: %s", call)
+			}
+		})
+	}
+}
+
+// Device-mapper doubles every hyphen in a Volume Group name, so the two prefixes
+// have to stay in step: e2e-vg- appears as e2e--vg-- in dmsetup output. Deriving
+// one from the other is what catches a hand edit of just one.
+func TestE2EDMNamePrefixMatchesTheVGPrefix(t *testing.T) {
+	assert.Equal(t, strings.ReplaceAll(E2EVGNamePrefix, "-", "--"), E2EDMNamePrefix)
+}
+
+// The suite's prefix separates it from everything else on the node, but not one
+// run of it from another. A second run sweeping by prefix alone would take a
+// running suite's Volume Groups out from under it, mid-spec, and that run would
+// report it as the agent losing storage. An LVMVolumeGroup describing the group is
+// what says somebody still wants it — so a kept name has to survive the sweep with
+// its device-mapper nodes, and not be reported as a leftover either.
+func TestWipeE2ELVM_LeavesAKeptVolumeGroupAlone(t *testing.T) {
+	const (
+		live  = E2EVGNamePrefix + "mine-1"
+		stale = E2EVGNamePrefix + "stale-2"
+	)
+
+	h := newWipeHarness(t)
+	h.vgs(t, live, stale)
+	h.dm(t,
+		dmNode{name: dmNameForVG(live) + "-pool"},
+		dmNode{name: dmNameForVG(stale) + "-pool"},
+	)
+
+	out, code := h.run(t, live)
+	require.Zero(t, code)
+
+	for _, call := range h.calls(t) {
+		if !strings.Contains(call, "remove") {
+			continue
+		}
+		assert.NotContains(t, call, "mine", "a destructive command reached a Volume Group something still describes: %s", call)
+	}
+
+	assert.Contains(t, h.calls(t), "lvm vgremove -ff -y "+stale,
+		"the leftover is still removed")
+	assert.Contains(t, h.calls(t), "dmsetup remove --retry -f "+dmNameForVG(stale)+"-pool",
+		"and so are its device-mapper nodes")
+
+	assert.NotContains(t, out, live, "a Volume Group somebody still describes is not a leftover")
+	assert.NotContains(t, out, dmNameForVG(live), "nor are its device-mapper nodes")
+}
+
+// A kept Volume Group must protect its own logical volumes and nothing else.
+// Device-mapper spells <vg>-<lv> with a single hyphen and doubles every hyphen
+// inside either half, so a name that continues past the kept one with a SECOND
+// hyphen is a longer Volume Group name — a leftover — rather than a logical
+// volume of the kept group.
+//
+// Keying the keep list on the separator alone did not distinguish the two, and
+// the cost was not merely a leftover left behind: e2e_dms feeds the report at the
+// end of the script as well as the removal loop, so the entry disappeared from
+// both. WipeE2ELVM then returned nothing and both callers read that as "the node
+// is clean" — the leftover survived the run and was invisible while it did.
+//
+// The names here are the ones from the incident: a live e2e-vg-restart beside the
+// e2e-vg-restart-<runID> whose disk had already been detached.
+func TestWipeE2ELVM_DoesNotMistakeALongerVGNameForALogicalVolume(t *testing.T) {
+	const (
+		live  = E2EVGNamePrefix + "restart"
+		stale = E2EVGNamePrefix + "restart-1786799692"
+	)
+
+	h := newWipeHarness(t)
+	// No Volume Groups left: the stale group's disk is gone, so LVM sees no PV and
+	// only its device-mapper nodes survive. That is the case the report is the last
+	// line of defence for.
+	h.vgs(t)
+	h.dm(t,
+		dmNode{name: dmNameForVG(live) + "-pool"},
+		dmNode{name: dmNameForVG(stale) + "-e2e--thin--pool"},
+	)
+
+	out, code := h.run(t, live)
+	require.Zero(t, code)
+
+	assert.Contains(t, h.calls(t), "dmsetup remove --retry -f "+dmNameForVG(stale)+"-e2e--thin--pool",
+		"a different Volume Group's device-mapper node is not a logical volume of the kept one")
+
+	for _, call := range h.calls(t) {
+		if strings.Contains(call, "remove") {
+			assert.NotContains(t, call, dmNameForVG(live)+"-pool",
+				"a logical volume of the kept Volume Group must still be left alone: %s", call)
+		}
+	}
+
+	assert.NotContains(t, out, dmNameForVG(live),
+		"the kept group's own nodes are not leftovers")
+}
+
+// The keep list is the one place a value from the cluster reaches a shell command
+// running as root. A name is data an LVMVolumeGroup's author chooses, so a name
+// that could not be a Volume Group's is dropped rather than escaped — it cannot be
+// protecting one.
+func TestKeepPrelude_DropsANameThatCouldNotBeAVolumeGroup(t *testing.T) {
+	prelude := keepPrelude([]string{
+		"e2e-vg-good",
+		"'; touch /tmp/pwned; echo '",
+		"has space",
+		"new\nline",
+		"",
+		"-leading-hyphen",
+	})
+
+	assert.Contains(t, prelude, "e2e-vg-good", "a usable name is kept")
+	assert.Contains(t, prelude, dmNameForVG("e2e-vg-good"))
+
+	for _, rejected := range []string{"touch", "has space", "new\nline", "-leading-hyphen"} {
+		assert.NotContains(t, prelude, rejected, "an unusable name must not reach the script")
+	}
+
+	// And what is left is still two single-quoted assignments, one per list.
+	assert.Equal(t, 4, strings.Count(prelude, "'"),
+		"exactly the two pairs of quotes the prelude opens itself")
+}
+
+// The names go into the script as device-mapper spells them, which is what makes
+// E2EDMNamePrefix the E2EVGNamePrefix of the dm world.
+func TestDMNameForVG(t *testing.T) {
+	assert.Equal(t, E2EDMNamePrefix, dmNameForVG(E2EVGNamePrefix))
+	assert.Equal(t, "e2e--vg--restart--1786799692", dmNameForVG("e2e-vg-restart-1786799692"))
+	assert.Equal(t, "nohyphens", dmNameForVG("nohyphens"))
+}

--- a/e2e/tests/controller_restart_test.go
+++ b/e2e/tests/controller_restart_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/deckhouse/sds-node-configurator/e2e/cfg"
@@ -102,6 +103,33 @@ var _ = Describe("Controller restart stability", Label("sds-node-configurator", 
 	AfterAll(func() {
 		if managedDisk == nil {
 			return
+		}
+
+		// Before the disk goes, not after. cleanupLVMVolumeGroups strips the
+		// finalizers off an LVMVolumeGroup the agent did not manage to delete,
+		// which removes the resource but leaves the Volume Group on the node.
+		// Detaching the disk under it then leaves device-mapper entries pointing
+		// at a device that no longer exists — an orphan that nothing later in the
+		// run cleans up.
+		By("Wiping any Volume Group left on the node before the disk goes")
+		// AfterEach has already run cleanupLVMVolumeGroups, so anything this run
+		// still owns has a resource describing it and is not a leftover. Passing the
+		// live ones keeps the sweep off a concurrently running suite's Volume Groups
+		// as well — the prefix cannot tell one run from another.
+		keep, keepErr := framework.LiveVolumeGroupNames(ctx, k8sClient)
+		if keepErr != nil {
+			GinkgoWriter.Printf("not wiping e2e LVM on %s, cannot tell leftovers from live Volume Groups: %v\n", targetNode, keepErr)
+			AddReportEntry("leftover-lvm-sweep-failed/"+targetNode, keepErr.Error())
+		} else if leftovers, err := framework.WipeE2ELVM(ctx, cl, targetNode, keep); err != nil {
+			GinkgoWriter.Printf("failed to wipe e2e LVM on %s: %v\n", targetNode, err)
+			AddReportEntry("leftover-lvm-sweep-failed/"+targetNode, err.Error())
+		} else if len(leftovers) > 0 {
+			GinkgoWriter.Printf("LVM the wipe could not remove on %s: %v\n", targetNode, leftovers)
+			// This is the spec that strands the group and then detaches the disk
+			// under it, so a leftover here is the orphan itself, about to outlive
+			// the run — whether it is still a Volume Group (vg:) or already only
+			// the device-mapper nodes under one (dm:).
+			AddReportEntry("leftover-lvm/"+targetNode, strings.Join(leftovers, ","))
 		}
 
 		By("Detaching and deleting the test disk")

--- a/e2e/tests/sds_node_configurator_suite_test.go
+++ b/e2e/tests/sds_node_configurator_suite_test.go
@@ -19,15 +19,18 @@ package tests
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/deckhouse/sds-node-configurator/e2e/framework"
+	"github.com/deckhouse/sds-node-configurator/e2e/sdsclient"
 	"github.com/deckhouse/storage-e2e/pkg/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSdsNodeConfigurator(t *testing.T) {
@@ -86,7 +89,103 @@ var _ = BeforeSuite(func() {
 		GinkgoWriter.Printf("BeforeSuite: unable to install %s access, continuing anyway: %v\n",
 			framework.DebugNodeUserName, err)
 	}
+
+	wipeLeftoverLVM(ctx, cl)
 })
+
+// wipeLeftoverLVM clears Volume Groups and device-mapper entries a previous run
+// left on the nodes. A run that was killed, or one that force-removed an
+// LVMVolumeGroup the agent had not finished deleting, leaves the group on the
+// node; if its disk was detached afterwards the dm entries survive as orphans
+// pointing at a device that is gone.
+//
+// Only the suite's own e2e-vg- prefix is touched, so this is safe on a cluster
+// that carries storage the suite did not create. Like everything else in
+// BeforeSuite it cannot fail the run: starting dirty is worse than starting
+// clean, but it is not a reason to report the suite as broken.
+//
+// A Volume Group an LVMVolumeGroup still describes is left alone. The prefix
+// separates this suite from everything else on the node but not one run of it from
+// another, and this sweep runs across every node before the first spec — so
+// without that check a second run starting against the same cluster would take
+// the first one's Volume Groups out from under it, mid-spec, and the first run
+// would report it as the agent losing storage. Failing to list them is therefore a
+// reason not to sweep at all rather than a reason to sweep blind.
+//
+// The list is taken again for every node, not once for the walk. The walk is one
+// NodeExec per node of the cluster, so it is long next to the moment another run's
+// BeforeSuite needs to create its first LVMVolumeGroup — and a group created after
+// a single list was taken, on a node this walk has not reached yet, would be swept
+// out from under that run with the same symptom the keep list exists to prevent.
+// One extra List per node is not worth trading that against.
+func wipeLeftoverLVM(ctx context.Context, cl *e2e.Cluster) {
+	nodes, err := cl.Clientset().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		GinkgoWriter.Printf("BeforeSuite: not sweeping leftover LVM, listing nodes failed: %v\n", err)
+		return
+	}
+
+	k8sClient, err := sdsclient.New(cl.RESTConfig())
+	if err != nil {
+		GinkgoWriter.Printf("BeforeSuite: not sweeping leftover LVM, building the client failed: %v\n", err)
+		return
+	}
+
+	// The nodes the sweep could not run on at all. Collected rather than reported
+	// as they come, because the two things that stop it — passwordless sudo and the
+	// lvm binary — are how the run is configured, not properties of one node, so
+	// every node answers the same way and the report would carry one sentence per
+	// node of the cluster.
+	var cannotRun []string
+
+	for i := range nodes.Items {
+		node := nodes.Items[i].Name
+
+		keep, keepErr := framework.LiveVolumeGroupNames(ctx, k8sClient)
+		if keepErr != nil {
+			GinkgoWriter.Printf("BeforeSuite: not sweeping leftover LVM on %s, cannot tell leftovers from live Volume Groups: %v\n",
+				node, keepErr)
+			AddReportEntry("leftover-lvm-sweep-failed/"+node, keepErr.Error())
+			continue
+		}
+		if len(keep) > 0 {
+			GinkgoWriter.Printf("BeforeSuite: on %s leaving %d Volume Group(s) alone, an LVMVolumeGroup still describes them: %v\n",
+				node, len(keep), keep)
+		}
+
+		leftovers, err := framework.WipeE2ELVM(ctx, cl, node, keep)
+		switch {
+		case errors.Is(err, framework.ErrWipeCannotRun):
+			// One cause for the whole cluster — no passwordless sudo, or lvm not on
+			// PATH — so it is collected and said once at the end. A report entry per
+			// node would be the same sentence as many times as the cluster has nodes,
+			// which buries the per-node failures below that are actually per-node.
+			GinkgoWriter.Printf("BeforeSuite: %v\n", err)
+			cannotRun = append(cannotRun, node)
+		case err != nil:
+			GinkgoWriter.Printf("BeforeSuite: sweeping leftover LVM on %s failed: %v\n", node, err)
+			// In the report as well as the log: a node the sweep could not reach
+			// is the one whose leftovers will be blamed on whichever spec happens
+			// to run there, and finding that out means reading the whole output.
+			AddReportEntry("leftover-lvm-sweep-failed/"+node, err.Error())
+		case len(leftovers) > 0:
+			// vg: a Volume Group vgremove could not take; dm: a device-mapper node
+			// that outlived one. The first is the more interesting of the two — it
+			// means the node starts this run already carrying storage from the last.
+			GinkgoWriter.Printf("BeforeSuite: %s still carries LVM the sweep could not remove: %v\n",
+				node, leftovers)
+			AddReportEntry("leftover-lvm/"+node, strings.Join(leftovers, ","))
+		}
+	}
+
+	// Once, and still in the report: a cluster the sweep cannot touch accumulates
+	// the leftovers this exists to clear, and the run that finally trips over them
+	// will not be this one.
+	if len(cannotRun) > 0 {
+		AddReportEntry("leftover-lvm-sweep-unavailable",
+			fmt.Sprintf("%s: %s", framework.ErrWipeCannotRun, strings.Join(cannotRun, ",")))
+	}
+}
 
 func suiteTimeout() time.Duration {
 	const (

--- a/images/agent/internal/controller/bd/discoverer.go
+++ b/images/agent/internal/controller/bd/discoverer.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -49,7 +50,6 @@ var (
 	ErrDeviceListInvalid                             = errors.New("device list invalid")
 	ErrDeviceListKNameIsEmpty                        = fmt.Errorf("kname is empty: %w", ErrDeviceListInvalid)
 	ErrDEviceListParentVisitingRecursionLimitReached = fmt.Errorf("max parent recursion reached: %w", ErrDeviceListInvalid)
-	ErrDeviceListParentNotFound                      = fmt.Errorf("parent not found: %w", ErrDeviceListInvalid)
 )
 
 type Discoverer struct {
@@ -60,6 +60,19 @@ type Discoverer struct {
 	metrics                 *monitoring.Metrics
 	sdsCache                *cache.Cache
 	cfg                     DiscovererConfig
+	// reportedOrphans holds the KNames of the devices whose parent was missing on
+	// the previous pass, so an orphan is named when it appears or goes away rather
+	// than once per pass for as long as it exists. Nothing on the node clears an
+	// orphaned device-mapper node by itself, and filterDevices runs on every udev
+	// event: at Warning every time, the first and useful copy would be buried by
+	// the identical ones behind it. The same rule the LVMVolumeGroup discoverer
+	// applies to a refused import.
+	//
+	// Guarded because filterDevices is reachable from the scanner's retry goroutine
+	// as well as from its main loop, and concurrent writes to a bare map take the
+	// process down.
+	orphanMu        sync.Mutex
+	reportedOrphans map[string]struct{}
 }
 
 type DiscovererConfig struct {
@@ -83,6 +96,7 @@ func NewDiscoverer(
 		metrics:                 metrics,
 		sdsCache:                sdsCache,
 		cfg:                     cfg,
+		reportedOrphans:         make(map[string]struct{}),
 	}
 }
 
@@ -321,8 +335,19 @@ func (d *Discoverer) getBlockDeviceCandidates() ([]internal.BlockDeviceCandidate
 
 // Calls visitor function for each parent of the device
 //
-// Once maxDepth reached or travel function returns false it stops
+// Once the visitor returns false, or the chain ends, it stops.
 // Returns true if interrupted by visitor
+//
+// maxDepth is what makes a cycle in the parent chain an error rather than an
+// infinite walk, and callers pass len(devicesByKName) for it. That bound is exact:
+// a walk that visits more devices than the list holds must have visited one of
+// them twice, and there is no other way to exceed it. A constant is not exact, and
+// the difference matters — it conflates a chain that loops, which makes the list
+// invalid, with a chain that is merely long, which is a property of one device.
+// LVM on LUKS on md-raid on multipath on partitions is a legal stack and the node
+// is free to keep growing it, so a constant would eventually fail the node's whole
+// device list over the length of one device's chain: the same failure this
+// function stopped having for a parent that is named but absent.
 func visitParents(devicesByKName map[string]*internal.Device, device *internal.Device, visitor func(parent *internal.Device) bool, maxDepth int) (bool, error) {
 	if maxDepth <= 0 {
 		return false, ErrDEviceListParentVisitingRecursionLimitReached
@@ -333,7 +358,25 @@ func visitParents(devicesByKName map[string]*internal.Device, device *internal.D
 
 	parent, found := devicesByKName[device.PkName]
 	if !found {
-		return false, ErrDeviceListParentNotFound
+		// A parent that is named but absent ends the walk with nothing inherited,
+		// exactly like a device that names no parent at all. It is not a broken
+		// list: a device-mapper node outlives the disk under it, so a detached
+		// disk leaves dm entries whose PkName points at a device that is gone —
+		// `dmsetup ls` still shows them while /dev/sdX does not exist.
+		//
+		// This used to return ErrDeviceListParentNotFound, which filterDevices
+		// turned into a hard error and getBlockDeviceCandidates propagated,
+		// throwing away every candidate on the node. One orphaned dm node was
+		// therefore enough to stop the agent creating any BlockDevice at all,
+		// permanently and on a five-second retry loop, on a node that was
+		// otherwise healthy. The caller already handles "not found" by logging
+		// that it could not resolve a serial and moving on, which is the correct
+		// outcome here.
+		//
+		// It is silent because it says nothing new: filterDevices names the
+		// orphans once per pass before it walks anything, which is the one place
+		// where each is reported once rather than once per walk that reaches it.
+		return false, nil
 	}
 
 	if !visitor(parent) {
@@ -341,6 +384,104 @@ func visitParents(devicesByKName map[string]*internal.Device, device *internal.D
 	}
 
 	return visitParents(devicesByKName, parent, visitor, maxDepth-1)
+}
+
+// orphanedParents returns the devices whose PkName names a device that is not in
+// the list, in the order they appear.
+//
+// Tolerating them is what visitParents does now, and it has to: a device-mapper
+// node outlives the disk under it, so one detached disk used to cost the node
+// every BlockDevice it had. But tolerating them quietly would replace a loud
+// failure with a silent one — the device simply never becomes a BlockDevice, with
+// no error, no warning, and nothing for an operator to search for. Naming them is
+// what keeps the state findable.
+func orphanedParents(devices []internal.Device, kNamesInList map[string]struct{}) []internal.Device {
+	var orphans []internal.Device
+
+	for _, device := range devices {
+		if device.PkName == "" {
+			continue
+		}
+		if _, found := kNamesInList[device.PkName]; !found {
+			orphans = append(orphans, device)
+		}
+	}
+
+	return orphans
+}
+
+// reportOrphanedParents says it out loud once per orphan — when it appears, and
+// again when it goes away — rather than once per pass for as long as it exists.
+//
+// Warning rather than Debug: an orphaned device-mapper node is leftover state
+// that nothing on the node clears by itself, and the answer is a `dmsetup remove`
+// somebody has to run. That is also exactly why it must not be repeated every
+// pass. filterDevices runs on every udev event, so a state that never resolves
+// itself would print the same line for the lifetime of the process and bury the
+// copy that was worth reading — the same reason the LVMVolumeGroup discoverer
+// reports a refused import only when it appears or changes.
+//
+// The recovery gets a line of its own, because otherwise the only record of an
+// orphan going away is the absence of a message.
+func (d *Discoverer) reportOrphanedParents(devices []internal.Device, kNamesInList map[string]struct{}) {
+	orphans := orphanedParents(devices, kNamesInList)
+
+	current := make(map[string]struct{}, len(orphans))
+	for _, device := range orphans {
+		current[device.KName] = struct{}{}
+	}
+
+	d.orphanMu.Lock()
+	previous := d.reportedOrphans
+	d.reportedOrphans = current
+	d.orphanMu.Unlock()
+
+	for _, device := range orphans {
+		if _, known := previous[device.KName]; known {
+			d.log.Debug(fmt.Sprintf("[filterDevices] device %s (kname %s) still names the missing parent %s",
+				device.Name, device.KName, device.PkName))
+			continue
+		}
+
+		d.log.Warning(fmt.Sprintf("[filterDevices] device %s (kname %s) names the parent %s, which is not in the device list; "+
+			"it inherits no serial or WWN and will most likely not become a BlockDevice. "+
+			"A device-mapper node left behind by a detached disk looks exactly like this — check `dmsetup ls` and `dmsetup deps` for %s",
+			device.Name, device.KName, device.PkName, device.KName))
+	}
+
+	for kName := range previous {
+		if _, still := current[kName]; !still {
+			d.log.Info(fmt.Sprintf("[filterDevices] device with kname %s no longer names a missing parent", kName))
+		}
+	}
+}
+
+// reportUnusableDevices says which entries could not be indexed by KName and were
+// therefore dropped from the pass.
+//
+// Loud, and every time rather than on a transition, because unlike an orphaned
+// device-mapper node this is not a state of the node: an entry with no KName, or a
+// second entry under a KName the list already holds, is the device list itself
+// being wrong. Nothing on the node clears it and nothing here can act on it, so it
+// has to be findable — and it is rare enough that repeating it costs nothing. The
+// orphan report is the one that has to hold its tongue, because an orphan is
+// ordinary and lasts.
+//
+// It is a Warning and not an error because the pass goes on: dropping the entry
+// costs one undiscovered device, where failing the list used to cost the node
+// every BlockDevice it had.
+func (d *Discoverer) reportUnusableDevices(unusable []internal.Device) {
+	for _, device := range unusable {
+		if device.KName == "" {
+			d.log.Warning(fmt.Sprintf("[filterDevices] device %s has no kname and cannot be indexed; skipping it. "+
+				"Every other device on this node is still discovered", device.Name))
+			continue
+		}
+
+		d.log.Warning(fmt.Sprintf("[filterDevices] device %s repeats the kname %s of an earlier device in the list; skipping it. "+
+			"Two entries under one kname resolve to one BlockDevice, so keeping both would have them overwrite each other every pass. "+
+			"Every other device on this node is still discovered", device.Name, device.KName))
+	}
 }
 
 // Removing devices we don't need
@@ -359,19 +500,68 @@ func (d *Discoverer) filterDevices(devices []internal.Device) ([]internal.Device
 	filteredDevices := slices.Clone(devices)
 	start := time.Now()
 	// arrange devices by pkname to fast access
+	//
+	// An entry that cannot go into the map leaves the list instead of failing it.
+	// Both ways of being unusable — no KName at all, or a KName another entry
+	// already holds — are properties of ONE entry, exactly like the named-but-absent
+	// parent this file stopped failing over: keeping the old behaviour here would
+	// mean a single bad record still cost the node every BlockDevice it has, on the
+	// five-second retry loop, for as long as the record existed. The duplicate is
+	// not hypothetical either — with Features.NetlinkBlockDeviceDiscovery the list
+	// comes from the agent's own bookkeeping (udev.DeviceMap.Snapshot), built from a
+	// stream of events, so one missed remove leaves two entries under one KName.
+	//
+	// Dropped from filteredDevices rather than merely left out of the map: a device
+	// the map does not hold is a device nothing can inherit from and, worse for the
+	// duplicate, two entries under one KName resolve to one BlockDevice name and
+	// would fight over the same resource every pass.
 	devicesByKName := make(map[string]*internal.Device, len(filteredDevices))
-	for _, device := range filteredDevices {
+	var unusable []internal.Device
+	// The KNames the list holds, kept as a set of its own so the orphan report at
+	// the end can ask "is this parent in the list" without reading through
+	// devicesByKName — whose pointers address a backing array the compaction below
+	// rewrites.
+	kNamesInList := make(map[string]struct{}, len(filteredDevices))
+	filteredDevices = slices.DeleteFunc(filteredDevices, func(device internal.Device) bool {
 		if device.KName == "" {
-			return devices, fmt.Errorf("empty kname is unexpected for device: %v", device)
+			unusable = append(unusable, device)
+			return true
 		}
-		firstDevice, alreadyExists := devicesByKName[device.KName]
-		if alreadyExists {
-			d.log.Error(ErrDeviceListInvalid, "second device with same kname", "first", firstDevice, "second", device)
-			return devices, fmt.Errorf("%w: second device with kname %s found", ErrDeviceListInvalid, device.KName)
+		if _, alreadyExists := kNamesInList[device.KName]; alreadyExists {
+			unusable = append(unusable, device)
+			return true
 		}
-		devicesByKName[device.KName] = &device
+
+		kNamesInList[device.KName] = struct{}{}
+
+		return false
+	})
+	for i := range filteredDevices {
+		// The element, not a copy of it. The loop below fills SerialInherited and
+		// WWNInherited through &filteredDevices[i], so with copies in the map a
+		// parent's inherited value was never visible to its children and every walk
+		// went to the top of the chain again. Harmless but pointless work, and a
+		// trap for anyone who later reads a mutable field back out of this map.
+		//
+		// Taken after DeleteFunc has finished moving elements, because it takes
+		// addresses into the backing array the compaction rewrites.
+		devicesByKName[filteredDevices[i].KName] = &filteredDevices[i]
 	}
 	d.log.Trace("[filterDevices] Made map by KName", "duration", time.Since(start))
+
+	d.reportUnusableDevices(unusable)
+
+	// Before the type filtering, deliberately. The orphan this exists for is a thin
+	// pool's dm node, which carries type "lvm" and is therefore dropped by
+	// hasValidType a hundred lines below whatever its parent does — so reporting
+	// only the survivors would say nothing at all in the case taken from the stand.
+	// What the line is for is the leftover state on the node, not the candidate: an
+	// entry in `dmsetup ls` pointing at a disk that is gone stays there until
+	// somebody removes it.
+	//
+	// It reads the KName set rather than devicesByKName, whose pointers address the
+	// backing array the compaction below rewrites.
+	d.reportOrphanedParents(filteredDevices, kNamesInList)
 
 	start = time.Now()
 	// feel up missing serial and wwn for mpath and partitions
@@ -389,7 +579,7 @@ func (d *Discoverer) filterDevices(devices []internal.Device) ([]internal.Device
 				}
 				device.SerialInherited = parent.Serial
 				return false
-			}, 16)
+			}, len(devicesByKName))
 
 			if err != nil {
 				return nil, fmt.Errorf("looking serial for device %v: %w", device, err)
@@ -411,7 +601,7 @@ func (d *Discoverer) filterDevices(devices []internal.Device) ([]internal.Device
 				}
 				device.WWNInherited = parent.Wwn
 				return false
-			}, 16)
+			}, len(devicesByKName))
 
 			if err != nil {
 				return nil, fmt.Errorf("looking WWN for device %v: %w", device, err)

--- a/images/agent/internal/controller/bd/orphaned_parent_test.go
+++ b/images/agent/internal/controller/bd/orphaned_parent_test.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal"
+	"github.com/deckhouse/sds-node-configurator/images/agent/internal/logger"
+)
+
+// orphanedDMDevices reproduces what an e2e node looks like after a spec detached
+// a disk without removing the Volume Group on it: the device-mapper nodes of the
+// thin pool outlive /dev/sdc, so they are still reported with PkName pointing at
+// a device that is no longer in the list.
+//
+// Taken from a live stand — VG e2e-vg-restart-1786799692 on master-1, where
+// `dmsetup ls` still listed the pool while `ls /dev/sdc` said No such file.
+func orphanedDMDevices() []internal.Device {
+	size := resource.MustParse("2Gi")
+
+	return []internal.Device{
+		{
+			Name:   "/dev/sdd",
+			KName:  "/dev/sdd",
+			Type:   "disk",
+			Serial: "1587bcc6f6e4117d2ac8bb7001bfc8de",
+			Size:   size,
+		},
+		{
+			// The orphan: its parent /dev/sdc was detached and is absent below.
+			Name:   "/dev/mapper/e2e--vg--restart-e2e--thin--pool_tdata",
+			KName:  "/dev/dm-1",
+			PkName: "/dev/sdc",
+			Type:   "lvm",
+			Size:   size,
+		},
+	}
+}
+
+// A device-mapper node whose backing disk is gone must not take the whole device
+// list down with it.
+//
+// It used to: visitParents returned ErrDeviceListParentNotFound, filterDevices
+// turned that into a hard error, and getBlockDeviceCandidates threw away every
+// candidate on the node. The agent then created no BlockDevice at all — for any
+// disk, healthy ones included — retrying every five seconds for as long as the
+// orphan existed. On the e2e stand that meant every spec waiting for a new
+// consumable BlockDevice timed out after the first spec that detached a disk.
+func TestFilterDevices_OrphanedDMParentDoesNotDropEveryCandidate(t *testing.T) {
+	d := setupDiscoverer()
+
+	filtered, err := d.filterDevices(orphanedDMDevices())
+
+	require.NoError(t, err, "an absent parent is a normal node state, not an invalid device list")
+
+	names := make([]string, 0, len(filtered))
+	for i := range filtered {
+		names = append(names, filtered[i].Name)
+	}
+	assert.Contains(t, names, "/dev/sdd",
+		"the healthy disk still has to be discovered next to the orphan")
+}
+
+// Tolerating the orphan must not make it invisible. The walk ends quietly by
+// design, and the caller only logs "can't find serial" at Trace, so without this
+// pass the state that took the whole e2e suite down leaves no trace at the
+// default log level: the device just never becomes a BlockDevice.
+func TestOrphanedParents_NamesTheDeviceWhoseParentIsGone(t *testing.T) {
+	devices := orphanedDMDevices()
+
+	kNames := make(map[string]struct{}, len(devices))
+	for i := range devices {
+		kNames[devices[i].KName] = struct{}{}
+	}
+
+	orphans := orphanedParents(devices, kNames)
+
+	require.Len(t, orphans, 1, "only the device whose parent is absent")
+	assert.Equal(t, "/dev/dm-1", orphans[0].KName)
+	assert.Equal(t, "/dev/sdc", orphans[0].PkName, "and the parent it names is what an operator has to look for")
+}
+
+// A device that names no parent is not an orphan, and neither is one whose
+// parent is present — otherwise every plain disk on the node would produce a
+// warning and bury the one that matters.
+func TestOrphanedParents_IgnoresIntactChains(t *testing.T) {
+	devices := []internal.Device{
+		{Name: "/dev/sda", KName: "/dev/sda"},
+		{Name: "/dev/sda1", KName: "/dev/sda1", PkName: "/dev/sda"},
+	}
+
+	kNames := make(map[string]struct{}, len(devices))
+	for i := range devices {
+		kNames[devices[i].KName] = struct{}{}
+	}
+
+	assert.Empty(t, orphanedParents(devices, kNames))
+}
+
+// The orphan inherits nothing, which is the whole point: there is no parent to
+// take a serial from. The walk has to end quietly rather than error.
+func TestVisitParents_AbsentParentEndsTheWalk(t *testing.T) {
+	devicesByKName := map[string]*internal.Device{
+		"/dev/dm-1": {Name: "/dev/mapper/pool_tdata", KName: "/dev/dm-1", PkName: "/dev/sdc"},
+	}
+
+	visited := 0
+	found, err := visitParents(devicesByKName, devicesByKName["/dev/dm-1"], func(*internal.Device) bool {
+		visited++
+		return true
+	}, len(devicesByKName))
+
+	require.NoError(t, err)
+	assert.False(t, found, "nothing was inherited")
+	assert.Zero(t, visited, "there was no parent to visit")
+}
+
+// The guard that does still have to fail, and the one place where one entry does
+// still cost the node its whole device list.
+//
+// That is deliberate rather than an oversight left standing beside the fix above.
+// A named-but-absent parent is an ordinary state of a live node — a dm node
+// outlives the disk under it — while a cycle in PkName is not a state the kernel
+// can produce at all: it would mean a device is its own ancestor. Reaching it says
+// the list did not come from the node, so there is nothing in it worth trusting
+// device by device, and unlike a missing KName there is no single entry to blame
+// and drop.
+func TestVisitParents_ACycleStillErrors(t *testing.T) {
+	a := &internal.Device{Name: "/dev/dm-0", KName: "/dev/dm-0", PkName: "/dev/dm-1"}
+	b := &internal.Device{Name: "/dev/dm-1", KName: "/dev/dm-1", PkName: "/dev/dm-0"}
+	devicesByKName := map[string]*internal.Device{"/dev/dm-0": a, "/dev/dm-1": b}
+
+	_, err := visitParents(devicesByKName, a, func(*internal.Device) bool { return true }, len(devicesByKName))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDeviceListInvalid)
+}
+
+// The other half of the same guard, and the reason the bound is len(devicesByKName)
+// rather than a constant: a long chain is a property of one device, not of the
+// list. LVM on LUKS on md-raid on multipath on partitions is a legal stack, and
+// against a constant of 16 this walk failed — taking every candidate on the node
+// with it, which is the failure this file stopped having for a missing parent.
+func TestVisitParents_ALongChainIsNotACycle(t *testing.T) {
+	const depth = 40
+
+	devicesByKName := make(map[string]*internal.Device, depth)
+	for i := range depth {
+		kName := fmt.Sprintf("/dev/dm-%d", i)
+		dev := &internal.Device{Name: kName, KName: kName}
+		if i+1 < depth {
+			dev.PkName = fmt.Sprintf("/dev/dm-%d", i+1)
+		}
+		devicesByKName[kName] = dev
+	}
+
+	visited := 0
+	found, err := visitParents(devicesByKName, devicesByKName["/dev/dm-0"], func(*internal.Device) bool {
+		visited++
+		return true
+	}, len(devicesByKName))
+
+	require.NoError(t, err)
+	assert.False(t, found, "the visitor never interrupted the walk")
+	assert.Equal(t, depth-1, visited, "every parent of the chain is visited")
+}
+
+// An entry with no KName cannot be indexed, but that is a property of that one
+// entry — so it leaves the list rather than failing it. Returning an error here
+// used to throw away every candidate on the node, which is the same failure this
+// file removed for a named-but-absent parent, reached by a different input.
+func TestFilterDevices_AnEntryWithNoKNameDoesNotDropEveryCandidate(t *testing.T) {
+	d := setupDiscoverer()
+
+	devices := append(orphanedDMDevices(), internal.Device{
+		Name: "/dev/ghost",
+		Type: "disk",
+		Size: resource.MustParse("2Gi"),
+	})
+
+	filtered, err := d.filterDevices(devices)
+
+	require.NoError(t, err, "one unusable entry is not an unusable list")
+	assert.Contains(t, deviceNames(filtered), "/dev/sdd", "the healthy disk still has to be discovered")
+	assert.NotContains(t, deviceNames(filtered), "/dev/ghost", "and the entry that cannot be indexed is gone")
+}
+
+// Two entries under one KName are the shape the netlink device map produces when a
+// remove event is missed: udev.DeviceMap.Snapshot builds the list from a stream of
+// events rather than from lsblk. Both resolve to one BlockDevice name, so keeping
+// both would have them overwrite each other every pass — the second one is dropped,
+// and the node keeps every other device.
+func TestFilterDevices_ADuplicateKNameDoesNotDropEveryCandidate(t *testing.T) {
+	d := setupDiscoverer()
+
+	devices := orphanedDMDevices()
+	stale := devices[0]
+	stale.Name = "/dev/sdd-stale"
+	devices = append(devices, stale)
+
+	filtered, err := d.filterDevices(devices)
+
+	require.NoError(t, err, "a repeated kname is not an unusable list")
+	names := deviceNames(filtered)
+	assert.Contains(t, names, "/dev/sdd", "the first entry under the kname is the one kept")
+	assert.NotContains(t, names, "/dev/sdd-stale", "and the second is dropped rather than fought over")
+}
+
+// Dropping it quietly would replace a loud failure with a silent one, so both
+// kinds are named — every pass, because unlike an orphaned dm node this is the
+// device list itself being wrong rather than a state of the node.
+func TestFilterDevices_NamesTheEntriesItCouldNotIndex(t *testing.T) {
+	var lines []string
+	d := capturingDiscoverer(&lines)
+
+	devices := orphanedDMDevices()
+	stale := devices[0]
+	stale.Name = "/dev/sdd-stale"
+	devices = append(devices, stale, internal.Device{Name: "/dev/ghost", Type: "disk"})
+
+	_, err := d.filterDevices(devices)
+	require.NoError(t, err)
+
+	assert.Len(t, linesContaining(lines, "has no kname and cannot be indexed"), 1)
+	assert.Len(t, linesContaining(lines, "repeats the kname"), 1)
+}
+
+func deviceNames(devices []internal.Device) []string {
+	names := make([]string, 0, len(devices))
+	for i := range devices {
+		names = append(names, devices[i].Name)
+	}
+
+	return names
+}
+
+// capturingDiscoverer is setupDiscoverer with a logger that keeps what it was
+// given, so a test can assert on which level a line went to rather than only on
+// whether the code ran.
+func capturingDiscoverer(lines *[]string) *Discoverer {
+	d := setupDiscoverer()
+	d.log = logger.NewLoggerWrap(funcr.New(func(_, args string) {
+		*lines = append(*lines, args)
+	}, funcr.Options{Verbosity: 10}))
+
+	return d
+}
+
+func linesContaining(lines []string, needle string) []string {
+	var got []string
+	for _, line := range lines {
+		if strings.Contains(line, needle) {
+			got = append(got, line)
+		}
+	}
+
+	return got
+}
+
+// An orphaned device-mapper node is state that nothing on the node clears by
+// itself, and filterDevices runs on every udev event. Reported at Warning every
+// pass, the copy worth reading would be buried by thousands of identical ones —
+// which is the same failure the message is meant to prevent, moved from the
+// resource into the log.
+func TestReportOrphanedParents_WarnsOnceWhileTheOrphanPersists(t *testing.T) {
+	var lines []string
+	d := capturingDiscoverer(&lines)
+
+	for pass := 1; pass <= 3; pass++ {
+		_, err := d.filterDevices(orphanedDMDevices())
+		require.NoError(t, err)
+	}
+
+	warnings := linesContaining(lines, "WARNING [filterDevices] device /dev/mapper")
+	assert.Len(t, warnings, 1, "the orphan is named when it appears, not on every pass")
+
+	repeats := linesContaining(lines, "still names the missing parent")
+	assert.Len(t, repeats, 2, "the passes that merely saw it again say so at Debug")
+}
+
+// And the state going away is worth a line too: without one, the only record of
+// the orphan being cleared is that the warnings stop, which is indistinguishable
+// from the agent having stopped looking.
+func TestReportOrphanedParents_SaysWhenTheOrphanIsGone(t *testing.T) {
+	var lines []string
+	d := capturingDiscoverer(&lines)
+
+	_, err := d.filterDevices(orphanedDMDevices())
+	require.NoError(t, err)
+
+	// The disk is back, so nothing names a missing parent any more.
+	healthy := orphanedDMDevices()
+	healthy = append(healthy, internal.Device{
+		Name:   "/dev/sdc",
+		KName:  "/dev/sdc",
+		Type:   "disk",
+		Serial: "serial-sdc",
+		Size:   resource.MustParse("2Gi"),
+	})
+	_, err = d.filterDevices(healthy)
+	require.NoError(t, err)
+
+	assert.Len(t, linesContaining(lines, "no longer names a missing parent"), 1)
+
+	// And it is reported afresh if it comes back, rather than being remembered as
+	// already said.
+	_, err = d.filterDevices(orphanedDMDevices())
+	require.NoError(t, err)
+	assert.Len(t, linesContaining(lines, "WARNING [filterDevices] device /dev/mapper"), 2)
+}


### PR DESCRIPTION
Stacked on #351 — review that one first; this PR's diff against it is six files.

Two commits, two halves of the same failure.

> The base-images v2.1.2 and Go 1.26.6 bump that used to live here has moved to the base of #351. It is what takes the CVE gate green, so it belongs under the stack rather than on top of it.

## Description

**The agent must not lose a node's whole device list over one entry.**

`visitParents` returned `ErrDeviceListParentNotFound` when a device named a parent that was not in the list. `filterDevices` turned that into a hard error and `getBlockDeviceCandidates` propagated it, so the pass returned **no candidates at all** — a single device could stop the agent creating any `BlockDevice` on the node, for every disk, healthy ones included, and keep it that way on the five-second retry loop for as long as that device existed.

A named-but-absent parent is not a broken list. A device-mapper node outlives the disk underneath it: detach a disk that carried a Volume Group and the pool's dm entries remain, still reporting the `PkName` of a device that is gone. The walk now ends the way it already ends for a device that names no parent — `found=false`, no error, nothing inherited. Both callers were written for that outcome. The recursion guard keeps erroring, but only for a cycle. Its budget was a constant 16, which conflated a chain that loops — genuinely an invalid list — with a chain that is merely long, which is a property of one device: LVM on LUKS on md-raid on multipath on partitions is a legal stack and the node is free to keep growing it. Deep enough, and the constant failed the node's whole device list for the length of one device's chain, which is the failure this PR is about. The bound is now `len(devicesByKName)`, and it is exact: a walk that visits more devices than the list holds must have visited one of them twice. `ErrDeviceListParentNotFound` has no callers left and goes with it.

Tolerating it *quietly* would replace a loud failure with a silent one, so `filterDevices` names the orphans — once each, when one appears and again when it goes away. Nothing on the node clears an orphaned dm node by itself and `filterDevices` runs on every udev event, so a Warning every time would bury the copy worth reading; it is the rule the `LVMVolumeGroup` discoverer already applies to a refused import.

`devicesByKName` also holds the elements rather than copies of them. The loop below fills `SerialInherited`/`WWNInherited` through `&filteredDevices[i]`, so with copies in the map a parent's inherited value was never visible to its children and every walk went to the top of the chain again — pointless work rather than a wrong answer, but a trap for anyone who later reads a mutable field back out of the map.

**The suite must not create the orphan.**

`cleanupLVMVolumeGroups` deletes the `LVMVolumeGroup` resources and waits for the agent to remove the Volume Groups behind them. When that does not happen within two minutes it strips the finalizers, which removes the resource and leaves the Volume Group on the node — the log says so plainly, `Force removing N stuck LVMVolumeGroups`, and it fires on nearly every run. Detaching the disk afterwards is what strands the dm entries.

`framework.WipeE2ELVM` removes the suite's Volume Groups from a node and then the dm entries that survived them; once the disk is gone `vgremove` cannot help, because LVM no longer sees a PV. Called before `DetachDisk` in the spec observed leaving `e2e-vg-restart-*` behind, and across every node in `BeforeSuite` so a kept cluster starts clean.

The dm half **loops until a pass removes nothing** rather than a fixed number of times. `dmsetup ls` is not in dependency order and the chain is deeper than it looks — a thin volume holds its pool and the pool holds its `_tdata` — so the worst ordering needs one pass per level, and two fixed passes cleared the pool over its `_tdata` and left the level below it on the node. `--retry` goes with `-f` for the same reason: without it, removing a device something still holds open replaces its table with one that fails all I/O and then fails to remove it, so the entry stays in `dmsetup ls` with its mapping destroyed and the loop sees no progress.

## Why do we need it, and what problem does it solve?

Measured on the live e2e stand, on `master-1`:

```
$ dmsetup ls
e2e--vg--restart--1786799692-e2e--thin--pool--restart        (253:2)
e2e--vg--restart--1786799692-e2e--thin--pool--restart_tdata  (253:1)
e2e--vg--restart--1786799692-e2e--thin--pool--restart_tmeta  (253:0)

$ dmsetup deps          # (8, 32) is /dev/sdc
..._tdata: 1 dependencies : (8, 32)

$ ls /dev/sdc
ls: cannot access '/dev/sdc': No such file or directory
```

and the agent, every five seconds:

```
ERROR [GetBlockDeviceCandidates] unable to filter devices
err="looking serial for device {...-e2e--thin--pool--restart_tdata ... lvm /dev/dm-1 /dev/sdc true}:
     parent not found: device list invalid"
ERROR reconciling block devices
WARNING [RunBlockDeviceController] Reconciler needs a retry in 5.000000
```

The cluster had **zero** `BlockDevice` resources while a perfectly good unused 2Gi disk sat attached to that same node.

This is what makes the dvp e2e suite red. It explains the shape of the failures exactly — only `master-1`, where the spec that strands the group runs, and a blast radius that varies with when in the run the orphan appears. It reproduces on `main`: a control run of the suite at the merge-base failed the same way, 18 passed against 20 failed with 48 of those timeouts. So it predates the branch this is stacked on.

## What is the expected result?

- One orphaned dm entry costs one undiscovered device instead of the node's entire device list.
- A node that has had a disk detached keeps discovering its remaining disks.
- A cycle in the parent chain still fails loudly.
- The suite stops stranding Volume Groups, so the orphan is not created to begin with, and a cluster kept across runs starts clean.
- A three-level device-mapper chain is cleared, not just the top two.

## Notes for the reviewer

The wipe runs as root on a shared cluster, so what it refuses to touch matters more than what it removes: every destructive command is fed from a list filtered by the suite's own `e2e-vg-` prefix, never a glob or a literal.

That is now asserted by **running the script under `bash`** against stand-in `lvm`, `dmsetup` and `sudo` binaries on a `PATH` of its own, and looking at the arguments they were called with. Reading the text of the script could only catch a clumsy edit — in particular it could not catch the two-pass limit above, which the chain test does catch: against the previous revision it fails with `dm:e2e--vg--restart--1-pool_tdata` left behind. The listing order in the fixtures is fixed rather than taken from a map, because how many passes a chain needs depends entirely on which end of it `dmsetup ls` starts from.

The prefix separates this suite from everything else on the node; it does not separate one run from another. So it is not the only thing the sweep goes on: `WipeE2ELVM` takes the Volume Groups it must not touch and both callers pass `LiveVolumeGroupNames`. An `LVMVolumeGroup` describing a group is what says somebody still wants it, and unlike a naming convention it is checked rather than agreed to — a leftover by definition has no resource, since `cleanupLVMVolumeGroups` strips the finalizers off the ones the agent could not delete. Failing to list them is a reason not to sweep rather than a reason to sweep blind. The SDK's cluster lock does not close this on its own: the suite releases it between specs on purpose, so another run's `BeforeSuite` can hold it while this one is between two specs.

Every listing in the script goes through `e2e_vgs`/`e2e_dms`, the report at the end included, so the prefix filter and the keep list cannot be applied in three places and forgotten in the fourth. Names are matched against what LVM accepts before they reach the script and dropped if they do not fit: the keep list is the one place a value from the cluster is interpolated into a command running as root.

The live cluster was torn down before the wipe could be run against the real orphan, so that half is covered by these tests and reasoning, not by an observed clean-up. The agent half is covered by a test built from the stand's own device list, which fails against the previous commit with the production error message.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

