### PR TITLE
docs(crds): add the missing Russian description for status.extentSize

### DIFF
--- a/crds/doc-ru-lvmvolumegroup.yaml
+++ b/crds/doc-ru-lvmvolumegroup.yaml
@@ -208,6 +208,9 @@ spec:
                 vgFree:
                   description: |
                     Свободное место в группе томов.
+                extentSize:
+                  description: |
+                    Размер физического extent'а группы томов.
                 allocatedSize:
                   description: |
                     Объём пространства, занимаемый в данный момент в группе томов.


### PR DESCRIPTION
## Description

Adds the Russian description of `status.extentSize` to `crds/doc-ru-lvmvolumegroup.yaml`.

`status.extentSize` was introduced in #201 (extent-aligned size comparison): it went into the Go type and into `crds/lvmvolumegroup.yaml`, but its Russian counterpart was never updated. It is the only field of the LVMVolumeGroup schema without a Russian description — every other node carrying a `description` in the English CRD has one in the `doc-ru` file.

No schema change: `doc-ru-*` files only carry documentation strings.

## Why do we need it, and what problem does it solve?

The Russian documentation page for the LVMVolumeGroup resource is rendered from `doc-ru-lvmvolumegroup.yaml`. A field missing there is a field a Russian-speaking reader cannot find out anything about — `extentSize` is what the agent compares logical volume sizes against, so it is the field to look at when a resize does not appear to have taken effect.

## What is the expected result?

`status.extentSize` shows up with a description on the Russian LVMVolumeGroup documentation page. Nothing changes in the cluster: no CRD field, validation rule, printer column or controller behaviour is touched.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
